### PR TITLE
Refactoring dashboard (pt1): Holding on to nin as a separate step

### DIFF
--- a/plugins/eduid_action.mfa/component.js
+++ b/plugins/eduid_action.mfa/component.js
@@ -184,7 +184,6 @@ const mapStateToProps = (state, props) => {
   return {
     webauthn_options: options,
     testing: state.config.testing,
-    testing: state.config.testing,
     assertion: state.plugin.webauthn_assertion,
     external_mfa_url: external_mfa_url
   };
@@ -197,13 +196,16 @@ const credentialsGot = assertion => ({
   payload: assertion
 });
 
+let credentials_locked = false;
+
 const mapDispatchToProps = (dispatch, props) => {
   return {
     getCredentials: function() {
-      if (this.props.assertion === null) {
+      if (this.props.assertion === null && !credentials_locked) {
         let options = this.props.webauthn_options;
         if (options.publicKey !== undefined) {
           try {
+            credentials_locked = true;
             navigator.credentials
               .get(options)
               .then(assertion => {
@@ -212,8 +214,10 @@ const mapDispatchToProps = (dispatch, props) => {
                 } else {
                   dispatch(credentialsGot(assertion));
                 }
+                credentials_locked = false;
               })
               .catch(error => {
+                credentials_locked = false;
                 console.log("Problem getting MFA credentials:", error);
                 if (navigator.appVersion.indexOf("Edge") != -1) {
                   dispatch(postActionFail("mfa.edge-no-u2f"));
@@ -221,6 +225,7 @@ const mapDispatchToProps = (dispatch, props) => {
                 }
               });
           } catch (error) {
+            credentials_locked = false;
             console.log("Error getting credentials:", error);
             dispatch(postActionFail("mfa.error-getting-token"));
           }

--- a/src/components/AddNin.js
+++ b/src/components/AddNin.js
@@ -214,14 +214,7 @@ class AddNin extends Component {
       ninHeading = verifyIdentityStyle;
     }
 
-    return (
-      <div>
-        <div id="add-nin-number-container">
-          {ninHeading}
-          {ninInput}
-        </div>
-      </div>
-    );
+    return <div>{ninInput}</div>;
   }
 }
 

--- a/src/components/AddNin.js
+++ b/src/components/AddNin.js
@@ -117,6 +117,10 @@ class AddNin extends Component {
     //   });
     // }
 
+    console.log("these are props (AddNin.js)", this.props);
+    console.log("this is nins array (AddNin.js)", this.props.nins);
+    console.log("this is nin (AddNin.js)", this.props.nin);
+
     if (this.props.nins.length) {
       ninStatus = "unverified";
       const nins = this.props.nins.filter(nin => nin.verified);

--- a/src/components/AddNin.js
+++ b/src/components/AddNin.js
@@ -7,7 +7,7 @@ import { ButtonGroup, Form } from "reactstrap";
 
 import TextInput from "components/EduIDTextInput";
 import EduIDButton from "components/EduIDButton";
-import vettingRegistry from "vetting-registry";
+// import vettingRegistry from "vetting-registry";
 
 import "style/Nins.scss";
 
@@ -53,13 +53,13 @@ let NinForm = props => {
   );
 };
 
-let NinButtons = props => {
-  return (
-    <ButtonGroup vertical={true} id="nins-btn-group">
-      {props.buttons}
-    </ButtonGroup>
-  );
-};
+// let NinButtons = props => {
+//   return (
+//     <ButtonGroup vertical={true} id="nins-btn-group">
+//       {props.buttons}
+//     </ButtonGroup>
+//   );
+// };
 
 let NinNumber = props => {
   // look at a way to see verified status here? <span>{verifiedNin}</span>
@@ -103,19 +103,19 @@ class AddNin extends Component {
       ninButtons = "",
       verifiedNin = "";
 
-    if (this.props.is_configured) {
-      const vettingBtns = vettingRegistry(!this.props.valid_nin);
-      const verifyOptions = this.props.proofing_methods.filter(
-        option => option !== "oidc"
-      );
-      vettingButtons = verifyOptions.map((key, index) => {
-        return (
-          <div className="vetting-button" key={index}>
-            {vettingBtns[key]}
-          </div>
-        );
-      });
-    }
+    // if (this.props.is_configured) {
+    //   const vettingBtns = vettingRegistry(!this.props.valid_nin);
+    //   const verifyOptions = this.props.proofing_methods.filter(
+    //     option => option !== "oidc"
+    //   );
+    //   vettingButtons = verifyOptions.map((key, index) => {
+    //     return (
+    //       <div className="vetting-button" key={index}>
+    //         {vettingBtns[key]}
+    //       </div>
+    //     );
+    //   });
+    // }
 
     if (this.props.nins.length) {
       ninStatus = "unverified";
@@ -174,25 +174,25 @@ class AddNin extends Component {
       </div>
     ];
 
-    let settingsStyle = [
-      <div className="intro">
-        <h4>{this.props.l10n("nins.main_title")}</h4>
-        <p>{this.props.l10n("nins.justification")}</p>
-      </div>
-    ];
+    // let settingsStyle = [
+    //   <div className="intro">
+    //     <h4>{this.props.l10n("nins.main_title")}</h4>
+    //     <p>{this.props.l10n("nins.justification")}</p>
+    //   </div>
+    // ];
 
-    vettingButtons = [
-      <div key="1" id="connect-nin-number">
-        <h3> Step 2. Connect your national identity number to eduID</h3>
-        <p>
-          Choose a way below to verify that the given identity number belongs to
-          you.
-        </p>
-        <div>
-          <NinButtons buttons={vettingButtons} {...this.props} />
-        </div>
-      </div>
-    ];
+    // vettingButtons = [
+    //   <div key="1" id="connect-nin-number">
+    //     <h3> Step 2. Connect your national identity number to eduID</h3>
+    //     <p>
+    //       Choose a way below to verify that the given identity number belongs to
+    //       you.
+    //     </p>
+    //     <div>
+    //       <NinButtons buttons={vettingButtons} {...this.props} />
+    //     </div>
+    //   </div>
+    // ];
 
     if (ninStatus === "nonin") {
       ninInput = noNin;
@@ -216,12 +216,9 @@ class AddNin extends Component {
 
     return (
       <div>
-        <div id="nin-process">
-          <div id="add-nin-number-container">
-            {ninHeading}
-            {ninInput}
-          </div>
-          <div id="connect-nin-number-container">{ninButtons}</div>
+        <div id="add-nin-number-container">
+          {ninHeading}
+          {ninInput}
         </div>
       </div>
     );

--- a/src/components/AddNin.js
+++ b/src/components/AddNin.js
@@ -194,7 +194,9 @@ class AddNin extends Component {
     //   </div>
     // ];
 
-    if (ninStatus === "nonin") {
+    ninStatus === "nonin";
+
+    if (true) {
       ninInput = noNin;
     } else if (ninStatus === "unverified") {
       ninInput = ninUnverified;

--- a/src/components/AddNin.js
+++ b/src/components/AddNin.js
@@ -101,8 +101,8 @@ class AddNin extends Component {
       vettingButtons = "",
       ninInput = "",
       ninButtons = "",
-      verifiedNin = "";
-
+      verifiedNin = "",
+      validNin = "";
     // if (this.props.is_configured) {
     //   const vettingBtns = vettingRegistry(!this.props.valid_nin);
     //   const verifyOptions = this.props.proofing_methods.filter(

--- a/src/components/AddNin.js
+++ b/src/components/AddNin.js
@@ -1,69 +1,14 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { Field, reduxForm } from "redux-form";
 import { Link } from "react-router-dom";
-import { ButtonGroup, Form } from "reactstrap";
 
 import NinForm from "./NinForm";
-import TextInput from "components/EduIDTextInput";
 import EduIDButton from "components/EduIDButton";
-// import vettingRegistry from "vetting-registry";
 
 import "style/Nins.scss";
 
-const validate = values => {
-  let value = values.nin;
-  // accept only digits
-  if (/[^0-9]+/.test(value)) return { nin: "nins.illegal_chars" };
-  if (value.length !== 12) return { nin: "nins.wrong_length" };
-
-  // The Luhn Algorithm. It's so pretty.
-  // taken from https://gist.github.com/DiegoSalazar/4075533/
-  let nCheck = 0,
-    bEven = false;
-  value = value.slice(2); // To pass the Luhn check only use the 10 last digits
-  for (let n = value.length - 1; n >= 0; n--) {
-    let cDigit = value.charAt(n),
-      nDigit = parseInt(cDigit, 10);
-    if (bEven) {
-      if ((nDigit *= 2) > 9) nDigit -= 9;
-    }
-    nCheck += nDigit;
-    bEven = !bEven;
-  }
-  if (nCheck % 10 !== 0) {
-    return { nin: "nins.invalid_nin" };
-  }
-  return {};
-};
-
-// let NinForm = props => {
-//   return (
-//     <Form id="nin-form" role="form">
-//       <Field
-//         component={TextInput}
-//         componentClass="input"
-//         type="text"
-//         name="nin"
-//         className="nin-input"
-//         placeholder={props.l10n("nins.input_placeholder")}
-//         helpBlock={props.l10n("nins.input_help_text")}
-//       />
-//     </Form>
-//   );
-// };
-
-// let NinButtons = props => {
-//   return (
-//     <ButtonGroup vertical={true} id="nins-btn-group">
-//       {props.buttons}
-//     </ButtonGroup>
-//   );
-// };
-
 let NinNumber = props => {
-  // look at a way to see verified status here? <span>{verifiedNin}</span>
   return (
     <div data-ninnumber={props.nins[0].number} id="nin-number-container">
       <p id="nin-number">{props.nins[0].number}</p>

--- a/src/components/AddNin.js
+++ b/src/components/AddNin.js
@@ -121,6 +121,11 @@ class AddNin extends Component {
     console.log("this is nins array (AddNin.js)", this.props.nins);
     console.log("this is nin (AddNin.js)", this.props.nin);
 
+    if (this.props.valid_nin) {
+      console.log("is the nin valid? (AddNin.js)", this.props.valid_nin);
+      validNin = this.props.nin;
+    }
+
     if (this.props.nins.length) {
       ninStatus = "unverified";
       const nins = this.props.nins.filter(nin => nin.verified);

--- a/src/components/AddNin.js
+++ b/src/components/AddNin.js
@@ -140,8 +140,6 @@ class AddNin extends Component {
         <div key="1">{this.props.l10n("nins.help_text")}</div>
         <div key="2" id="nin-form-container">
           <NinForm {...this.props} />
-        </div>
-        <div key="3">
           <button key="1">ADD FUNCTIONALITY HERE</button>
         </div>
       </div>
@@ -149,29 +147,19 @@ class AddNin extends Component {
 
     let ninUnverified = [
       <div key="1" id="add-nin-number">
-        <div>
-          <NinNumber {...this.props} />
-        </div>
+        <NinNumber {...this.props} />
         <div id="nin-buttons">
-          <div>
-            <VerifyButton {...this.props} />
-          </div>
-          <div>
-            <RemoveButton {...this.props} />
-          </div>
+          <VerifyButton {...this.props} />
+          <RemoveButton {...this.props} />
         </div>
       </div>
     ];
 
     let ninVerified = [
       <div key="1" id="add-nin-number">
-        <div>
           <NinNumber {...this.props} />
-        </div>
         <div id="nin-buttons">
-          <div>
             <RemoveButton {...this.props} />
-          </div>
         </div>
       </div>
     ];

--- a/src/components/AddNin.js
+++ b/src/components/AddNin.js
@@ -140,7 +140,9 @@ class AddNin extends Component {
         <div key="1">{this.props.l10n("nins.help_text")}</div>
         <div key="2" id="nin-form-container">
           <NinForm {...this.props} />
-          <button key="1">ADD FUNCTIONALITY HERE</button>
+          <button onClick={this.addNin} key="1">
+            ADD
+          </button>
         </div>
       </div>
     ];
@@ -157,9 +159,9 @@ class AddNin extends Component {
 
     let ninVerified = [
       <div key="1" id="add-nin-number">
-          <NinNumber {...this.props} />
+        <NinNumber {...this.props} />
         <div id="nin-buttons">
-            <RemoveButton {...this.props} />
+          <RemoveButton {...this.props} />
         </div>
       </div>
     ];

--- a/src/components/AddNin.js
+++ b/src/components/AddNin.js
@@ -95,6 +95,17 @@ let VerifyButton = props => {
 };
 
 class AddNin extends Component {
+  addNin(validNin) {
+    console.log("youre back in AddNin");
+    console.log("and this is validNin:", validNin);
+    
+
+    //   console.log("this is ninInput", e.target);
+    //   const ninInput = e.target.previousSibling.firstChild.children[0];
+    //   // console.log("this is ninInput", ninInput)
+    //   const ninValue = ninInput.value;
+    //   console.log("this is ninInput", ninValue);
+  }
   render() {
     const url = window.location.href;
     let ninStatus = "nonin",
@@ -198,12 +209,12 @@ class AddNin extends Component {
 
     if (true) {
       return (
-          <div key="1" id="add-nin-number">
-            <div key="1">{this.props.l10n("nins.help_text")}</div>
-            <div key="2" id="nin-form-container">
-              <NinForm {...this.props} />
-            </div>
+        <div key="1" id="add-nin-number">
+          <div key="1">{this.props.l10n("nins.help_text")}</div>
+          <div key="2" id="nin-form-container">
+            <NinForm addNin={this.addNin} {...this.props} />
           </div>
+        </div>
       );
     } else if (ninStatus === "unverified") {
       ninInput = ninUnverified;

--- a/src/components/AddNin.js
+++ b/src/components/AddNin.js
@@ -95,48 +95,18 @@ let VerifyButton = props => {
 };
 
 class AddNin extends Component {
+  constructor(props) {
+    super(props);
+    this.state = { nin: null };
+    this.addNin = this.addNin.bind(this);
+  }
   addNin(validNin) {
-    console.log("youre back in AddNin");
-    console.log("and this is validNin:", validNin);
-    
-
-    //   console.log("this is ninInput", e.target);
-    //   const ninInput = e.target.previousSibling.firstChild.children[0];
-    //   // console.log("this is ninInput", ninInput)
-    //   const ninValue = ninInput.value;
-    //   console.log("this is ninInput", ninValue);
+    this.setState((state, props) => {
+      return { nin: validNin };
+    }, console.log("this is state in AddNin:", this.state.nin));
   }
   render() {
-    const url = window.location.href;
-    let ninStatus = "nonin",
-      ninHeading = "",
-      vettingButtons = "",
-      ninInput = "",
-      ninButtons = "",
-      verifiedNin = "",
-      validNin = "";
-    // if (this.props.is_configured) {
-    //   const vettingBtns = vettingRegistry(!this.props.valid_nin);
-    //   const verifyOptions = this.props.proofing_methods.filter(
-    //     option => option !== "oidc"
-    //   );
-    //   vettingButtons = verifyOptions.map((key, index) => {
-    //     return (
-    //       <div className="vetting-button" key={index}>
-    //         {vettingBtns[key]}
-    //       </div>
-    //     );
-    //   });
-    // }
-
-    console.log("these are props (AddNin.js)", this.props);
-    console.log("this is nins array (AddNin.js)", this.props.nins);
-    console.log("this is nin (AddNin.js)", this.props.nin);
-
-    if (this.props.valid_nin) {
-      console.log("is the nin valid? (AddNin.js)", this.props.valid_nin);
-      validNin = this.props.nin;
-    }
+    let ninStatus = "nonin";
 
     if (this.props.nins.length) {
       ninStatus = "unverified";
@@ -147,28 +117,6 @@ class AddNin extends Component {
       }
     }
 
-    // let noNin = [
-    //   <div key="1" id="add-nin-number">
-    //     <div key="1">{this.props.l10n("nins.help_text")}</div>
-    //     <div key="2" id="nin-form-container">
-    //       <NinForm {...this.props} />
-    //       <button onClick={this.addNin} key="1">
-    //         ADD
-    //       </button>
-    //     </div>
-    //   </div>
-    // ];
-
-    let ninUnverified = [
-      <div key="1" id="add-nin-number">
-        <NinNumber {...this.props} />
-        <div id="nin-buttons">
-          <VerifyButton {...this.props} />
-          <RemoveButton {...this.props} />
-        </div>
-      </div>
-    ];
-
     let ninVerified = [
       <div key="1" id="add-nin-number">
         <NinNumber {...this.props} />
@@ -178,36 +126,7 @@ class AddNin extends Component {
       </div>
     ];
 
-    let verifyIdentityStyle = [
-      <div key="1" className="intro">
-        <h3> Step 1. Add your national identity number</h3>
-        <p>Your number can be used to connect eduID to your person.</p>
-      </div>
-    ];
-
-    // let settingsStyle = [
-    //   <div className="intro">
-    //     <h4>{this.props.l10n("nins.main_title")}</h4>
-    //     <p>{this.props.l10n("nins.justification")}</p>
-    //   </div>
-    // ];
-
-    // vettingButtons = [
-    //   <div key="1" id="connect-nin-number">
-    //     <h3> Step 2. Connect your national identity number to eduID</h3>
-    //     <p>
-    //       Choose a way below to verify that the given identity number belongs to
-    //       you.
-    //     </p>
-    //     <div>
-    //       <NinButtons buttons={vettingButtons} {...this.props} />
-    //     </div>
-    //   </div>
-    // ];
-
-    ninStatus === "nonin";
-
-    if (true) {
+    if (this.state.nin === null) {
       return (
         <div key="1" id="add-nin-number">
           <div key="1">{this.props.l10n("nins.help_text")}</div>
@@ -216,48 +135,31 @@ class AddNin extends Component {
           </div>
         </div>
       );
-    } else if (ninStatus === "unverified") {
-      ninInput = ninUnverified;
+    } else if (this.state.nin !== null) {
+      return (
+        <div key="1" id="add-nin-number">
+          <NinNumber {...this.props} />
+          <div id="nin-buttons">
+            <VerifyButton {...this.props} />
+            <RemoveButton {...this.props} />
+          </div>
+        </div>
+      );
       if (this.props.nins.length > 1) {
         ninInput = this.props.l10n("nins.only_one_to_verify");
       }
     } else if (ninStatus === "verified") {
       ninInput = ninVerified;
     }
-
-    if (url.includes("settings")) {
-      ninHeading = settingsStyle;
-    } else if (url.includes("step2")) {
-      ninButtons = vettingButtons;
-      ninHeading = verifyIdentityStyle;
-    } else {
-      ninHeading = verifyIdentityStyle;
-    }
-
-    // return <div>{ninInput}</div>;
   }
 }
 
-// NinForm = reduxForm({
-//   form: "nins",
-//   destroyOnUnmount: false,
-//   enableReinitialize: true,
-//   keepDirtyOnReinitialize: true,
-//   keepValuesOnReinitialize: true,
-//   updateUnregisteredFields: true,
-//   validate: validate
-// })(NinForm);
-
-// NinForm = connect(state => ({
-//   initialValues: { nin: state.nins.nin }
-// }))(NinForm);
-
-AddNin.propTypes = {
-  nin: PropTypes.string,
-  nins: PropTypes.array,
-  validateNin: PropTypes.func,
-  handleDelete: PropTypes.func,
-  proofing_methods: PropTypes.array
-};
+// AddNin.propTypes = {
+//   nin: PropTypes.string,
+//   nins: PropTypes.array,
+//   validateNin: PropTypes.func,
+//   handleDelete: PropTypes.func,
+//   proofing_methods: PropTypes.array
+// };
 
 export default AddNin;

--- a/src/components/AddNin.js
+++ b/src/components/AddNin.js
@@ -5,7 +5,6 @@ import { Field, reduxForm } from "redux-form";
 import { Link } from "react-router-dom";
 import { ButtonGroup, Form } from "reactstrap";
 
-import AddNin from "./AddNin";
 import TextInput from "components/EduIDTextInput";
 import EduIDButton from "components/EduIDButton";
 import vettingRegistry from "vetting-registry";
@@ -94,7 +93,7 @@ let VerifyButton = props => {
   );
 };
 
-class Nins extends Component {
+class AddNin extends Component {
   render() {
     const url = window.location.href;
     let ninStatus = "nonin",
@@ -218,11 +217,10 @@ class Nins extends Component {
     return (
       <div>
         <div id="nin-process">
-          <AddNin {...this.props}/>
-          {/* <div id="add-nin-number-container">
+          <div id="add-nin-number-container">
             {ninHeading}
             {ninInput}
-          </div> */}
+          </div>
           <div id="connect-nin-number-container">{ninButtons}</div>
         </div>
       </div>
@@ -244,7 +242,7 @@ NinForm = connect(state => ({
   initialValues: { nin: state.nins.nin }
 }))(NinForm);
 
-Nins.propTypes = {
+AddNin.propTypes = {
   nin: PropTypes.string,
   nins: PropTypes.array,
   validateNin: PropTypes.func,
@@ -252,4 +250,4 @@ Nins.propTypes = {
   proofing_methods: PropTypes.array
 };
 
-export default Nins;
+export default AddNin;

--- a/src/components/NinForm.js
+++ b/src/components/NinForm.js
@@ -37,8 +37,15 @@ const validate = values => {
   return {};
 };
 
-
 class NinForm extends Component {
+  addNin(e) {
+    console.log("you've clicked the button");
+  //   console.log("this is ninInput", e.target);
+  //   const ninInput = e.target.previousSibling.firstChild.children[0];
+  //   // console.log("this is ninInput", ninInput)
+  //   const ninValue = ninInput.value;
+  //   console.log("this is ninInput", ninValue);
+  // }
   render() {
     // const url = window.location.href;
     // let ninStatus = "nonin",
@@ -47,7 +54,8 @@ class NinForm extends Component {
     //   ninInput = "",
     //   ninButtons = "",
     //   verifiedNin = "",
-    let validNin = "";
+    let validNin = "",
+      formButton = "";
 
     console.log("these are props (AddNin.js)", this.props);
     console.log("this is nins array (AddNin.js)", this.props.nins);
@@ -55,7 +63,12 @@ class NinForm extends Component {
 
     if (this.props.valid_nin) {
       console.log("is the nin valid? (AddNin.js)", this.props.valid_nin);
-      validNin = this.props.nin;
+      // validNin = this.props.nin;
+      formButton = [
+        <button onClick={this.addNin} key="1">
+          ADD
+        </button>
+      ];
     }
 
     return (
@@ -71,9 +84,7 @@ class NinForm extends Component {
             helpBlock={this.props.l10n("nins.input_help_text")}
           />
         </Form>
-        <button onClick={this.addNin} key="1">
-          ADD
-        </button>
+        {formButton}
       </div>
     );
   }

--- a/src/components/NinForm.js
+++ b/src/components/NinForm.js
@@ -45,7 +45,7 @@ class NinForm extends Component {
   //   // console.log("this is ninInput", ninInput)
   //   const ninValue = ninInput.value;
   //   console.log("this is ninInput", ninValue);
-  // }
+   }
   render() {
     // const url = window.location.href;
     // let ninStatus = "nonin",

--- a/src/components/NinForm.js
+++ b/src/components/NinForm.js
@@ -77,21 +77,21 @@ const validate = values => {
 //   );
 // };
 
-let NinInput = props => {
-  return (
-    <Form id="nin-form" role="form">
-      <Field
-        component={TextInput}
-        componentClass="input"
-        type="text"
-        name="nin"
-        className="nin-input"
-        placeholder={props.l10n("nins.input_placeholder")}
-        helpBlock={props.l10n("nins.input_help_text")}
-      />
-    </Form>
-  );
-};
+// let NinInput = props => {
+//   return (
+//     <Form id="nin-form" role="form">
+//       <Field
+//         component={TextInput}
+//         componentClass="input"
+//         type="text"
+//         name="nin"
+//         className="nin-input"
+//         placeholder={props.l10n("nins.input_placeholder")}
+//         helpBlock={props.l10n("nins.input_help_text")}
+//       />
+//     </Form>
+//   );
+// };
 
 class NinForm extends Component {
   render() {
@@ -210,7 +210,18 @@ class NinForm extends Component {
 
     return (
       <div key="2" id="nin-form-container">
-        <NinInput {...this.props} />
+        {/* <NinInput {...this.props} /> */}
+        <Form id="nin-form" role="form">
+          <Field
+            component={TextInput}
+            componentClass="input"
+            type="text"
+            name="nin"
+            className="nin-input"
+            placeholder={this.props.l10n("nins.input_placeholder")}
+            helpBlock={this.props.l10n("nins.input_help_text")}
+          />
+        </Form>
         <button onClick={this.addNin} key="1">
           ADD
         </button>
@@ -219,7 +230,7 @@ class NinForm extends Component {
   }
 }
 
-NinInput = reduxForm({
+NinForm = reduxForm({
   form: "nins"
   // destroyOnUnmount: false,
   // enableReinitialize: true,
@@ -227,7 +238,7 @@ NinInput = reduxForm({
   // keepValuesOnReinitialize: true,
   // updateUnregisteredFields: true,
   // validate: validate
-})(NinInput);
+})(NinForm);
 
 // NinForm = connect(state => ({
 //   initialValues: { nin: state.nins.nin }

--- a/src/components/NinForm.js
+++ b/src/components/NinForm.js
@@ -2,19 +2,14 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { Field, reduxForm } from "redux-form";
-import { Link } from "react-router-dom";
-import { ButtonGroup, Form } from "reactstrap";
+import { Form } from "reactstrap";
 
 import TextInput from "components/EduIDTextInput";
-import EduIDButton from "components/EduIDButton";
-// import vettingRegistry from "vetting-registry";
 
 import "style/Nins.scss";
 
 const validate = values => {
-  console.log("values to be validated", values);
   let value = values.nin;
-  console.log("value in validation", values);
   // accept only digits
   if (/[^0-9]+/.test(value)) return { nin: "nins.illegal_chars" };
   if (value.length !== 12) return { nin: "nins.wrong_length" };
@@ -41,23 +36,11 @@ const validate = values => {
 
 class NinForm extends Component {
   render() {
-    // const url = window.location.href;
-    // let ninStatus = "nonin",
-    //   ninHeading = "",
-    //   vettingButtons = "",
-    //   ninInput = "",
-    //   ninButtons = "",
-    //   verifiedNin = "",
     let validNin = "",
       formButton = "";
 
-    console.log("these are props (AddNin.js)", this.props);
-    console.log("this is nins array (AddNin.js)", this.props.nins);
-    console.log("this is nin (AddNin.js)", this.props.nin);
-
     if (this.props.valid_nin) {
-      console.log("is the nin valid? (AddNin.js)", this.props.valid_nin);
-       validNin = this.props.nin;
+      validNin = this.props.nin;
       formButton = [
         <button onClick={() => this.props.addNin(validNin)} key="1">
           ADD
@@ -98,12 +81,12 @@ NinForm = connect(state => ({
   initialValues: { nin: state.nins.nin }
 }))(NinForm);
 
-NinForm.propTypes = {
-  nin: PropTypes.string,
-  nins: PropTypes.array,
-  validateNin: PropTypes.func,
-  handleDelete: PropTypes.func,
-  proofing_methods: PropTypes.array
-};
+// NinForm.propTypes = {
+//   nin: PropTypes.string,
+//   nins: PropTypes.array,
+//   validateNin: PropTypes.func,
+//   handleDelete: PropTypes.func,
+//   proofing_methods: PropTypes.array
+// };
 
 export default NinForm;

--- a/src/components/NinForm.js
+++ b/src/components/NinForm.js
@@ -5,7 +5,6 @@ import { Field, reduxForm } from "redux-form";
 import { Link } from "react-router-dom";
 import { ButtonGroup, Form } from "reactstrap";
 
-import NinForm from "./NinForm";
 import TextInput from "components/EduIDTextInput";
 import EduIDButton from "components/EduIDButton";
 // import vettingRegistry from "vetting-registry";
@@ -38,22 +37,6 @@ const validate = values => {
   return {};
 };
 
-// let NinForm = props => {
-//   return (
-//     <Form id="nin-form" role="form">
-//       <Field
-//         component={TextInput}
-//         componentClass="input"
-//         type="text"
-//         name="nin"
-//         className="nin-input"
-//         placeholder={props.l10n("nins.input_placeholder")}
-//         helpBlock={props.l10n("nins.input_help_text")}
-//       />
-//     </Form>
-//   );
-// };
-
 // let NinButtons = props => {
 //   return (
 //     <ButtonGroup vertical={true} id="nins-btn-group">
@@ -62,39 +45,55 @@ const validate = values => {
 //   );
 // };
 
-let NinNumber = props => {
-  // look at a way to see verified status here? <span>{verifiedNin}</span>
+// let NinNumber = props => {
+//   // look at a way to see verified status here? <span>{verifiedNin}</span>
+//   return (
+//     <div data-ninnumber={props.nins[0].number} id="nin-number-container">
+//       <p id="nin-number">{props.nins[0].number}</p>
+//     </div>
+//   );
+// };
+
+// let RemoveButton = props => {
+//   return (
+//     <EduIDButton
+//       className="btn-danger"
+//       className="btn-sm"
+//       id={"button-rm-nin-" + props.nins[0].number}
+//       onClick={props.handleDelete}
+//     >
+//       {props.l10n("nins.button_delete")}
+//     </EduIDButton>
+//   );
+// };
+
+// let VerifyButton = props => {
+//   return (
+//     <Link id="verify-button" to="/profile/verify-identity/step2">
+//       <button>
+//         <p>connect eduid to my person</p>
+//       </button>
+//     </Link>
+//   );
+// };
+
+let NinInput = props => {
   return (
-    <div data-ninnumber={props.nins[0].number} id="nin-number-container">
-      <p id="nin-number">{props.nins[0].number}</p>
-    </div>
+    <Form id="nin-form" role="form">
+      <Field
+        component={TextInput}
+        componentClass="input"
+        type="text"
+        name="nin"
+        className="nin-input"
+        placeholder={props.l10n("nins.input_placeholder")}
+        helpBlock={props.l10n("nins.input_help_text")}
+      />
+    </Form>
   );
 };
 
-let RemoveButton = props => {
-  return (
-    <EduIDButton
-      className="btn-danger"
-      className="btn-sm"
-      id={"button-rm-nin-" + props.nins[0].number}
-      onClick={props.handleDelete}
-    >
-      {props.l10n("nins.button_delete")}
-    </EduIDButton>
-  );
-};
-
-let VerifyButton = props => {
-  return (
-    <Link id="verify-button" to="/profile/verify-identity/step2">
-      <button>
-        <p>connect eduid to my person</p>
-      </button>
-    </Link>
-  );
-};
-
-class AddNin extends Component {
+class NinForm extends Component {
   render() {
     const url = window.location.href;
     let ninStatus = "nonin",
@@ -127,14 +126,14 @@ class AddNin extends Component {
       validNin = this.props.nin;
     }
 
-    if (this.props.nins.length) {
-      ninStatus = "unverified";
-      const nins = this.props.nins.filter(nin => nin.verified);
-      if (nins.length === 1) {
-        ninStatus = "verified";
-        verifiedNin = nins[0].number;
-      }
-    }
+    // if (this.props.nins.length) {
+    //   ninStatus = "unverified";
+    //   const nins = this.props.nins.filter(nin => nin.verified);
+    //   if (nins.length === 1) {
+    //     ninStatus = "verified";
+    //     verifiedNin = nins[0].number;
+    //   }
+    // }
 
     // let noNin = [
     //   <div key="1" id="add-nin-number">
@@ -148,31 +147,31 @@ class AddNin extends Component {
     //   </div>
     // ];
 
-    let ninUnverified = [
-      <div key="1" id="add-nin-number">
-        <NinNumber {...this.props} />
-        <div id="nin-buttons">
-          <VerifyButton {...this.props} />
-          <RemoveButton {...this.props} />
-        </div>
-      </div>
-    ];
+    // let ninUnverified = [
+    //   <div key="1" id="add-nin-number">
+    //     <NinNumber {...this.props} />
+    //     <div id="nin-buttons">
+    //       <VerifyButton {...this.props} />
+    //       <RemoveButton {...this.props} />
+    //     </div>
+    //   </div>
+    // ];
 
-    let ninVerified = [
-      <div key="1" id="add-nin-number">
-        <NinNumber {...this.props} />
-        <div id="nin-buttons">
-          <RemoveButton {...this.props} />
-        </div>
-      </div>
-    ];
+    // let ninVerified = [
+    //   <div key="1" id="add-nin-number">
+    //     <NinNumber {...this.props} />
+    //     <div id="nin-buttons">
+    //       <RemoveButton {...this.props} />
+    //     </div>
+    //   </div>
+    // ];
 
-    let verifyIdentityStyle = [
-      <div key="1" className="intro">
-        <h3> Step 1. Add your national identity number</h3>
-        <p>Your number can be used to connect eduID to your person.</p>
-      </div>
-    ];
+    // let verifyIdentityStyle = [
+    //   <div key="1" className="intro">
+    //     <h3> Step 1. Add your national identity number</h3>
+    //     <p>Your number can be used to connect eduID to your person.</p>
+    //   </div>
+    // ];
 
     // let settingsStyle = [
     //   <div className="intro">
@@ -194,54 +193,47 @@ class AddNin extends Component {
     //   </div>
     // ];
 
-    ninStatus === "nonin";
+    // ;
 
-    if (true) {
-      return (
-          <div key="1" id="add-nin-number">
-            <div key="1">{this.props.l10n("nins.help_text")}</div>
-            <div key="2" id="nin-form-container">
-              <NinForm {...this.props} />
-            </div>
-          </div>
-      );
-    } else if (ninStatus === "unverified") {
-      ninInput = ninUnverified;
-      if (this.props.nins.length > 1) {
-        ninInput = this.props.l10n("nins.only_one_to_verify");
-      }
-    } else if (ninStatus === "verified") {
-      ninInput = ninVerified;
-    }
+    // if (true) {
+    //   ninInput = noNin;
+    // }
 
-    if (url.includes("settings")) {
-      ninHeading = settingsStyle;
-    } else if (url.includes("step2")) {
-      ninButtons = vettingButtons;
-      ninHeading = verifyIdentityStyle;
-    } else {
-      ninHeading = verifyIdentityStyle;
-    }
+    // if (url.includes("settings")) {
+    //   ninHeading = settingsStyle;
+    // } else if (url.includes("step2")) {
+    //   ninButtons = vettingButtons;
+    //   ninHeading = verifyIdentityStyle;
+    // } else {
+    //   ninHeading = verifyIdentityStyle;
+    // }
 
-    // return <div>{ninInput}</div>;
+    return (
+      <div key="2" id="nin-form-container">
+        <NinInput {...this.props} />
+        <button onClick={this.addNin} key="1">
+          ADD
+        </button>
+      </div>
+    );
   }
 }
 
-// NinForm = reduxForm({
-//   form: "nins",
-//   destroyOnUnmount: false,
-//   enableReinitialize: true,
-//   keepDirtyOnReinitialize: true,
-//   keepValuesOnReinitialize: true,
-//   updateUnregisteredFields: true,
-//   validate: validate
-// })(NinForm);
+NinInput = reduxForm({
+  form: "nins"
+  // destroyOnUnmount: false,
+  // enableReinitialize: true,
+  // keepDirtyOnReinitialize: true,
+  // keepValuesOnReinitialize: true,
+  // updateUnregisteredFields: true,
+  // validate: validate
+})(NinInput);
 
 // NinForm = connect(state => ({
 //   initialValues: { nin: state.nins.nin }
 // }))(NinForm);
 
-AddNin.propTypes = {
+NinForm.propTypes = {
   nin: PropTypes.string,
   nins: PropTypes.array,
   validateNin: PropTypes.func,
@@ -249,4 +241,4 @@ AddNin.propTypes = {
   proofing_methods: PropTypes.array
 };
 
-export default AddNin;
+export default NinForm;

--- a/src/components/NinForm.js
+++ b/src/components/NinForm.js
@@ -12,7 +12,9 @@ import EduIDButton from "components/EduIDButton";
 import "style/Nins.scss";
 
 const validate = values => {
+  console.log("values to be validated", values);
   let value = values.nin;
+  console.log("value in validation", values);
   // accept only digits
   if (/[^0-9]+/.test(value)) return { nin: "nins.illegal_chars" };
   if (value.length !== 12) return { nin: "nins.wrong_length" };
@@ -38,14 +40,6 @@ const validate = values => {
 };
 
 class NinForm extends Component {
-  addNin(e) {
-    console.log("you've clicked the button");
-  //   console.log("this is ninInput", e.target);
-  //   const ninInput = e.target.previousSibling.firstChild.children[0];
-  //   // console.log("this is ninInput", ninInput)
-  //   const ninValue = ninInput.value;
-  //   console.log("this is ninInput", ninValue);
-   }
   render() {
     // const url = window.location.href;
     // let ninStatus = "nonin",
@@ -63,9 +57,9 @@ class NinForm extends Component {
 
     if (this.props.valid_nin) {
       console.log("is the nin valid? (AddNin.js)", this.props.valid_nin);
-      // validNin = this.props.nin;
+       validNin = this.props.nin;
       formButton = [
-        <button onClick={this.addNin} key="1">
+        <button onClick={() => this.props.addNin(validNin)} key="1">
           ADD
         </button>
       ];
@@ -100,9 +94,9 @@ NinForm = reduxForm({
   validate: validate
 })(NinForm);
 
-// NinForm = connect(state => ({
-//   initialValues: { nin: state.nins.nin }
-// }))(NinForm);
+NinForm = connect(state => ({
+  initialValues: { nin: state.nins.nin }
+}))(NinForm);
 
 NinForm.propTypes = {
   nin: PropTypes.string,

--- a/src/components/NinForm.js
+++ b/src/components/NinForm.js
@@ -37,85 +37,17 @@ const validate = values => {
   return {};
 };
 
-// let NinButtons = props => {
-//   return (
-//     <ButtonGroup vertical={true} id="nins-btn-group">
-//       {props.buttons}
-//     </ButtonGroup>
-//   );
-// };
-
-// let NinNumber = props => {
-//   // look at a way to see verified status here? <span>{verifiedNin}</span>
-//   return (
-//     <div data-ninnumber={props.nins[0].number} id="nin-number-container">
-//       <p id="nin-number">{props.nins[0].number}</p>
-//     </div>
-//   );
-// };
-
-// let RemoveButton = props => {
-//   return (
-//     <EduIDButton
-//       className="btn-danger"
-//       className="btn-sm"
-//       id={"button-rm-nin-" + props.nins[0].number}
-//       onClick={props.handleDelete}
-//     >
-//       {props.l10n("nins.button_delete")}
-//     </EduIDButton>
-//   );
-// };
-
-// let VerifyButton = props => {
-//   return (
-//     <Link id="verify-button" to="/profile/verify-identity/step2">
-//       <button>
-//         <p>connect eduid to my person</p>
-//       </button>
-//     </Link>
-//   );
-// };
-
-// let NinInput = props => {
-//   return (
-//     <Form id="nin-form" role="form">
-//       <Field
-//         component={TextInput}
-//         componentClass="input"
-//         type="text"
-//         name="nin"
-//         className="nin-input"
-//         placeholder={props.l10n("nins.input_placeholder")}
-//         helpBlock={props.l10n("nins.input_help_text")}
-//       />
-//     </Form>
-//   );
-// };
 
 class NinForm extends Component {
   render() {
-    const url = window.location.href;
-    let ninStatus = "nonin",
-      ninHeading = "",
-      vettingButtons = "",
-      ninInput = "",
-      ninButtons = "",
-      verifiedNin = "",
-      validNin = "";
-    // if (this.props.is_configured) {
-    //   const vettingBtns = vettingRegistry(!this.props.valid_nin);
-    //   const verifyOptions = this.props.proofing_methods.filter(
-    //     option => option !== "oidc"
-    //   );
-    //   vettingButtons = verifyOptions.map((key, index) => {
-    //     return (
-    //       <div className="vetting-button" key={index}>
-    //         {vettingBtns[key]}
-    //       </div>
-    //     );
-    //   });
-    // }
+    // const url = window.location.href;
+    // let ninStatus = "nonin",
+    //   ninHeading = "",
+    //   vettingButtons = "",
+    //   ninInput = "",
+    //   ninButtons = "",
+    //   verifiedNin = "",
+    let validNin = "";
 
     console.log("these are props (AddNin.js)", this.props);
     console.log("this is nins array (AddNin.js)", this.props.nins);
@@ -126,91 +58,8 @@ class NinForm extends Component {
       validNin = this.props.nin;
     }
 
-    // if (this.props.nins.length) {
-    //   ninStatus = "unverified";
-    //   const nins = this.props.nins.filter(nin => nin.verified);
-    //   if (nins.length === 1) {
-    //     ninStatus = "verified";
-    //     verifiedNin = nins[0].number;
-    //   }
-    // }
-
-    // let noNin = [
-    //   <div key="1" id="add-nin-number">
-    //     <div key="1">{this.props.l10n("nins.help_text")}</div>
-    //     <div key="2" id="nin-form-container">
-    //       <NinForm {...this.props} />
-    //       <button onClick={this.addNin} key="1">
-    //         ADD
-    //       </button>
-    //     </div>
-    //   </div>
-    // ];
-
-    // let ninUnverified = [
-    //   <div key="1" id="add-nin-number">
-    //     <NinNumber {...this.props} />
-    //     <div id="nin-buttons">
-    //       <VerifyButton {...this.props} />
-    //       <RemoveButton {...this.props} />
-    //     </div>
-    //   </div>
-    // ];
-
-    // let ninVerified = [
-    //   <div key="1" id="add-nin-number">
-    //     <NinNumber {...this.props} />
-    //     <div id="nin-buttons">
-    //       <RemoveButton {...this.props} />
-    //     </div>
-    //   </div>
-    // ];
-
-    // let verifyIdentityStyle = [
-    //   <div key="1" className="intro">
-    //     <h3> Step 1. Add your national identity number</h3>
-    //     <p>Your number can be used to connect eduID to your person.</p>
-    //   </div>
-    // ];
-
-    // let settingsStyle = [
-    //   <div className="intro">
-    //     <h4>{this.props.l10n("nins.main_title")}</h4>
-    //     <p>{this.props.l10n("nins.justification")}</p>
-    //   </div>
-    // ];
-
-    // vettingButtons = [
-    //   <div key="1" id="connect-nin-number">
-    //     <h3> Step 2. Connect your national identity number to eduID</h3>
-    //     <p>
-    //       Choose a way below to verify that the given identity number belongs to
-    //       you.
-    //     </p>
-    //     <div>
-    //       <NinButtons buttons={vettingButtons} {...this.props} />
-    //     </div>
-    //   </div>
-    // ];
-
-    // ;
-
-    // if (true) {
-    //   ninInput = noNin;
-    // }
-
-    // if (url.includes("settings")) {
-    //   ninHeading = settingsStyle;
-    // } else if (url.includes("step2")) {
-    //   ninButtons = vettingButtons;
-    //   ninHeading = verifyIdentityStyle;
-    // } else {
-    //   ninHeading = verifyIdentityStyle;
-    // }
-
     return (
       <div key="2" id="nin-form-container">
-        {/* <NinInput {...this.props} /> */}
         <Form id="nin-form" role="form">
           <Field
             component={TextInput}
@@ -231,13 +80,13 @@ class NinForm extends Component {
 }
 
 NinForm = reduxForm({
-  form: "nins"
-  // destroyOnUnmount: false,
-  // enableReinitialize: true,
-  // keepDirtyOnReinitialize: true,
-  // keepValuesOnReinitialize: true,
-  // updateUnregisteredFields: true,
-  // validate: validate
+  form: "nins",
+  destroyOnUnmount: false,
+  enableReinitialize: true,
+  keepDirtyOnReinitialize: true,
+  keepValuesOnReinitialize: true,
+  updateUnregisteredFields: true,
+  validate: validate
 })(NinForm);
 
 // NinForm = connect(state => ({

--- a/src/components/Nins.js
+++ b/src/components/Nins.js
@@ -218,11 +218,11 @@ class Nins extends Component {
     return (
       <div>
         <div id="nin-process">
-          <AddNin {...this.props}/>
-          {/* <div id="add-nin-number-container">
+          <div id="add-nin-number-container">
             {ninHeading}
-            {ninInput}
-          </div> */}
+            <AddNin {...this.props} />
+            {/* {ninInput} */}
+          </div>
           <div id="connect-nin-number-container">{ninButtons}</div>
         </div>
       </div>

--- a/src/components/Nins.js
+++ b/src/components/Nins.js
@@ -12,47 +12,47 @@ import vettingRegistry from "vetting-registry";
 
 import "style/Nins.scss";
 
-const validate = values => {
-  let value = values.nin;
-  // accept only digits
-  if (/[^0-9]+/.test(value)) return { nin: "nins.illegal_chars" };
-  if (value.length !== 12) return { nin: "nins.wrong_length" };
+// const validate = values => {
+//   let value = values.nin;
+//   // accept only digits
+//   if (/[^0-9]+/.test(value)) return { nin: "nins.illegal_chars" };
+//   if (value.length !== 12) return { nin: "nins.wrong_length" };
 
   // The Luhn Algorithm. It's so pretty.
   // taken from https://gist.github.com/DiegoSalazar/4075533/
-  let nCheck = 0,
-    bEven = false;
-  value = value.slice(2); // To pass the Luhn check only use the 10 last digits
-  for (let n = value.length - 1; n >= 0; n--) {
-    let cDigit = value.charAt(n),
-      nDigit = parseInt(cDigit, 10);
-    if (bEven) {
-      if ((nDigit *= 2) > 9) nDigit -= 9;
-    }
-    nCheck += nDigit;
-    bEven = !bEven;
-  }
-  if (nCheck % 10 !== 0) {
-    return { nin: "nins.invalid_nin" };
-  }
-  return {};
-};
+//   let nCheck = 0,
+//     bEven = false;
+//   value = value.slice(2); // To pass the Luhn check only use the 10 last digits
+//   for (let n = value.length - 1; n >= 0; n--) {
+//     let cDigit = value.charAt(n),
+//       nDigit = parseInt(cDigit, 10);
+//     if (bEven) {
+//       if ((nDigit *= 2) > 9) nDigit -= 9;
+//     }
+//     nCheck += nDigit;
+//     bEven = !bEven;
+//   }
+//   if (nCheck % 10 !== 0) {
+//     return { nin: "nins.invalid_nin" };
+//   }
+//   return {};
+// };
 
-let NinForm = props => {
-  return (
-    <Form id="nin-form" role="form">
-      <Field
-        component={TextInput}
-        componentClass="input"
-        type="text"
-        name="nin"
-        className="nin-input"
-        placeholder={props.l10n("nins.input_placeholder")}
-        helpBlock={props.l10n("nins.input_help_text")}
-      />
-    </Form>
-  );
-};
+// let NinForm = props => {
+//   return (
+//     <Form id="nin-form" role="form">
+//       <Field
+//         component={TextInput}
+//         componentClass="input"
+//         type="text"
+//         name="nin"
+//         className="nin-input"
+//         placeholder={props.l10n("nins.input_placeholder")}
+//         helpBlock={props.l10n("nins.input_help_text")}
+//       />
+//     </Form>
+//   );
+// };
 
 let NinButtons = props => {
   return (
@@ -62,37 +62,37 @@ let NinButtons = props => {
   );
 };
 
-let NinNumber = props => {
-  // look at a way to see verified status here? <span>{verifiedNin}</span>
-  return (
-    <div data-ninnumber={props.nins[0].number} id="nin-number-container">
-      <p id="nin-number">{props.nins[0].number}</p>
-    </div>
-  );
-};
+// let NinNumber = props => {
+//   // look at a way to see verified status here? <span>{verifiedNin}</span>
+//   return (
+//     <div data-ninnumber={props.nins[0].number} id="nin-number-container">
+//       <p id="nin-number">{props.nins[0].number}</p>
+//     </div>
+//   );
+// };
 
-let RemoveButton = props => {
-  return (
-    <EduIDButton
-      className="btn-danger"
-      className="btn-sm"
-      id={"button-rm-nin-" + props.nins[0].number}
-      onClick={props.handleDelete}
-    >
-      {props.l10n("nins.button_delete")}
-    </EduIDButton>
-  );
-};
+// let RemoveButton = props => {
+//   return (
+//     <EduIDButton
+//       className="btn-danger"
+//       className="btn-sm"
+//       id={"button-rm-nin-" + props.nins[0].number}
+//       onClick={props.handleDelete}
+//     >
+//       {props.l10n("nins.button_delete")}
+//     </EduIDButton>
+//   );
+// };
 
-let VerifyButton = props => {
-  return (
-    <Link id="verify-button" to="/profile/verify-identity/step2">
-      <button>
-        <p>connect eduid to my person</p>
-      </button>
-    </Link>
-  );
-};
+// let VerifyButton = props => {
+//   return (
+//     <Link id="verify-button" to="/profile/verify-identity/step2">
+//       <button>
+//         <p>connect eduid to my person</p>
+//       </button>
+//     </Link>
+//   );
+// };
 
 class Nins extends Component {
   render() {
@@ -118,55 +118,55 @@ class Nins extends Component {
       });
     }
 
-    if (this.props.nins.length) {
-      ninStatus = "unverified";
-      const nins = this.props.nins.filter(nin => nin.verified);
-      if (nins.length === 1) {
-        ninStatus = "verified";
-        verifiedNin = nins[0].number;
-      }
-    }
+    // if (this.props.nins.length) {
+    //   ninStatus = "unverified";
+    //   const nins = this.props.nins.filter(nin => nin.verified);
+    //   if (nins.length === 1) {
+    //     ninStatus = "verified";
+    //     verifiedNin = nins[0].number;
+    //   }
+    // }
 
-    let noNin = [
-      <div key="1" id="add-nin-number">
-        <div key="1">{this.props.l10n("nins.help_text")}</div>
-        <div key="2" id="nin-form-container">
-          <NinForm {...this.props} />
-        </div>
-        <div key="3">
-          <button key="1">ADD FUNCTIONALITY HERE</button>
-        </div>
-      </div>
-    ];
+    // let noNin = [
+    //   <div key="1" id="add-nin-number">
+    //     <div key="1">{this.props.l10n("nins.help_text")}</div>
+    //     <div key="2" id="nin-form-container">
+    //       <NinForm {...this.props} />
+    //     </div>
+    //     <div key="3">
+    //       <button key="1">ADD FUNCTIONALITY HERE</button>
+    //     </div>
+    //   </div>
+    // ];
 
-    let ninUnverified = [
-      <div key="1" id="add-nin-number">
-        <div>
-          <NinNumber {...this.props} />
-        </div>
-        <div id="nin-buttons">
-          <div>
-            <VerifyButton {...this.props} />
-          </div>
-          <div>
-            <RemoveButton {...this.props} />
-          </div>
-        </div>
-      </div>
-    ];
+    // let ninUnverified = [
+    //   <div key="1" id="add-nin-number">
+    //     <div>
+    //       <NinNumber {...this.props} />
+    //     </div>
+    //     <div id="nin-buttons">
+    //       <div>
+    //         <VerifyButton {...this.props} />
+    //       </div>
+    //       <div>
+    //         <RemoveButton {...this.props} />
+    //       </div>
+    //     </div>
+    //   </div>
+    // ];
 
-    let ninVerified = [
-      <div key="1" id="add-nin-number">
-        <div>
-          <NinNumber {...this.props} />
-        </div>
-        <div id="nin-buttons">
-          <div>
-            <RemoveButton {...this.props} />
-          </div>
-        </div>
-      </div>
-    ];
+    // let ninVerified = [
+    //   <div key="1" id="add-nin-number">
+    //     <div>
+    //       <NinNumber {...this.props} />
+    //     </div>
+    //     <div id="nin-buttons">
+    //       <div>
+    //         <RemoveButton {...this.props} />
+    //       </div>
+    //     </div>
+    //   </div>
+    // ];
 
     let verifyIdentityStyle = [
       <div key="1" className="intro">
@@ -195,16 +195,16 @@ class Nins extends Component {
       </div>
     ];
 
-    if (ninStatus === "nonin") {
-      ninInput = noNin;
-    } else if (ninStatus === "unverified") {
-      ninInput = ninUnverified;
-      if (this.props.nins.length > 1) {
-        ninInput = this.props.l10n("nins.only_one_to_verify");
-      }
-    } else if (ninStatus === "verified") {
-      ninInput = ninVerified;
-    }
+    // if (ninStatus === "nonin") {
+    //   ninInput = noNin;
+    // } else if (ninStatus === "unverified") {
+    //   ninInput = ninUnverified;
+    //   if (this.props.nins.length > 1) {
+    //     ninInput = this.props.l10n("nins.only_one_to_verify");
+    //   }
+    // } else if (ninStatus === "verified") {
+    //   ninInput = ninVerified;
+    // }
 
     if (url.includes("settings")) {
       ninHeading = settingsStyle;
@@ -230,19 +230,19 @@ class Nins extends Component {
   }
 }
 
-NinForm = reduxForm({
-  form: "nins",
-  destroyOnUnmount: false,
-  enableReinitialize: true,
-  keepDirtyOnReinitialize: true,
-  keepValuesOnReinitialize: true,
-  updateUnregisteredFields: true,
-  validate: validate
-})(NinForm);
+// NinForm = reduxForm({
+//   form: "nins",
+//   destroyOnUnmount: false,
+//   enableReinitialize: true,
+//   keepDirtyOnReinitialize: true,
+//   keepValuesOnReinitialize: true,
+//   updateUnregisteredFields: true,
+//   validate: validate
+// })(NinForm);
 
-NinForm = connect(state => ({
-  initialValues: { nin: state.nins.nin }
-}))(NinForm);
+// NinForm = connect(state => ({
+//   initialValues: { nin: state.nins.nin }
+// }))(NinForm);
 
 Nins.propTypes = {
   nin: PropTypes.string,

--- a/src/sagas/LookupMobileProofing.js
+++ b/src/sagas/LookupMobileProofing.js
@@ -40,8 +40,11 @@ export function fetchLookupMobileProof(config, data) {
     .then(response => response.json());
 }
 const getData = state => {
+  const input = document.getElementsByName("nin")[0],
+        unconfirmed = document.getElementById("eduid-unconfirmed-nin"),
+        nin = input ? input.value : unconfirmed ? state.nins.nin : "testing";
   return {
-    ...state.form.nins.values,
+    nin: nin,
     csrf_token: state.config.csrf_token
   };
 };


### PR DESCRIPTION
**Background:** In prod nin is sent to db on click of the vetting buttons. In semi-new version users should feel like nin is added in a separate step before they are presented with the vetting buttons.    

Work summary: 
- Adds new component AddNin.js (child of Nins.js)
- Adds new component NinForm (child of AddNin.js)
- NinForm collects nin, validates it and, if nin passes validation, renders an ADD button
- The ADD button passes the valid nin back to parent (AddNin)
- AddNin is responsible for rendering the NinForm if a valid nin has been passed form NinForm

Next steps: 
- Refactoring dashboard (pt2): Add new component DisplayNin (child of AddNin.js) that renders different info and styles depending on verification status of the number
- Refactoring dashboard (pt3): Using existing logic to ensure that parent (AddNin) renders the correct values with correct status (e.g. render nin directly if the nins array is not 0)

