### PR TITLE
Refactoring dashboard (pt2): Adding existing redux actions to new components 

### DIFF
--- a/src/components/AddNin.js
+++ b/src/components/AddNin.js
@@ -87,10 +87,15 @@ class AddNin extends Component {
       return <NinDisplay {...this.props} />
     }
 
-    if (this.state.nin === null) {
-      console.log("is state.nin null?", this.state.nin === null)
-      console.log("show form!")
-      console.log("these are the props (AddNin):", this.props)
+    if (this.state.nin) {
+      console.log("is state.nin?", this.state.nin);
+      console.log("show number!");
+      console.log("these are the props (AddNin):", this.props);
+      return <NinDisplay removeNin={this.removeNin} {...this.props} />;
+    } else {
+      console.log("is state.nin?", this.state.nin);
+      console.log("show form!");
+      console.log("these are the props (AddNin):", this.props);
       return (
         <div key="1" className="intro">
           <h3> Step 1. Add your national identity number</h3>
@@ -103,11 +108,6 @@ class AddNin extends Component {
           </div>
         </div>
       );
-    } else {
-      console.log("is state.nin null?", this.state.nin === null)
-      console.log("show number!")
-      console.log("these are the props (AddNin):", this.props)
-      return <NinDisplay removeNin={this.removeNin} {...this.props} />;
     }
   }
 }

--- a/src/components/AddNin.js
+++ b/src/components/AddNin.js
@@ -77,21 +77,19 @@ class AddNin extends Component {
 
     if (this.state.nin === null) {
       return (
-        <div key="1" id="add-nin-number">
-          <div key="1">{this.props.l10n("nins.help_text")}</div>
-          <div key="2" id="nin-form-container">
-            <NinForm addNin={this.addNin} {...this.props} />
+        <div key="1" className="intro">
+          <h3> Step 1. Add your national identity number</h3>
+          <p>Your number can be used to connect eduID to your person.</p>
+          <div key="1" id="add-nin-number">
+            <div key="1">{this.props.l10n("nins.help_text")}</div>
+            <div key="2" id="nin-form-container">
+              <NinForm addNin={this.addNin} {...this.props} />
+            </div>
           </div>
         </div>
       );
     } else {
-      return (
-        <div key="1" id="add-nin-number">
-          <div key="1" id="nin-form-container">
-            <NinDisplay {...this.props} />
-          </div>
-        </div>
-      );
+      return <NinDisplay {...this.props} />;
     }
   }
 }

