### PR TITLE
fixes formatting of nin buttons

### DIFF
--- a/src/style/Nins.scss
+++ b/src/style/Nins.scss
@@ -17,29 +17,29 @@ div.proofing-buttons {
   margin-top: 30px;
 }
 
-@media only screen and (max-width: 991px) {
-  div.btn-group-vertical#nins-btn-group div {
-    width: 100%;
-  }
-  div.proofing-buttons {
-    text-align: center;
-  }
-  div#nin,
-  div#nin input {
-    display: inline-block;
-  }
-}
+// @media only screen and (max-width: 991px) {
+//   div.btn-group-vertical#nins-btn-group div {
+//     width: 100%;
+//   }
+//   div.proofing-buttons {
+//     text-align: center;
+//   }
+//   div#nin,
+//   div#nin input {
+//     display: inline-block;
+//   }
+// }
 
-@media only screen and (max-width: 767px) {
-  fieldset#nins-form div#nin input,
-  div.proofing-buttons button.eduid-button.proofing-button {
-    max-width: 500px;
-  }
-}
+// @media only screen and (max-width: 767px) {
+//   fieldset#nins-form div#nin input,
+//   div.proofing-buttons button.eduid-button.proofing-button {
+//     max-width: 500px;
+//   }
+// }
 
-@media only screen and (min-width: 768px) {
-  fieldset#nins-form div#nin input,
-  div.proofing-buttons button.eduid-button.proofing-button {
-    width: 500px;
-  }
-}
+// @media only screen and (min-width: 768px) {
+//   fieldset#nins-form div#nin input,
+//   div.proofing-buttons button.eduid-button.proofing-button {
+//     width: 500px;
+//   }
+// }

--- a/src/style/base.scss
+++ b/src/style/base.scss
@@ -466,8 +466,8 @@ div.modal-dialog div.modal-footer a {
 }
 
 .btn-group-vertical {
-  text-transform: uppercase;
   color: $link-color;
+  display: block;
 }
 
 .btn-group-vertical a {


### PR DESCRIPTION
Summary: 
- **base.scss**: changes .btn-group-vertical from `display: flex-inline` to `display: block`
- **base.scss**: removes uppercase from helper text under buttons
- **nins.scss**: comments out some redundant media queries