--- a/src/components/AddNin.js
+++ b/src/components/AddNin.js
@@ -43,6 +43,10 @@ class AddNin extends Component {
   }
   
   render() {
+    if (this.props.nins.length) {
+      console.log("show number! because nin arraaaaayyyy!");
+      return <NinDisplay removeNin={this.removeNin} {...this.props} />;
+    }
     if (this.state.nin === null) {
       console.log("show form! because nin is null!");
       console.log("these are the props (AddNin):", this.props);

--- a/src/components/AddNin.js
+++ b/src/components/AddNin.js
@@ -4,6 +4,7 @@ import { connect } from "react-redux";
 import { Link } from "react-router-dom";
 
 import NinForm from "./NinForm";
+import NinDisplay from "./NinDisplay";
 import EduIDButton from "components/EduIDButton";
 
 import "style/Nins.scss";
@@ -83,10 +84,8 @@ class AddNin extends Component {
     } else if (this.state.nin !== null) {
       return (
         <div key="1" id="add-nin-number">
-          <NinNumber {...this.props} />
-          <div id="nin-buttons">
-            <VerifyButton {...this.props} />
-            <RemoveButton {...this.props} />
+          <div key="1" id="nin-form-container">
+            <NinDisplay addNin={this.addNin} {...this.props} />
           </div>
         </div>
       );

--- a/src/components/AddNin.js
+++ b/src/components/AddNin.js
@@ -1,6 +1,10 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
+import { isValid } from "redux-form";
+// import Nins from "components/Nins";
+import * as actions from "actions/Nins";
+import i18n from "i18n-messages";
 // import { Link } from "react-router-dom";
 
 import NinForm from "./NinForm";
@@ -9,37 +13,6 @@ import NinDisplay from "./NinDisplay";
 
 import "style/Nins.scss";
 
-// let NinNumber = props => {
-//   return (
-//     <div data-ninnumber={props.nins[0].number} id="nin-number-container">
-//       <p id="nin-number">{props.nins[0].number}</p>
-//     </div>
-//   );
-// };
-
-// let RemoveButton = props => {
-//   return (
-//     <EduIDButton
-//       className="btn-danger"
-//       className="btn-sm"
-//       id={"button-rm-nin-" + props.nins[0].number}
-//       onClick={props.handleDelete}
-//     >
-//       {props.l10n("nins.button_delete")}
-//     </EduIDButton>
-//   );
-// };
-
-// let VerifyButton = props => {
-//   return (
-//     <Link id="verify-button" to="/profile/verify-identity/step2">
-//       <button>
-//         <p>connect eduid to my person</p>
-//       </button>
-//     </Link>
-//   );
-// };
-
 class AddNin extends Component {
   constructor(props) {
     super(props);
@@ -47,54 +20,31 @@ class AddNin extends Component {
     this.addNin = this.addNin.bind(this);
     this.removeNin = this.removeNin.bind(this);
   }
+
   addNin(validNin) {
     this.setState((state, props) => {
       return { nin: validNin };
-    }, console.log("this is state in addNin() in AddNin:", this.state.nin));
+      },
+      () => {
+        console.log("this is the updated state in addNin():", this.state.nin);
+      }
+    );
   }
 
   removeNin() {
     console.log("you  clicked removeNin")
     this.setState((state, props) => {
       return { nin: null };
-    }, console.log("this is state in removeNin() in AddNin:", this.state.nin));
+      },
+      () => {
+        console.log("this is state in removeNin() in AddNin:", this.state.nin);
+      }
+    );
   }
+  
   render() {
-    // let ninStatus = "nonin";
-
-    // if (this.props.nins.length) {
-    //   ninStatus = "unverified";
-    //   const nins = this.props.nins.filter(nin => nin.verified);
-    //   if (nins.length === 1) {
-    //     ninStatus = "verified";
-    //     verifiedNin = nins[0].number;
-    //   }
-    // if (this.props.nins.length > 1) {
-    //   ninInput = this.props.l10n("nins.only_one_to_verify");
-    // }
-    // }
-
-    // let ninVerified = [
-    //   <div key="1" id="add-nin-number">
-    //     <NinNumber {...this.props} />
-    //     <div id="nin-buttons">
-    //       <RemoveButton {...this.props} />
-    //     </div>
-    //   </div>
-    // ];
-    if (this.props.nins.length) {
-      console.log("show number beacsue nin arraaaaayyyyyy!")
-      return <NinDisplay {...this.props} />
-    }
-
-    if (this.state.nin) {
-      console.log("is state.nin?", this.state.nin);
-      console.log("show number!");
-      console.log("these are the props (AddNin):", this.props);
-      return <NinDisplay removeNin={this.removeNin} {...this.props} />;
-    } else {
-      console.log("is state.nin?", this.state.nin);
-      console.log("show form!");
+    if (this.state.nin === null) {
+      console.log("show form! because nin is null!");
       console.log("these are the props (AddNin):", this.props);
       return (
         <div key="1" className="intro">
@@ -108,9 +58,14 @@ class AddNin extends Component {
           </div>
         </div>
       );
+    } else {
+      console.log("show number! because nin is not null!");
+      return <NinDisplay removeNin={this.removeNin} {...this.props} />;
     }
   }
 }
+
+// export default i18n(NinsContainer);
 
 // AddNin.propTypes = {
 //   nin: PropTypes.string,

--- a/src/components/AddNin.js
+++ b/src/components/AddNin.js
@@ -1,44 +1,44 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import { Link } from "react-router-dom";
+// import { Link } from "react-router-dom";
 
 import NinForm from "./NinForm";
 import NinDisplay from "./NinDisplay";
-import EduIDButton from "components/EduIDButton";
+// import EduIDButton from "components/EduIDButton";
 
 import "style/Nins.scss";
 
-let NinNumber = props => {
-  return (
-    <div data-ninnumber={props.nins[0].number} id="nin-number-container">
-      <p id="nin-number">{props.nins[0].number}</p>
-    </div>
-  );
-};
+// let NinNumber = props => {
+//   return (
+//     <div data-ninnumber={props.nins[0].number} id="nin-number-container">
+//       <p id="nin-number">{props.nins[0].number}</p>
+//     </div>
+//   );
+// };
 
-let RemoveButton = props => {
-  return (
-    <EduIDButton
-      className="btn-danger"
-      className="btn-sm"
-      id={"button-rm-nin-" + props.nins[0].number}
-      onClick={props.handleDelete}
-    >
-      {props.l10n("nins.button_delete")}
-    </EduIDButton>
-  );
-};
+// let RemoveButton = props => {
+//   return (
+//     <EduIDButton
+//       className="btn-danger"
+//       className="btn-sm"
+//       id={"button-rm-nin-" + props.nins[0].number}
+//       onClick={props.handleDelete}
+//     >
+//       {props.l10n("nins.button_delete")}
+//     </EduIDButton>
+//   );
+// };
 
-let VerifyButton = props => {
-  return (
-    <Link id="verify-button" to="/profile/verify-identity/step2">
-      <button>
-        <p>connect eduid to my person</p>
-      </button>
-    </Link>
-  );
-};
+// let VerifyButton = props => {
+//   return (
+//     <Link id="verify-button" to="/profile/verify-identity/step2">
+//       <button>
+//         <p>connect eduid to my person</p>
+//       </button>
+//     </Link>
+//   );
+// };
 
 class AddNin extends Component {
   constructor(props) {
@@ -52,25 +52,28 @@ class AddNin extends Component {
     }, console.log("this is state in AddNin:", this.state.nin));
   }
   render() {
-    let ninStatus = "nonin";
+    // let ninStatus = "nonin";
 
-    if (this.props.nins.length) {
-      ninStatus = "unverified";
-      const nins = this.props.nins.filter(nin => nin.verified);
-      if (nins.length === 1) {
-        ninStatus = "verified";
-        verifiedNin = nins[0].number;
-      }
-    }
+    // if (this.props.nins.length) {
+    //   ninStatus = "unverified";
+    //   const nins = this.props.nins.filter(nin => nin.verified);
+    //   if (nins.length === 1) {
+    //     ninStatus = "verified";
+    //     verifiedNin = nins[0].number;
+    //   }
+    // if (this.props.nins.length > 1) {
+    //   ninInput = this.props.l10n("nins.only_one_to_verify");
+    // }
+    // }
 
-    let ninVerified = [
-      <div key="1" id="add-nin-number">
-        <NinNumber {...this.props} />
-        <div id="nin-buttons">
-          <RemoveButton {...this.props} />
-        </div>
-      </div>
-    ];
+    // let ninVerified = [
+    //   <div key="1" id="add-nin-number">
+    //     <NinNumber {...this.props} />
+    //     <div id="nin-buttons">
+    //       <RemoveButton {...this.props} />
+    //     </div>
+    //   </div>
+    // ];
 
     if (this.state.nin === null) {
       return (
@@ -81,19 +84,14 @@ class AddNin extends Component {
           </div>
         </div>
       );
-    } else if (this.state.nin !== null) {
+    } else {
       return (
         <div key="1" id="add-nin-number">
           <div key="1" id="nin-form-container">
-            <NinDisplay addNin={this.addNin} {...this.props} />
+            <NinDisplay {...this.props} />
           </div>
         </div>
       );
-      if (this.props.nins.length > 1) {
-        ninInput = this.props.l10n("nins.only_one_to_verify");
-      }
-    } else if (ninStatus === "verified") {
-      ninInput = ninVerified;
     }
   }
 }

--- a/src/components/AddNin.js
+++ b/src/components/AddNin.js
@@ -1,15 +1,8 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { connect } from "react-redux";
-import { isValid } from "redux-form";
-// import Nins from "components/Nins";
-import * as actions from "actions/Nins";
-import i18n from "i18n-messages";
-// import { Link } from "react-router-dom";
 
 import NinForm from "./NinForm";
 import NinDisplay from "./NinDisplay";
-// import EduIDButton from "components/EduIDButton";
 
 import "style/Nins.scss";
 
@@ -69,7 +62,6 @@ class AddNin extends Component {
   }
 }
 
-// export default i18n(NinsContainer);
 
 // AddNin.propTypes = {
 //   nin: PropTypes.string,

--- a/src/components/AddNin.js
+++ b/src/components/AddNin.js
@@ -45,11 +45,19 @@ class AddNin extends Component {
     super(props);
     this.state = { nin: null };
     this.addNin = this.addNin.bind(this);
+    this.removeNin = this.removeNin.bind(this);
   }
   addNin(validNin) {
     this.setState((state, props) => {
       return { nin: validNin };
-    }, console.log("this is state in AddNin:", this.state.nin));
+    }, console.log("this is state in addNin() in AddNin:", this.state.nin));
+  }
+
+  removeNin() {
+    console.log("you  clicked removeNin")
+    this.setState((state, props) => {
+      return { nin: null };
+    }, console.log("this is state in removeNin() in AddNin:", this.state.nin));
   }
   render() {
     // let ninStatus = "nonin";
@@ -75,10 +83,14 @@ class AddNin extends Component {
     //   </div>
     // ];
     if (this.props.nins.length) {
+      console.log("show number beacsue nin arraaaaayyyyyy!")
       return <NinDisplay {...this.props} />
     }
 
     if (this.state.nin === null) {
+      console.log("is state.nin null?", this.state.nin === null)
+      console.log("show form!")
+      console.log("these are the props (AddNin):", this.props)
       return (
         <div key="1" className="intro">
           <h3> Step 1. Add your national identity number</h3>
@@ -92,7 +104,10 @@ class AddNin extends Component {
         </div>
       );
     } else {
-      return <NinDisplay {...this.props} />;
+      console.log("is state.nin null?", this.state.nin === null)
+      console.log("show number!")
+      console.log("these are the props (AddNin):", this.props)
+      return <NinDisplay removeNin={this.removeNin} {...this.props} />;
     }
   }
 }

--- a/src/components/AddNin.js
+++ b/src/components/AddNin.js
@@ -74,6 +74,9 @@ class AddNin extends Component {
     //     </div>
     //   </div>
     // ];
+    if (this.props.nins.length) {
+      return <NinDisplay {...this.props} />
+    }
 
     if (this.state.nin === null) {
       return (

--- a/src/components/NinDisplay.js
+++ b/src/components/NinDisplay.js
@@ -32,9 +32,7 @@ let RemoveButton = props => {
 let VerifyButton = props => {
   return (
     <Link id="verify-button" to="/profile/verify-identity/step2">
-      <button>
-        <p>connect eduid to my person</p>
-      </button>
+      <p>connect eduid to my person</p>
     </Link>
   );
 };
@@ -75,13 +73,17 @@ class NinDisplay extends Component {
       return (
         <div key="1" className="intro">
           <h3> Step 1. Add your national id number</h3>
-          <p>Your id number has been added, but you still need to connect it to your person</p>
+          <p>
+            Your id number has been added,
+            <Link id="verify-id-link" to="/profile/verify-identity/step2">
+              but you still need to connect it to your person
+            </Link>
+          </p>
           <div key="1" id="add-nin-number">
             <div key="1" id="nin-form-container">
               <div key="1" id="add-nin-number">
                 <NinNumber {...this.props} />
                 <div id="nin-buttons">
-                  <VerifyButton {...this.props} />
                   <RemoveButton {...this.props} />
                 </div>
               </div>

--- a/src/components/NinDisplay.js
+++ b/src/components/NinDisplay.js
@@ -22,7 +22,6 @@ let RemoveButton = props => {
   return (
     <EduIDButton
       className="btn-danger btn-sm"
-      // id={"button-rm-nin-" + props.nin}
       onClick={e => {
         props.removeNin();
         props.handleDelete(e);
@@ -33,26 +32,8 @@ let RemoveButton = props => {
   );
 };
 
-let VerifyButton = props => {
-  return (
-    <Link id="verify-button" to="/profile/verify-identity/step2">
-      <p>connect eduid to my person</p>
-    </Link>
-  );
-};
-
 class NinDisplay extends Component {
   render() {
-    let ninStatus = "nonin";
-
-    // if (this.props.nins.length) {
-    //   ninStatus = "unverified";
-    //   const nins = this.props.nins.filter(nin => nin.verified);
-    //   if (nins.length === 1) {
-    //     ninStatus = "verified";
-    //     verifiedNin = nins[0].number;
-    //   }
-    // }
     if (this.props.nins) {
       if (this.props.nins[0].verified) {
         console.log(this.props.nins.verified);
@@ -120,5 +101,3 @@ export default connect(
   mapStateToProps,
   mapDispatchToProps
 )(NinDisplay);
-
-// export default NinDisplay;

--- a/src/components/NinDisplay.js
+++ b/src/components/NinDisplay.js
@@ -53,25 +53,24 @@ class NinDisplay extends Component {
     //     verifiedNin = nins[0].number;
     //   }
     // }
-
-    if (this.props.nins.verified) {
-      console.log(this.props.nins.verified);
-      return (
-        <div key="1" className="intro">
-          <h3> Step 1. Add your national identity number</h3>
-          <p>Your id number has been added and connected to your person.</p>
-          <div key="1" id="add-nin-number">
-            <div key="1" id="nin-form-container">
-              <div key="1" id="add-nin-number" className="verified">
-                <NinNumber {...this.props} />
-                <RemoveButton {...this.props} />
+    if (this.props.nins) {
+      if (this.props.nins[0].verified) {
+        console.log(this.props.nins.verified);
+        return (
+          <div key="1" className="intro">
+            <h3> Step 1. Add your national identity number</h3>
+            <p>Your id number has been added and connected to your person.</p>
+            <div key="1" id="add-nin-number">
+              <div key="1" id="nin-form-container">
+                <div key="1" id="add-nin-number" className="verified">
+                  <NinNumber {...this.props} />
+                  <RemoveButton {...this.props} />
+                </div>
               </div>
             </div>
           </div>
-        </div>
-      );
-    } else {
-      console.log(this.props.nins.length == 1);
+        );
+      }
       return (
         <div key="1" className="intro">
           <h3> Step 1. Add your national id number</h3>
@@ -109,7 +108,7 @@ const mapStateToProps = (state, props) => {
 
 const mapDispatchToProps = (dispatch, props) => {
   return {
-    handleDelete: function (e) {
+    handleDelete: function(e) {
       console.log("you're in handleDelete through ninDisplay!");
       const ninNumber = e.target.previousSibling.dataset.ninnumber;
       dispatch(actions.startRemove(ninNumber));

--- a/src/components/NinDisplay.js
+++ b/src/components/NinDisplay.js
@@ -1,9 +1,9 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-// import { connect } from "react-redux";
+import { connect } from "react-redux";
 import { Link } from "react-router-dom";
-// import * as actions from "actions/Nins";
-// import i18n from "i18n-messages";
+import * as actions from "actions/Nins";
+import i18n from "i18n-messages";
 
 import EduIDButton from "components/EduIDButton";
 
@@ -23,7 +23,10 @@ let RemoveButton = props => {
     <EduIDButton
       className="btn-danger btn-sm"
       // id={"button-rm-nin-" + props.nin}
-      onClick={() => props.removeNin()}
+      onClick={e => {
+        props.removeNin();
+        props.handleDelete(e);
+      }}
     >
       X
     </EduIDButton>
@@ -100,5 +103,23 @@ class NinDisplay extends Component {
 //   proofing_methods: PropTypes.array
 // };
 
+const mapStateToProps = (state, props) => {
+  return {};
+};
 
-export default NinDisplay;
+const mapDispatchToProps = (dispatch, props) => {
+  return {
+    handleDelete: function (e) {
+      console.log("you're in handleDelete through ninDisplay!");
+      const ninNumber = e.target.previousSibling.dataset.ninnumber;
+      dispatch(actions.startRemove(ninNumber));
+    }
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(NinDisplay);
+
+// export default NinDisplay;

--- a/src/components/NinDisplay.js
+++ b/src/components/NinDisplay.js
@@ -73,20 +73,36 @@ class NinDisplay extends Component {
 
     if (true) {
       return (
-        <div key="1" id="add-nin-number">
-          <NinNumber {...this.props} />
-          <div id="nin-buttons">
-            <VerifyButton {...this.props} />
-            <RemoveButton {...this.props} />
+        <div key="1" className="intro">
+          <h3> Step 1. Add your national id number</h3>
+          <p>Your id number has been added, but you still need to connect it to your person</p>
+          <div key="1" id="add-nin-number">
+            <div key="1" id="nin-form-container">
+              <div key="1" id="add-nin-number">
+                <NinNumber {...this.props} />
+                <div id="nin-buttons">
+                  <VerifyButton {...this.props} />
+                  <RemoveButton {...this.props} />
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       );
     } else {
       return (
-        <div key="1" id="add-nin-number">
-          <NinNumber {...this.props} />
-          <div id="nin-buttons">
-            <RemoveButton {...this.props} />
+        <div key="1" className="intro">
+          <h3> Step 1. Add your national identity number</h3>
+          <p>Your id number has been added and connected to your person.</p>
+          <div key="1" id="add-nin-number">
+            <div key="1" id="nin-form-container">
+              <div key="1" id="add-nin-number">
+                <NinNumber {...this.props} />
+                <div id="nin-buttons">
+                  <RemoveButton {...this.props} />
+                </div>
+              </div>
+            </div>
           </div>
         </div>
       );

--- a/src/components/NinDisplay.js
+++ b/src/components/NinDisplay.js
@@ -2,6 +2,8 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { Link } from "react-router-dom";
+import * as actions from "actions/Nins";
+import i18n from "i18n-messages";
 
 // import NinForm from "./NinForm";
 import EduIDButton from "components/EduIDButton";
@@ -24,7 +26,7 @@ let RemoveButton = props => {
       id={"button-rm-nin-" + props.nins[0].number}
       onClick={props.handleDelete}
     >
-      {props.l10n("nins.button_delete")}
+      X
     </EduIDButton>
   );
 };
@@ -83,9 +85,7 @@ class NinDisplay extends Component {
             <div key="1" id="nin-form-container">
               <div key="1" id="add-nin-number" className="unverified">
                 <NinNumber {...this.props} />
-                <div id="nin-buttons">
-                  <RemoveButton {...this.props} />
-                </div>
+                <RemoveButton {...this.props} />
               </div>
             </div>
           </div>
@@ -100,9 +100,7 @@ class NinDisplay extends Component {
             <div key="1" id="nin-form-container">
               <div key="1" id="add-nin-number" className="verified">
                 <NinNumber {...this.props} />
-                <div id="nin-buttons">
-                  <RemoveButton {...this.props} />
-                </div>
+                <RemoveButton {...this.props} />
               </div>
             </div>
           </div>
@@ -120,4 +118,32 @@ class NinDisplay extends Component {
 //   proofing_methods: PropTypes.array
 // };
 
-export default NinDisplay;
+const mapStateToProps = (state, props) => {
+  return {
+    nins: state.nins.nins,
+    // is_configured: state.config.is_configured,
+    // proofing_methods: state.config.PROOFING_METHODS,
+    // valid_nin: isValid("nins")(state),
+    nin: state.nins.nin,
+    message: state.nins.message
+  };
+};
+
+const mapDispatchToProps = (dispatch, props) => {
+  return {
+    handleDelete: function(e) {
+      console.log("you're in hansleDelete through ninDisplay!")
+      const ninNumber = e.target.previousSibling.dataset.ninnumber;
+      dispatch(actions.startRemove(ninNumber));
+    }
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(NinDisplay);
+
+// export default i18n(NinDisplay);
+
+// export default NinDisplay;

--- a/src/components/NinDisplay.js
+++ b/src/components/NinDisplay.js
@@ -1,0 +1,105 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+import { Link } from "react-router-dom";
+
+// import NinForm from "./NinForm";
+import EduIDButton from "components/EduIDButton";
+
+import "style/Nins.scss";
+
+let NinNumber = props => {
+  return (
+    <div data-ninnumber={props.nins[0].number} id="nin-number-container">
+      <p id="nin-number">{props.nins[0].number}</p>
+    </div>
+  );
+};
+
+let RemoveButton = props => {
+  return (
+    <EduIDButton
+      className="btn-danger"
+      className="btn-sm"
+      id={"button-rm-nin-" + props.nins[0].number}
+      onClick={props.handleDelete}
+    >
+      {props.l10n("nins.button_delete")}
+    </EduIDButton>
+  );
+};
+
+let VerifyButton = props => {
+  return (
+    <Link id="verify-button" to="/profile/verify-identity/step2">
+      <button>
+        <p>connect eduid to my person</p>
+      </button>
+    </Link>
+  );
+};
+
+class NinDisplay extends Component {
+  // constructor(props) {
+  //   super(props);
+  //   this.state = { nin: null };
+  //   this.addNin = this.addNin.bind(this);
+  // }
+  // addNin(validNin) {
+  //   this.setState((state, props) => {
+  //     return { nin: validNin };
+  //   }, console.log("this is state in AddNin:", this.state.nin));
+  // }
+  render() {
+    let ninStatus = "nonin";
+
+    // if (this.props.nins.length) {
+    //   ninStatus = "unverified";
+    //   const nins = this.props.nins.filter(nin => nin.verified);
+    //   if (nins.length === 1) {
+    //     ninStatus = "verified";
+    //     verifiedNin = nins[0].number;
+    //   }
+    // }
+
+    // let ninVerified = [
+    //   <div key="1" id="add-nin-number">
+    //     <NinNumber {...this.props} />
+    //     <div id="nin-buttons">
+    //       <RemoveButton {...this.props} />
+    //     </div>
+    //   </div>
+    // ];
+
+    if (true) {
+      return (
+        <div key="1" id="add-nin-number">
+          <NinNumber {...this.props} />
+          <div id="nin-buttons">
+            <VerifyButton {...this.props} />
+            <RemoveButton {...this.props} />
+          </div>
+        </div>
+      );
+    } else {
+      return (
+        <div key="1" id="add-nin-number">
+          <NinNumber {...this.props} />
+          <div id="nin-buttons">
+            <RemoveButton {...this.props} />
+          </div>
+        </div>
+      );
+    }
+  }
+}
+
+// NinDisplay.propTypes = {
+//   nin: PropTypes.string,
+//   nins: PropTypes.array,
+//   validateNin: PropTypes.func,
+//   handleDelete: PropTypes.func,
+//   proofing_methods: PropTypes.array
+// };
+
+export default NinDisplay;

--- a/src/components/NinDisplay.js
+++ b/src/components/NinDisplay.js
@@ -12,8 +12,8 @@ import "style/Nins.scss";
 
 let NinNumber = props => {
   return (
-    <div data-ninnumber={props.nins[0].number} id="nin-number-container">
-      <p id="nin-number">{props.nins[0].number}</p>
+    <div data-ninnumber={props.nin} id="nin-number-container">
+      <p id="nin-number">{props.nin}</p>
     </div>
   );
 };
@@ -21,10 +21,9 @@ let NinNumber = props => {
 let RemoveButton = props => {
   return (
     <EduIDButton
-      className="btn-danger"
-      className="btn-sm"
-      id={"button-rm-nin-" + props.nins[0].number}
-      onClick={props.handleDelete}
+      className="btn-danger btn-sm"
+      // id={"button-rm-nin-" + props.nin}
+      onClick={() => props.removeNin()}
     >
       X
     </EduIDButton>
@@ -50,6 +49,7 @@ class NinDisplay extends Component {
   //     return { nin: validNin };
   //   }, console.log("this is state in AddNin:", this.state.nin));
   // }
+
   render() {
     let ninStatus = "nonin";
 
@@ -118,32 +118,32 @@ class NinDisplay extends Component {
 //   proofing_methods: PropTypes.array
 // };
 
-const mapStateToProps = (state, props) => {
-  return {
-    nins: state.nins.nins,
-    // is_configured: state.config.is_configured,
-    // proofing_methods: state.config.PROOFING_METHODS,
-    // valid_nin: isValid("nins")(state),
-    nin: state.nins.nin,
-    message: state.nins.message
-  };
-};
+// const mapStateToProps = (state, props) => {
+//   return {
+//     nins: state.nins.nins,
+//     // is_configured: state.config.is_configured,
+//     // proofing_methods: state.config.PROOFING_METHODS,
+//     // valid_nin: isValid("nins")(state),
+//     nin: state.nins.nin,
+//     message: state.nins.message
+//   };
+// };
 
-const mapDispatchToProps = (dispatch, props) => {
-  return {
-    handleDelete: function(e) {
-      console.log("you're in hansleDelete through ninDisplay!")
-      const ninNumber = e.target.previousSibling.dataset.ninnumber;
-      dispatch(actions.startRemove(ninNumber));
-    }
-  };
-};
+// const mapDispatchToProps = (dispatch, props) => {
+//   // return {
+//   //   handleDelete: function(e) {
+//   //     console.log("you're in hansleDelete through ninDisplay!")
+//   //     const ninNumber = e.target.previousSibling.dataset.ninnumber;
+//   //     dispatch(actions.startRemove(ninNumber));
+//   //   }
+//   // };
+// };
 
-export default connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(NinDisplay);
+// export default connect(
+//   mapStateToProps,
+//   mapDispatchToProps
+// )(NinDisplay);
 
 // export default i18n(NinDisplay);
 
-// export default NinDisplay;
+export default NinDisplay;

--- a/src/components/NinDisplay.js
+++ b/src/components/NinDisplay.js
@@ -35,23 +35,23 @@ let RemoveButton = props => {
 class NinDisplay extends Component {
   render() {
     if (this.props.nins) {
-      if (this.props.nins[0].verified) {
-        console.log(this.props.nins.verified);
-        return (
-          <div key="1" className="intro">
-            <h3> Step 1. Add your national identity number</h3>
-            <p>Your id number has been added and connected to your person.</p>
-            <div key="1" id="add-nin-number">
-              <div key="1" id="nin-form-container">
-                <div key="1" id="add-nin-number" className="verified">
-                  <NinNumber {...this.props} />
-                  <RemoveButton {...this.props} />
-                </div>
-              </div>
-            </div>
-          </div>
-        );
-      }
+      // if (this.props.nins[0].verified) {
+      //   console.log(this.props.nins.verified);
+      //   return (
+      //     <div key="1" className="intro">
+      //       <h3> Step 1. Add your national identity number</h3>
+      //       <p>Your id number has been added and connected to your person.</p>
+      //       <div key="1" id="add-nin-number">
+      //         <div key="1" id="nin-form-container">
+      //           <div key="1" id="add-nin-number" className="verified">
+      //             <NinNumber {...this.props} />
+      //             <RemoveButton {...this.props} />
+      //           </div>
+      //         </div>
+      //       </div>
+      //     </div>
+      //   );
+      // }
       return (
         <div key="1" className="intro">
           <h3> Step 1. Add your national id number</h3>

--- a/src/components/NinDisplay.js
+++ b/src/components/NinDisplay.js
@@ -69,7 +69,7 @@ class NinDisplay extends Component {
     //   </div>
     // ];
 
-    if (true) {
+    if (this.props.nins.length) {
       return (
         <div key="1" className="intro">
           <h3> Step 1. Add your national id number</h3>
@@ -81,7 +81,7 @@ class NinDisplay extends Component {
           </p>
           <div key="1" id="add-nin-number">
             <div key="1" id="nin-form-container">
-              <div key="1" id="add-nin-number">
+              <div key="1" id="add-nin-number" className="unverified">
                 <NinNumber {...this.props} />
                 <div id="nin-buttons">
                   <RemoveButton {...this.props} />
@@ -98,7 +98,7 @@ class NinDisplay extends Component {
           <p>Your id number has been added and connected to your person.</p>
           <div key="1" id="add-nin-number">
             <div key="1" id="nin-form-container">
-              <div key="1" id="add-nin-number">
+              <div key="1" id="add-nin-number" className="verified">
                 <NinNumber {...this.props} />
                 <div id="nin-buttons">
                   <RemoveButton {...this.props} />

--- a/src/components/NinDisplay.js
+++ b/src/components/NinDisplay.js
@@ -1,11 +1,10 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { connect } from "react-redux";
+// import { connect } from "react-redux";
 import { Link } from "react-router-dom";
-import * as actions from "actions/Nins";
-import i18n from "i18n-messages";
+// import * as actions from "actions/Nins";
+// import i18n from "i18n-messages";
 
-// import NinForm from "./NinForm";
 import EduIDButton from "components/EduIDButton";
 
 import "style/Nins.scss";
@@ -19,6 +18,7 @@ let NinNumber = props => {
 };
 
 let RemoveButton = props => {
+  console.log("these are the props in remove button:", props);
   return (
     <EduIDButton
       className="btn-danger btn-sm"
@@ -39,17 +39,6 @@ let VerifyButton = props => {
 };
 
 class NinDisplay extends Component {
-  // constructor(props) {
-  //   super(props);
-  //   this.state = { nin: null };
-  //   this.addNin = this.addNin.bind(this);
-  // }
-  // addNin(validNin) {
-  //   this.setState((state, props) => {
-  //     return { nin: validNin };
-  //   }, console.log("this is state in AddNin:", this.state.nin));
-  // }
-
   render() {
     let ninStatus = "nonin";
 
@@ -62,16 +51,24 @@ class NinDisplay extends Component {
     //   }
     // }
 
-    // let ninVerified = [
-    //   <div key="1" id="add-nin-number">
-    //     <NinNumber {...this.props} />
-    //     <div id="nin-buttons">
-    //       <RemoveButton {...this.props} />
-    //     </div>
-    //   </div>
-    // ];
-
-    if (this.props.nins.length) {
+    if (this.props.nins.verified) {
+      console.log(this.props.nins.verified);
+      return (
+        <div key="1" className="intro">
+          <h3> Step 1. Add your national identity number</h3>
+          <p>Your id number has been added and connected to your person.</p>
+          <div key="1" id="add-nin-number">
+            <div key="1" id="nin-form-container">
+              <div key="1" id="add-nin-number" className="verified">
+                <NinNumber {...this.props} />
+                <RemoveButton {...this.props} />
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    } else {
+      console.log(this.props.nins.length == 1);
       return (
         <div key="1" className="intro">
           <h3> Step 1. Add your national id number</h3>
@@ -91,21 +88,6 @@ class NinDisplay extends Component {
           </div>
         </div>
       );
-    } else {
-      return (
-        <div key="1" className="intro">
-          <h3> Step 1. Add your national identity number</h3>
-          <p>Your id number has been added and connected to your person.</p>
-          <div key="1" id="add-nin-number">
-            <div key="1" id="nin-form-container">
-              <div key="1" id="add-nin-number" className="verified">
-                <NinNumber {...this.props} />
-                <RemoveButton {...this.props} />
-              </div>
-            </div>
-          </div>
-        </div>
-      );
     }
   }
 }
@@ -118,32 +100,5 @@ class NinDisplay extends Component {
 //   proofing_methods: PropTypes.array
 // };
 
-// const mapStateToProps = (state, props) => {
-//   return {
-//     nins: state.nins.nins,
-//     // is_configured: state.config.is_configured,
-//     // proofing_methods: state.config.PROOFING_METHODS,
-//     // valid_nin: isValid("nins")(state),
-//     nin: state.nins.nin,
-//     message: state.nins.message
-//   };
-// };
-
-// const mapDispatchToProps = (dispatch, props) => {
-//   // return {
-//   //   handleDelete: function(e) {
-//   //     console.log("you're in hansleDelete through ninDisplay!")
-//   //     const ninNumber = e.target.previousSibling.dataset.ninnumber;
-//   //     dispatch(actions.startRemove(ninNumber));
-//   //   }
-//   // };
-// };
-
-// export default connect(
-//   mapStateToProps,
-//   mapDispatchToProps
-// )(NinDisplay);
-
-// export default i18n(NinDisplay);
 
 export default NinDisplay;

--- a/src/components/NinForm.js
+++ b/src/components/NinForm.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { Field, reduxForm } from "redux-form";
 import { Form } from "reactstrap";
+import { Link } from "react-router-dom";
 
 import TextInput from "components/EduIDTextInput";
 
@@ -42,9 +43,11 @@ class NinForm extends Component {
     if (this.props.valid_nin) {
       validNin = this.props.nin;
       formButton = [
-        <button onClick={() => this.props.addNin(validNin)} key="1">
-          ADD
-        </button>
+        <Link id="verify-button" to="/profile/verify-identity/step2">
+          <button onClick={() => this.props.addNin(validNin)} key="1">
+            ADD
+          </button>
+        </Link>
       ];
     }
 

--- a/src/components/NinForm.js
+++ b/src/components/NinForm.js
@@ -43,8 +43,7 @@ class NinForm extends Component {
     if (this.props.valid_nin) {
       validNin = this.props.nin;
       formButton = [
-        <Link id="verify-button" to="/profile/verify-identity/step2">
-          <button
+          <button id="verify-button" 
             onClick={e => {
               this.props.addNin(validNin);
               this.props.confirmLetterProofing(e);
@@ -53,7 +52,6 @@ class NinForm extends Component {
           >
             ADD
           </button>
-        </Link>
       ];
     }
 

--- a/src/components/NinForm.js
+++ b/src/components/NinForm.js
@@ -99,12 +99,6 @@ NinForm = connect(state => ({
 const mapStateToProps = (state, props) => {
   return {
     initialValues: { nin: state.nins.nin },
-    // nins: state.nins.nins,
-    // // // is_configured: state.config.is_configured,
-    // // // proofing_methods: state.config.PROOFING_METHODS,
-    // // // valid_nin: isValid("nins")(state),
-    // nin: state.nins.nin,
-    // message: state.nins.message
   };
 };
 
@@ -123,4 +117,3 @@ export default connect(
   mapDispatchToProps
 )(NinForm);
 
-// export default NinForm;

--- a/src/components/NinForm.js
+++ b/src/components/NinForm.js
@@ -4,7 +4,7 @@ import { connect } from "react-redux";
 import { Field, reduxForm } from "redux-form";
 import { Form } from "reactstrap";
 import { Link } from "react-router-dom";
-
+import * as letterActions from "actions/LetterProofing";
 import TextInput from "components/EduIDTextInput";
 
 import "style/Nins.scss";
@@ -44,7 +44,13 @@ class NinForm extends Component {
       validNin = this.props.nin;
       formButton = [
         <Link id="verify-button" to="/profile/verify-identity/step2">
-          <button onClick={() => this.props.addNin(validNin)} key="1">
+          <button
+            onClick={e => {
+              this.props.addNin(validNin);
+              this.props.confirmLetterProofing(e);
+            }}
+            key="1"
+          >
             ADD
           </button>
         </Link>
@@ -92,4 +98,31 @@ NinForm = connect(state => ({
 //   proofing_methods: PropTypes.array
 // };
 
-export default NinForm;
+const mapStateToProps = (state, props) => {
+  return {
+    initialValues: { nin: state.nins.nin },
+    // nins: state.nins.nins,
+    // // // is_configured: state.config.is_configured,
+    // // // proofing_methods: state.config.PROOFING_METHODS,
+    // // // valid_nin: isValid("nins")(state),
+    // nin: state.nins.nin,
+    // message: state.nins.message
+  };
+};
+
+const mapDispatchToProps = (dispatch, props) => {
+  return {
+    confirmLetterProofing: function (e) {
+      console.log("you're in confirmLetterProofing!");
+      dispatch(letterActions.postLetterProofingSendLetter());
+      dispatch(letterActions.stopLetterConfirmation());
+    }
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(NinForm);
+
+// export default NinForm;

--- a/src/components/Nins.js
+++ b/src/components/Nins.js
@@ -18,8 +18,8 @@ import "style/Nins.scss";
 //   if (/[^0-9]+/.test(value)) return { nin: "nins.illegal_chars" };
 //   if (value.length !== 12) return { nin: "nins.wrong_length" };
 
-  // The Luhn Algorithm. It's so pretty.
-  // taken from https://gist.github.com/DiegoSalazar/4075533/
+// The Luhn Algorithm. It's so pretty.
+// taken from https://gist.github.com/DiegoSalazar/4075533/
 //   let nCheck = 0,
 //     bEven = false;
 //   value = value.slice(2); // To pass the Luhn check only use the 10 last digits
@@ -168,12 +168,12 @@ class Nins extends Component {
     //   </div>
     // ];
 
-    let verifyIdentityStyle = [
-      <div key="1" className="intro">
-        <h3> Step 1. Add your national identity number</h3>
-        <p>Your number can be used to connect eduID to your person.</p>
-      </div>
-    ];
+    // let verifyIdentityStyle = [
+    //   <div key="1" className="intro">
+    //     <h3> Step 1. Add your national identity number</h3>
+    //     <p>Your number can be used to connect eduID to your person.</p>
+    //   </div>
+    // ];
 
     let settingsStyle = [
       <div className="intro">
@@ -207,24 +207,22 @@ class Nins extends Component {
     // }
 
     if (url.includes("settings")) {
-      ninHeading = settingsStyle;
+      // ninHeading = settingsStyle;
     } else if (url.includes("step2")) {
       ninButtons = vettingButtons;
-      ninHeading = verifyIdentityStyle;
+      // ninHeading = verifyIdentityStyle;
     } else {
-      ninHeading = verifyIdentityStyle;
+      // ninHeading = verifyIdentityStyle;
     }
 
     return (
-      <div>
-        <div id="nin-process">
-          <div id="add-nin-number-container">
-            {ninHeading}
-            <AddNin {...this.props} />
-            {/* {ninInput} */}
-          </div>
-          <div id="connect-nin-number-container">{ninButtons}</div>
+      <div id="nin-process">
+        <div id="add-nin-number-container">
+          {/* {ninHeading} */}
+          <AddNin {...this.props} />
+          {/* {ninInput} */}
         </div>
+        <div id="connect-nin-number-container">{ninButtons}</div>
       </div>
     );
   }

--- a/src/components/Nins.js
+++ b/src/components/Nins.js
@@ -1,198 +1,17 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { connect } from "react-redux";
-import { Field, reduxForm } from "redux-form";
-import { Link } from "react-router-dom";
-import { ButtonGroup, Form } from "reactstrap";
+import { ButtonGroup } from "reactstrap";
 
 import AddNin from "./AddNin";
-import TextInput from "components/EduIDTextInput";
-import EduIDButton from "components/EduIDButton";
 import vettingRegistry from "vetting-registry";
 
 import "style/Nins.scss";
 
-// const validate = values => {
-//   let value = values.nin;
-//   // accept only digits
-//   if (/[^0-9]+/.test(value)) return { nin: "nins.illegal_chars" };
-//   if (value.length !== 12) return { nin: "nins.wrong_length" };
-
-// The Luhn Algorithm. It's so pretty.
-// taken from https://gist.github.com/DiegoSalazar/4075533/
-//   let nCheck = 0,
-//     bEven = false;
-//   value = value.slice(2); // To pass the Luhn check only use the 10 last digits
-//   for (let n = value.length - 1; n >= 0; n--) {
-//     let cDigit = value.charAt(n),
-//       nDigit = parseInt(cDigit, 10);
-//     if (bEven) {
-//       if ((nDigit *= 2) > 9) nDigit -= 9;
-//     }
-//     nCheck += nDigit;
-//     bEven = !bEven;
-//   }
-//   if (nCheck % 10 !== 0) {
-//     return { nin: "nins.invalid_nin" };
-//   }
-//   return {};
-// };
-
-// let NinForm = props => {
-//   return (
-//     <Form id="nin-form" role="form">
-//       <Field
-//         component={TextInput}
-//         componentClass="input"
-//         type="text"
-//         name="nin"
-//         className="nin-input"
-//         placeholder={props.l10n("nins.input_placeholder")}
-//         helpBlock={props.l10n("nins.input_help_text")}
-//       />
-//     </Form>
-//   );
-// };
-
-// let NinButtons = props => {
-//   return (
-//     <ButtonGroup vertical={true} id="nins-btn-group">
-//       {props.buttons}
-//     </ButtonGroup>
-//   );
-// };
-
-// let NinNumber = props => {
-//   // look at a way to see verified status here? <span>{verifiedNin}</span>
-//   return (
-//     <div data-ninnumber={props.nins[0].number} id="nin-number-container">
-//       <p id="nin-number">{props.nins[0].number}</p>
-//     </div>
-//   );
-// };
-
-// let RemoveButton = props => {
-//   return (
-//     <EduIDButton
-//       className="btn-danger"
-//       className="btn-sm"
-//       id={"button-rm-nin-" + props.nins[0].number}
-//       onClick={props.handleDelete}
-//     >
-//       {props.l10n("nins.button_delete")}
-//     </EduIDButton>
-//   );
-// };
-
-// let VerifyButton = props => {
-//   return (
-//     <Link id="verify-button" to="/profile/verify-identity/step2">
-//       <button>
-//         <p>connect eduid to my person</p>
-//       </button>
-//     </Link>
-//   );
-// };
-
 class Nins extends Component {
   render() {
-    const url = window.location.href;
-    // let ninStatus = "nonin",
-    // ninHeading = "",
     let vettingButtons = "",
       connectNin = "";
-    // ninInput = "",
-    // ninButtons = "",
-    // verifiedNin = "";
-
-    // if (this.props.is_configured) {
-    //   const vettingBtns = vettingRegistry(!this.props.valid_nin);
-    //   const verifyOptions = this.props.proofing_methods.filter(
-    //     option => option !== "oidc"
-    //   );
-    //   vettingButtons = verifyOptions.map((key, index) => {
-    //     return (
-    //       <div className="vetting-button" key={index}>
-    //         {vettingBtns[key]}
-    //       </div>
-    //     );
-    //   });
-    // }
-
-    // if (this.props.nins.length) {
-    //   ninStatus = "unverified";
-    //   const nins = this.props.nins.filter(nin => nin.verified);
-    //   if (nins.length === 1) {
-    //     ninStatus = "verified";
-    //     verifiedNin = nins[0].number;
-    //   }
-    // }
-
-    // let noNin = [
-    //   <div key="1" id="add-nin-number">
-    //     <div key="1">{this.props.l10n("nins.help_text")}</div>
-    //     <div key="2" id="nin-form-container">
-    //       <NinForm {...this.props} />
-    //     </div>
-    //     <div key="3">
-    //       <button key="1">ADD FUNCTIONALITY HERE</button>
-    //     </div>
-    //   </div>
-    // ];
-
-    // let ninUnverified = [
-    //   <div key="1" id="add-nin-number">
-    //     <div>
-    //       <NinNumber {...this.props} />
-    //     </div>
-    //     <div id="nin-buttons">
-    //       <div>
-    //         <VerifyButton {...this.props} />
-    //       </div>
-    //       <div>
-    //         <RemoveButton {...this.props} />
-    //       </div>
-    //     </div>
-    //   </div>
-    // ];
-
-    // let ninVerified = [
-    //   <div key="1" id="add-nin-number">
-    //     <div>
-    //       <NinNumber {...this.props} />
-    //     </div>
-    //     <div id="nin-buttons">
-    //       <div>
-    //         <RemoveButton {...this.props} />
-    //       </div>
-    //     </div>
-    //   </div>
-    // ];
-
-    // let verifyIdentityStyle = [
-    //   <div key="1" className="intro">
-    //     <h3> Step 1. Add your national identity number</h3>
-    //     <p>Your number can be used to connect eduID to your person.</p>
-    //   </div>
-    // ];
-
-    // console.log("will we get vetting buttons:", this.props.is_configured);
-    // console.log("is there a valid nin?:", this.props.valid_nin);
-    // console.log("is there a nin?:", this.props.nin);
-    // if (this.props.is_configured) {
-    //   const vettingBtns = vettingRegistry(!this.props.valid_nin);
-    //   console.log("vettingBtns:", vettingBtns)
-    //   const verifyOptions = this.props.proofing_methods.filter(
-    //     option => option !== "oidc"
-    //   );
-    //   vettingButtons = verifyOptions.map((key, index) => {
-    //     return (
-    //       <div className="vetting-button" key={index}>
-    //         {vettingBtns[key]}
-    //       </div>
-    //     );
-    //   });
-    // }
+  
     if (this.props.is_configured) {
       const vettingBtns = vettingRegistry(!this.props.valid_nin);
       const verifyOptions = this.props.proofing_methods.filter(
@@ -207,9 +26,6 @@ class Nins extends Component {
       });
     }
 
-    // console.log("is state nin null:", this.state.nin === null);
-    // console.log("is state nin something else:", this.state.nin !== null);
-    // !this.props.nin === ""
     if (this.props.nins.length) {
       connectNin = [
         <div key="1" id="connect-nin-number">
@@ -226,58 +42,17 @@ class Nins extends Component {
         </div>
       ];
     }
-    // let settingsStyle = [
-    //   <div className="intro">
-    //     <h4>{this.props.l10n("nins.main_title")}</h4>
-    //     <p>{this.props.l10n("nins.justification")}</p>
-    //   </div>
-    // ];
-
-    // if (ninStatus === "nonin") {
-    //   ninInput = noNin;
-    // } else if (ninStatus === "unverified") {
-    //   ninInput = ninUnverified;
-    //   if (this.props.nins.length > 1) {
-    //     ninInput = this.props.l10n("nins.only_one_to_verify");
-    //   }
-    // } else if (ninStatus === "verified") {
-    //   ninInput = ninVerified;
-    // }
-
-    // if (url.includes("settings")) {
-    //   // ninHeading = settingsStyle;
-    // } else if (url.includes("step2")) {
-    //   ninButtons = vettingButtons;
-    //   // ninHeading = verifyIdentityStyle;
-    // } else {
-    //   // ninHeading = verifyIdentityStyle;
-    // }
+  
     return (
       <div id="nin-process">
         <div id="add-nin-number-container">
-          {/* {ninHeading} */}
           <AddNin {...this.props} />
-          {/* {ninInput} */}
         </div>
         <div id="connect-nin-number-container">{connectNin}</div>
       </div>
     );
   }
 }
-
-// NinForm = reduxForm({
-//   form: "nins",
-//   destroyOnUnmount: false,
-//   enableReinitialize: true,
-//   keepDirtyOnReinitialize: true,
-//   keepValuesOnReinitialize: true,
-//   updateUnregisteredFields: true,
-//   validate: validate
-// })(NinForm);
-
-// NinForm = connect(state => ({
-//   initialValues: { nin: state.nins.nin }
-// }))(NinForm);
 
 Nins.propTypes = {
   nin: PropTypes.string,

--- a/src/components/Nins.js
+++ b/src/components/Nins.js
@@ -210,7 +210,7 @@ class Nins extends Component {
     // console.log("is state nin null:", this.state.nin === null);
     // console.log("is state nin something else:", this.state.nin !== null);
     // !this.props.nin === ""
-    if (url.includes("step2")) {
+    if (this.props.nins.length) {
       connectNin = [
         <div key="1" id="connect-nin-number">
           <h3> Step 2. Connect your national identity number to eduID</h3>

--- a/src/components/Nins.js
+++ b/src/components/Nins.js
@@ -54,13 +54,13 @@ import "style/Nins.scss";
 //   );
 // };
 
-let NinButtons = props => {
-  return (
-    <ButtonGroup vertical={true} id="nins-btn-group">
-      {props.buttons}
-    </ButtonGroup>
-  );
-};
+// let NinButtons = props => {
+//   return (
+//     <ButtonGroup vertical={true} id="nins-btn-group">
+//       {props.buttons}
+//     </ButtonGroup>
+//   );
+// };
 
 // let NinNumber = props => {
 //   // look at a way to see verified status here? <span>{verifiedNin}</span>
@@ -97,26 +97,27 @@ let NinButtons = props => {
 class Nins extends Component {
   render() {
     const url = window.location.href;
-    let ninStatus = "nonin",
-      ninHeading = "",
-      vettingButtons = "",
-      ninInput = "",
-      ninButtons = "",
-      verifiedNin = "";
+    // let ninStatus = "nonin",
+    // ninHeading = "",
+    let vettingButtons = "",
+      connectNin = "";
+    // ninInput = "",
+    // ninButtons = "",
+    // verifiedNin = "";
 
-    if (this.props.is_configured) {
-      const vettingBtns = vettingRegistry(!this.props.valid_nin);
-      const verifyOptions = this.props.proofing_methods.filter(
-        option => option !== "oidc"
-      );
-      vettingButtons = verifyOptions.map((key, index) => {
-        return (
-          <div className="vetting-button" key={index}>
-            {vettingBtns[key]}
-          </div>
-        );
-      });
-    }
+    // if (this.props.is_configured) {
+    //   const vettingBtns = vettingRegistry(!this.props.valid_nin);
+    //   const verifyOptions = this.props.proofing_methods.filter(
+    //     option => option !== "oidc"
+    //   );
+    //   vettingButtons = verifyOptions.map((key, index) => {
+    //     return (
+    //       <div className="vetting-button" key={index}>
+    //         {vettingBtns[key]}
+    //       </div>
+    //     );
+    //   });
+    // }
 
     // if (this.props.nins.length) {
     //   ninStatus = "unverified";
@@ -175,25 +176,62 @@ class Nins extends Component {
     //   </div>
     // ];
 
-    let settingsStyle = [
-      <div className="intro">
-        <h4>{this.props.l10n("nins.main_title")}</h4>
-        <p>{this.props.l10n("nins.justification")}</p>
-      </div>
-    ];
+    // console.log("will we get vetting buttons:", this.props.is_configured);
+    // console.log("is there a valid nin?:", this.props.valid_nin);
+    // console.log("is there a nin?:", this.props.nin);
+    // if (this.props.is_configured) {
+    //   const vettingBtns = vettingRegistry(!this.props.valid_nin);
+    //   console.log("vettingBtns:", vettingBtns)
+    //   const verifyOptions = this.props.proofing_methods.filter(
+    //     option => option !== "oidc"
+    //   );
+    //   vettingButtons = verifyOptions.map((key, index) => {
+    //     return (
+    //       <div className="vetting-button" key={index}>
+    //         {vettingBtns[key]}
+    //       </div>
+    //     );
+    //   });
+    // }
+    if (this.props.is_configured) {
+      const vettingBtns = vettingRegistry(!this.props.valid_nin);
+      const verifyOptions = this.props.proofing_methods.filter(
+        option => option !== "oidc"
+      );
+      vettingButtons = verifyOptions.map((key, index) => {
+        return (
+          <div className="vetting-button" key={index}>
+            {vettingBtns[key]}
+          </div>
+        );
+      });
+    }
 
-    vettingButtons = [
-      <div key="1" id="connect-nin-number">
-        <h3> Step 2. Connect your national identity number to eduID</h3>
-        <p>
-          Choose a way below to verify that the given identity number belongs to
-          you.
-        </p>
-        <div>
-          <NinButtons buttons={vettingButtons} {...this.props} />
+    // console.log("is state nin null:", this.state.nin === null);
+    // console.log("is state nin something else:", this.state.nin !== null);
+    // !this.props.nin === ""
+    if (url.includes("step2")) {
+      connectNin = [
+        <div key="1" id="connect-nin-number">
+          <h3> Step 2. Connect your national identity number to eduID</h3>
+          <p>
+            Choose a way below to verify that the given identity number belongs
+            to you.
+          </p>
+          <div>
+            <ButtonGroup vertical={true} id="nins-btn-group">
+              {vettingButtons}
+            </ButtonGroup>
+          </div>
         </div>
-      </div>
-    ];
+      ];
+    }
+    // let settingsStyle = [
+    //   <div className="intro">
+    //     <h4>{this.props.l10n("nins.main_title")}</h4>
+    //     <p>{this.props.l10n("nins.justification")}</p>
+    //   </div>
+    // ];
 
     // if (ninStatus === "nonin") {
     //   ninInput = noNin;
@@ -206,15 +244,14 @@ class Nins extends Component {
     //   ninInput = ninVerified;
     // }
 
-    if (url.includes("settings")) {
-      // ninHeading = settingsStyle;
-    } else if (url.includes("step2")) {
-      ninButtons = vettingButtons;
-      // ninHeading = verifyIdentityStyle;
-    } else {
-      // ninHeading = verifyIdentityStyle;
-    }
-
+    // if (url.includes("settings")) {
+    //   // ninHeading = settingsStyle;
+    // } else if (url.includes("step2")) {
+    //   ninButtons = vettingButtons;
+    //   // ninHeading = verifyIdentityStyle;
+    // } else {
+    //   // ninHeading = verifyIdentityStyle;
+    // }
     return (
       <div id="nin-process">
         <div id="add-nin-number-container">
@@ -222,7 +259,7 @@ class Nins extends Component {
           <AddNin {...this.props} />
           {/* {ninInput} */}
         </div>
-        <div id="connect-nin-number-container">{ninButtons}</div>
+        <div id="connect-nin-number-container">{connectNin}</div>
       </div>
     );
   }

--- a/src/containers/Nins.js
+++ b/src/containers/Nins.js
@@ -17,10 +17,11 @@ const mapStateToProps = (state, props) => {
 
 const mapDispatchToProps = (dispatch, props) => {
   return {
-    handleDelete: function(e) {
-      const nin = e.target.closest(".nin-holder").dataset.ninnumber;
-      dispatch(actions.startRemove(nin));
-    }
+    // handleDelete: function(e) {
+    //   console.log("you came here through nins.js")
+    //   const nin = e.target.closest(".nin-holder").dataset.ninnumber;
+    //   dispatch(actions.startRemove(nin));
+    // }
   };
 };
 

--- a/src/containers/Nins.js
+++ b/src/containers/Nins.js
@@ -17,11 +17,11 @@ const mapStateToProps = (state, props) => {
 
 const mapDispatchToProps = (dispatch, props) => {
   return {
-    // handleDelete: function(e) {
-    //   console.log("you came here through nins.js")
-    //   const nin = e.target.closest(".nin-holder").dataset.ninnumber;
-    //   dispatch(actions.startRemove(nin));
-    // }
+    handleDelete: function(e) {
+      console.log("you came here through nins.js")
+      const nin = e.target.closest(".nin-holder").dataset.ninnumber;
+      dispatch(actions.startRemove(nin));
+    }
   };
 };
 

--- a/src/style/Nins.scss
+++ b/src/style/Nins.scss
@@ -25,25 +25,29 @@
 }
 
 /*--- styles for nin buttons ---*/
-#nin-buttons {
-  display: flex;
+// #nin-buttons {
+//   display: flex;
+// }
+
+#verify-id-link {
+  margin-left: 5px;
 }
 
-#verify-button button {
-  background-color: transparent;
-}
+// #verify-button button {
+//   background-color: transparent;
+// }
 
-#verify-button button p {
-  margin: 0;
-  padding: 0;
-  font-size: 14px;
-  color: #3f5c57;
-  border-bottom: 2px solid transparent;
-}
+// #verify-button button p {
+//   margin: 0;
+//   padding: 0;
+//   font-size: 14px;
+//   color: #3f5c57;
+//   border-bottom: 2px solid transparent;
+// }
 
-#verify-button p:hover {
-  border-bottom: 2px solid #3f5c57;
-}
+// #verify-button p:hover {
+//   border-bottom: 2px solid #3f5c57;
+// }
 
 //--- STEP 2. CONNECT NIN STYLES ---//
 

--- a/src/style/Nins.scss
+++ b/src/style/Nins.scss
@@ -24,6 +24,14 @@
   font-size: 24px;
 }
 
+.unverified {
+  color: #b75865;
+}
+
+.verified {
+  color: #3f5c57;
+}
+
 /*--- styles for nin buttons ---*/
 // #nin-buttons {
 //   display: flex;


### PR DESCRIPTION
**Background**: The dashboard is being reengineered to make users aware that adding their nin is the first step in a 2-step process to complete their eduid account. 
* [Pt 1:](https://github.com/SUNET/eduid-front/pull/74) _NinForm.js_ passes only valid nin to parent (_AddNin.js_) which sets `this.state.nin` to `validNin`, and based on this, controls rendering of `<NinForm />` vs `validNin`. 

**Work summary**: 
* Adds new component _NinDisplay.js_ (child of _AddNin.js_)
* _NinDisplay.js_: `<button>X</button>` reverts `this.state.nin` to `null` in parent (_AddNin.js_) and dispatches action via the existing `handleDelete()` (empties the nin array)
* _NinForm.js_ [UPDATED]: In addition to triggering a change in `this.state.nin` of its parent `<button>ADD</button>`  also dispatches action via the existing `confirmLetterProofing` (populates the nin array)
* _AddNin.js_ [UPDATED]:  saves it in the state saves it in the state
* Removes all dependency on rerouting within _Nins.js_ (could scale it back elsewhere)

>  👋 **Happily taking suggestions for better ways of populating the nins array**  👍

⚠️**Warning**: 
* Use of `confirmLetterProofing()` to populate the nins array could affect functionality related to actually confirming letters
* Nins are not updated (rendering is based on saved info or if empty, the info given by user), either `handleDelete()` is not complete or we need to trigger specific actions to update nin

**Overall structure of components** 
```
<Nins >
   <AddNin >
	if (this.state.nin === null) {
		<NinForm />
	 } else {	
		<NinDisplay />
	}
   </ AddNin >

    if (this.props.nins.length) {
	{connectNin}
     }
</ Nins >
```