### PR TITLE
Adds postNin saga to new endpoint

### DIFF
--- a/src/actions/Nins.js
+++ b/src/actions/Nins.js
@@ -1,6 +1,11 @@
 export const GET_NINS = "GET_NINS";
 export const GET_NINS_SUCCESS = "GET_PERSONAL_DATA_NINS_SUCCESS";
 export const GET_NINS_FAIL = "GET_PERSONAL_DATA_NINS_FAIL";
+
+export const POST_NIN = "POST_NIN";
+export const POST_NIN_FAIL = "POST_SECURITY_ADD_NIN_FAIL"
+export const POST_NIN_SUCCESS =  "POST_SECURITY_ADD_NIN_SUCCESS"
+
 export const POST_NIN_REMOVE = "POST_NIN_REMOVE";
 export const POST_NIN_REMOVE_SUCCESS = "POST_SECURITY_REMOVE_NIN_SUCCESS";
 export const POST_NIN_REMOVE_FAIL = "POST_SECURITY_REMOVE_NIN_FAIL";
@@ -22,6 +27,27 @@ export function getNinsFail(err) {
     }
   };
 }
+
+export function postNin(nin) {
+  return {
+    type: POST_NIN,
+    payload: {
+      nin: nin
+    }
+  };
+}
+
+export function postNinFail(err) {
+  return {
+    type: POST_NIN_FAIL,
+    error: true,
+    payload: {
+      error: err,
+      message: err.toString()
+    }
+  };
+}
+
 
 export function startRemove(nin) {
   return {

--- a/src/components/AddNin.js
+++ b/src/components/AddNin.js
@@ -1,133 +1,21 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-// import { connect } from "react-redux";
-// import { Field, reduxForm } from "redux-form";
-// import { Link } from "react-router-dom";
-// import { ButtonGroup, Form } from "reactstrap";
-
 import NinForm from "./NinForm";
-// import TextInput from "components/EduIDTextInput";
-// import EduIDButton from "components/EduIDButton";
-// import vettingRegistry from "vetting-registry";
+import NinDisplay from "./NinDisplay";
 
 import "style/Nins.scss";
 
-// const validate = values => {
-//   let value = values.nin;
-//   // accept only digits
-//   if (/[^0-9]+/.test(value)) return { nin: "nins.illegal_chars" };
-//   if (value.length !== 12) return { nin: "nins.wrong_length" };
-
-//   // The Luhn Algorithm. It's so pretty.
-//   // taken from https://gist.github.com/DiegoSalazar/4075533/
-//   let nCheck = 0,
-//     bEven = false;
-//   value = value.slice(2); // To pass the Luhn check only use the 10 last digits
-//   for (let n = value.length - 1; n >= 0; n--) {
-//     let cDigit = value.charAt(n),
-//       nDigit = parseInt(cDigit, 10);
-//     if (bEven) {
-//       if ((nDigit *= 2) > 9) nDigit -= 9;
-//     }
-//     nCheck += nDigit;
-//     bEven = !bEven;
-//   }
-//   if (nCheck % 10 !== 0) {
-//     return { nin: "nins.invalid_nin" };
-//   }
-//   return {};
-// };
-
-// let NinForm = props => {
-//   return (
-//     <Form id="nin-form" role="form">
-//       <Field
-//         component={TextInput}
-//         componentClass="input"
-//         type="text"
-//         name="nin"
-//         className="nin-input"
-//         placeholder={props.l10n("nins.input_placeholder")}
-//         helpBlock={props.l10n("nins.input_help_text")}
-//       />
-//     </Form>
-//   );
-// };
-
-// let NinButtons = props => {
-//   return (
-//     <ButtonGroup vertical={true} id="nins-btn-group">
-//       {props.buttons}
-//     </ButtonGroup>
-//   );
-// };
-
-// let NinNumber = props => {
-//   // look at a way to see verified status here? <span>{verifiedNin}</span>
-//   return (
-//     <div data-ninnumber={props.nins[0].number} id="nin-number-container">
-//       <p id="nin-number">{props.nins[0].number}</p>
-//     </div>
-//   );
-// };
-
-// let RemoveButton = props => {
-//   return (
-//     <EduIDButton
-//       className="btn-danger"
-//       className="btn-sm"
-//       id={"button-rm-nin-" + props.nins[0].number}
-//       onClick={props.handleDelete}
-//     >
-//       {props.l10n("nins.button_delete")}
-//     </EduIDButton>
-//   );
-// };
-
-let VerifyButton = props => {
-  return (
-    <Link id="verify-button" to="/profile/verify-identity/step2">
-      <button>
-        <p>connect eduid to my person</p>
-      </button>
-    </Link>
-  );
-};
-
 class AddNin extends Component {
   render() {
-    // const url = window.location.href;
-    // let ninStatus = "nonin",
-    //   ninHeading = "",
-    //   vettingButtons = "",
-    //   ninInput = "",
-    //   ninButtons = "",
-    //   verifiedNin = "",
-    //   validNin = "";
-    // if (this.props.is_configured) {
-    //   const vettingBtns = vettingRegistry(!this.props.valid_nin);
-    //   const verifyOptions = this.props.proofing_methods.filter(
-    //     option => option !== "oidc"
-    //   );
-    //   vettingButtons = verifyOptions.map((key, index) => {
-    //     return (
-    //       <div className="vetting-button" key={index}>
-    //         {vettingBtns[key]}
-    //       </div>
-    //     );
-    //   });
-    // }
-
     console.log("show form! because nin is null!");
     console.log("these are the props (AddNin):", this.props);
+
     if (this.props.nins.length) {
-      return (
-        <div key="1" className="intro">
-          <h3> Step 1. Add your national identity number</h3>
-          <p>nin array has a number!</p>
-        </div>
-      );
+      console.log("show number! because nin arraaaaayyyy!");
+      return <NinDisplay removeNin={this.removeNin} {...this.props} />;
     } else {
+      console.log("show form! because nin is null!");
+      console.log("these are the props (AddNin):", this.props);
       return (
         <div key="1" className="intro">
           <h3> Step 1. Add your national identity number</h3>
@@ -141,125 +29,8 @@ class AddNin extends Component {
         </div>
       );
     }
-
-    // if (this.props.valid_nin) {
-    //   console.log("is the nin valid? (AddNin.js)", this.props.valid_nin);
-    //   validNin = this.props.nin;
-    // }
-
-    // if (this.props.nins.length) {
-    //   ninStatus = "unverified";
-    //   const nins = this.props.nins.filter(nin => nin.verified);
-    //   if (nins.length === 1) {
-    //     ninStatus = "verified";
-    //     verifiedNin = nins[0].number;
-    //   }
-    // }
-
-    // let noNin = [
-    //   <div key="1" id="add-nin-number">
-    //     <div key="1">{this.props.l10n("nins.help_text")}</div>
-    //     <div key="2" id="nin-form-container">
-    //       <NinForm {...this.props} />
-    //       <button onClick={this.addNin} key="1">
-    //         ADD
-    //       </button>
-    //     </div>
-    //   </div>
-    // ];
-
-    // let ninUnverified = [
-    //   <div key="1" id="add-nin-number">
-    //     <NinNumber {...this.props} />
-    //     <div id="nin-buttons">
-    //       <VerifyButton {...this.props} />
-    //       <RemoveButton {...this.props} />
-    //     </div>
-    //   </div>
-    // ];
-
-    // let ninVerified = [
-    //   <div key="1" id="add-nin-number">
-    //     <NinNumber {...this.props} />
-    //     <div id="nin-buttons">
-    //       <RemoveButton {...this.props} />
-    //     </div>
-    //   </div>
-    // ];
-
-    // let verifyIdentityStyle = [
-    //   <div key="1" className="intro">
-    //     <h3> Step 1. Add your national identity number</h3>
-    //     <p>Your number can be used to connect eduID to your person.</p>
-    //   </div>
-    // ];
-
-    // let settingsStyle = [
-    //   <div className="intro">
-    //     <h4>{this.props.l10n("nins.main_title")}</h4>
-    //     <p>{this.props.l10n("nins.justification")}</p>
-    //   </div>
-    // ];
-
-    // vettingButtons = [
-    //   <div key="1" id="connect-nin-number">
-    //     <h3> Step 2. Connect your national identity number to eduID</h3>
-    //     <p>
-    //       Choose a way below to verify that the given identity number belongs to
-    //       you.
-    //     </p>
-    //     <div>
-    //       <NinButtons buttons={vettingButtons} {...this.props} />
-    //     </div>
-    //   </div>
-    // ];
-
-    // ninStatus === "nonin";
-
-    // if (true) {
-    //   return (
-    //       <div key="1" id="add-nin-number">
-    //         <div key="1">{this.props.l10n("nins.help_text")}</div>
-    //         <div key="2" id="nin-form-container">
-    //           <NinForm {...this.props} />
-    //         </div>
-    //       </div>
-    //   );
-    // } else if (ninStatus === "unverified") {
-    //   ninInput = ninUnverified;
-    //   if (this.props.nins.length > 1) {
-    //     ninInput = this.props.l10n("nins.only_one_to_verify");
-    //   }
-    // } else if (ninStatus === "verified") {
-    //   ninInput = ninVerified;
-    // }
-
-    // if (url.includes("settings")) {
-    //   ninHeading = settingsStyle;
-    // } else if (url.includes("step2")) {
-    //   ninButtons = vettingButtons;
-    //   ninHeading = verifyIdentityStyle;
-    // } else {
-    //   ninHeading = verifyIdentityStyle;
-    // }
-
-    // return <div>{ninInput}</div>;
   }
 }
-
-// NinForm = reduxForm({
-//   form: "nins",
-//   destroyOnUnmount: false,
-//   enableReinitialize: true,
-//   keepDirtyOnReinitialize: true,
-//   keepValuesOnReinitialize: true,
-//   updateUnregisteredFields: true,
-//   validate: validate
-// })(NinForm);
-
-// NinForm = connect(state => ({
-//   initialValues: { nin: state.nins.nin }
-// }))(NinForm);
 
 AddNin.propTypes = {
   nin: PropTypes.string,

--- a/src/components/AddNin.js
+++ b/src/components/AddNin.js
@@ -1,42 +1,42 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { connect } from "react-redux";
-import { Field, reduxForm } from "redux-form";
-import { Link } from "react-router-dom";
-import { ButtonGroup, Form } from "reactstrap";
+// import { connect } from "react-redux";
+// import { Field, reduxForm } from "redux-form";
+// import { Link } from "react-router-dom";
+// import { ButtonGroup, Form } from "reactstrap";
 
 import NinForm from "./NinForm";
-import TextInput from "components/EduIDTextInput";
-import EduIDButton from "components/EduIDButton";
+// import TextInput from "components/EduIDTextInput";
+// import EduIDButton from "components/EduIDButton";
 // import vettingRegistry from "vetting-registry";
 
 import "style/Nins.scss";
 
-const validate = values => {
-  let value = values.nin;
-  // accept only digits
-  if (/[^0-9]+/.test(value)) return { nin: "nins.illegal_chars" };
-  if (value.length !== 12) return { nin: "nins.wrong_length" };
+// const validate = values => {
+//   let value = values.nin;
+//   // accept only digits
+//   if (/[^0-9]+/.test(value)) return { nin: "nins.illegal_chars" };
+//   if (value.length !== 12) return { nin: "nins.wrong_length" };
 
-  // The Luhn Algorithm. It's so pretty.
-  // taken from https://gist.github.com/DiegoSalazar/4075533/
-  let nCheck = 0,
-    bEven = false;
-  value = value.slice(2); // To pass the Luhn check only use the 10 last digits
-  for (let n = value.length - 1; n >= 0; n--) {
-    let cDigit = value.charAt(n),
-      nDigit = parseInt(cDigit, 10);
-    if (bEven) {
-      if ((nDigit *= 2) > 9) nDigit -= 9;
-    }
-    nCheck += nDigit;
-    bEven = !bEven;
-  }
-  if (nCheck % 10 !== 0) {
-    return { nin: "nins.invalid_nin" };
-  }
-  return {};
-};
+//   // The Luhn Algorithm. It's so pretty.
+//   // taken from https://gist.github.com/DiegoSalazar/4075533/
+//   let nCheck = 0,
+//     bEven = false;
+//   value = value.slice(2); // To pass the Luhn check only use the 10 last digits
+//   for (let n = value.length - 1; n >= 0; n--) {
+//     let cDigit = value.charAt(n),
+//       nDigit = parseInt(cDigit, 10);
+//     if (bEven) {
+//       if ((nDigit *= 2) > 9) nDigit -= 9;
+//     }
+//     nCheck += nDigit;
+//     bEven = !bEven;
+//   }
+//   if (nCheck % 10 !== 0) {
+//     return { nin: "nins.invalid_nin" };
+//   }
+//   return {};
+// };
 
 // let NinForm = props => {
 //   return (
@@ -62,27 +62,27 @@ const validate = values => {
 //   );
 // };
 
-let NinNumber = props => {
-  // look at a way to see verified status here? <span>{verifiedNin}</span>
-  return (
-    <div data-ninnumber={props.nins[0].number} id="nin-number-container">
-      <p id="nin-number">{props.nins[0].number}</p>
-    </div>
-  );
-};
+// let NinNumber = props => {
+//   // look at a way to see verified status here? <span>{verifiedNin}</span>
+//   return (
+//     <div data-ninnumber={props.nins[0].number} id="nin-number-container">
+//       <p id="nin-number">{props.nins[0].number}</p>
+//     </div>
+//   );
+// };
 
-let RemoveButton = props => {
-  return (
-    <EduIDButton
-      className="btn-danger"
-      className="btn-sm"
-      id={"button-rm-nin-" + props.nins[0].number}
-      onClick={props.handleDelete}
-    >
-      {props.l10n("nins.button_delete")}
-    </EduIDButton>
-  );
-};
+// let RemoveButton = props => {
+//   return (
+//     <EduIDButton
+//       className="btn-danger"
+//       className="btn-sm"
+//       id={"button-rm-nin-" + props.nins[0].number}
+//       onClick={props.handleDelete}
+//     >
+//       {props.l10n("nins.button_delete")}
+//     </EduIDButton>
+//   );
+// };
 
 let VerifyButton = props => {
   return (
@@ -96,14 +96,14 @@ let VerifyButton = props => {
 
 class AddNin extends Component {
   render() {
-    const url = window.location.href;
-    let ninStatus = "nonin",
-      ninHeading = "",
-      vettingButtons = "",
-      ninInput = "",
-      ninButtons = "",
-      verifiedNin = "",
-      validNin = "";
+    // const url = window.location.href;
+    // let ninStatus = "nonin",
+    //   ninHeading = "",
+    //   vettingButtons = "",
+    //   ninInput = "",
+    //   ninButtons = "",
+    //   verifiedNin = "",
+    //   validNin = "";
     // if (this.props.is_configured) {
     //   const vettingBtns = vettingRegistry(!this.props.valid_nin);
     //   const verifyOptions = this.props.proofing_methods.filter(
@@ -118,23 +118,35 @@ class AddNin extends Component {
     //   });
     // }
 
-    console.log("these are props (AddNin.js)", this.props);
-    console.log("this is nins array (AddNin.js)", this.props.nins);
-    console.log("this is nin (AddNin.js)", this.props.nin);
+    console.log("show form! because nin is null!");
+    console.log("these are the props (AddNin):", this.props);
+    return (
+      <div key="1" className="intro">
+        <h3> Step 1. Add your national identity number</h3>
+        <p>Your number can be used to connect eduID to your person.</p>
+        <div key="1" id="add-nin-number">
+          <div key="1">{this.props.l10n("nins.help_text")}</div>
+          <div key="2" id="nin-form-container">
+            <NinForm addNin={this.addNin} {...this.props} />
+          </div>
+        </div>
+      </div>
+    );
+   
 
-    if (this.props.valid_nin) {
-      console.log("is the nin valid? (AddNin.js)", this.props.valid_nin);
-      validNin = this.props.nin;
-    }
+    // if (this.props.valid_nin) {
+    //   console.log("is the nin valid? (AddNin.js)", this.props.valid_nin);
+    //   validNin = this.props.nin;
+    // }
 
-    if (this.props.nins.length) {
-      ninStatus = "unverified";
-      const nins = this.props.nins.filter(nin => nin.verified);
-      if (nins.length === 1) {
-        ninStatus = "verified";
-        verifiedNin = nins[0].number;
-      }
-    }
+    // if (this.props.nins.length) {
+    //   ninStatus = "unverified";
+    //   const nins = this.props.nins.filter(nin => nin.verified);
+    //   if (nins.length === 1) {
+    //     ninStatus = "verified";
+    //     verifiedNin = nins[0].number;
+    //   }
+    // }
 
     // let noNin = [
     //   <div key="1" id="add-nin-number">
@@ -148,31 +160,31 @@ class AddNin extends Component {
     //   </div>
     // ];
 
-    let ninUnverified = [
-      <div key="1" id="add-nin-number">
-        <NinNumber {...this.props} />
-        <div id="nin-buttons">
-          <VerifyButton {...this.props} />
-          <RemoveButton {...this.props} />
-        </div>
-      </div>
-    ];
+    // let ninUnverified = [
+    //   <div key="1" id="add-nin-number">
+    //     <NinNumber {...this.props} />
+    //     <div id="nin-buttons">
+    //       <VerifyButton {...this.props} />
+    //       <RemoveButton {...this.props} />
+    //     </div>
+    //   </div>
+    // ];
 
-    let ninVerified = [
-      <div key="1" id="add-nin-number">
-        <NinNumber {...this.props} />
-        <div id="nin-buttons">
-          <RemoveButton {...this.props} />
-        </div>
-      </div>
-    ];
+    // let ninVerified = [
+    //   <div key="1" id="add-nin-number">
+    //     <NinNumber {...this.props} />
+    //     <div id="nin-buttons">
+    //       <RemoveButton {...this.props} />
+    //     </div>
+    //   </div>
+    // ];
 
-    let verifyIdentityStyle = [
-      <div key="1" className="intro">
-        <h3> Step 1. Add your national identity number</h3>
-        <p>Your number can be used to connect eduID to your person.</p>
-      </div>
-    ];
+    // let verifyIdentityStyle = [
+    //   <div key="1" className="intro">
+    //     <h3> Step 1. Add your national identity number</h3>
+    //     <p>Your number can be used to connect eduID to your person.</p>
+    //   </div>
+    // ];
 
     // let settingsStyle = [
     //   <div className="intro">
@@ -194,34 +206,34 @@ class AddNin extends Component {
     //   </div>
     // ];
 
-    ninStatus === "nonin";
+    // ninStatus === "nonin";
 
-    if (true) {
-      return (
-          <div key="1" id="add-nin-number">
-            <div key="1">{this.props.l10n("nins.help_text")}</div>
-            <div key="2" id="nin-form-container">
-              <NinForm {...this.props} />
-            </div>
-          </div>
-      );
-    } else if (ninStatus === "unverified") {
-      ninInput = ninUnverified;
-      if (this.props.nins.length > 1) {
-        ninInput = this.props.l10n("nins.only_one_to_verify");
-      }
-    } else if (ninStatus === "verified") {
-      ninInput = ninVerified;
-    }
+    // if (true) {
+    //   return (
+    //       <div key="1" id="add-nin-number">
+    //         <div key="1">{this.props.l10n("nins.help_text")}</div>
+    //         <div key="2" id="nin-form-container">
+    //           <NinForm {...this.props} />
+    //         </div>
+    //       </div>
+    //   );
+    // } else if (ninStatus === "unverified") {
+    //   ninInput = ninUnverified;
+    //   if (this.props.nins.length > 1) {
+    //     ninInput = this.props.l10n("nins.only_one_to_verify");
+    //   }
+    // } else if (ninStatus === "verified") {
+    //   ninInput = ninVerified;
+    // }
 
-    if (url.includes("settings")) {
-      ninHeading = settingsStyle;
-    } else if (url.includes("step2")) {
-      ninButtons = vettingButtons;
-      ninHeading = verifyIdentityStyle;
-    } else {
-      ninHeading = verifyIdentityStyle;
-    }
+    // if (url.includes("settings")) {
+    //   ninHeading = settingsStyle;
+    // } else if (url.includes("step2")) {
+    //   ninButtons = vettingButtons;
+    //   ninHeading = verifyIdentityStyle;
+    // } else {
+    //   ninHeading = verifyIdentityStyle;
+    // }
 
     // return <div>{ninInput}</div>;
   }

--- a/src/components/AddNin.js
+++ b/src/components/AddNin.js
@@ -120,19 +120,27 @@ class AddNin extends Component {
 
     console.log("show form! because nin is null!");
     console.log("these are the props (AddNin):", this.props);
-    return (
-      <div key="1" className="intro">
-        <h3> Step 1. Add your national identity number</h3>
-        <p>Your number can be used to connect eduID to your person.</p>
-        <div key="1" id="add-nin-number">
-          <div key="1">{this.props.l10n("nins.help_text")}</div>
-          <div key="2" id="nin-form-container">
-            <NinForm addNin={this.addNin} {...this.props} />
+    if (this.props.nins.length) {
+      return (
+        <div key="1" className="intro">
+          <h3> Step 1. Add your national identity number</h3>
+          <p>nin array has a number!</p>
+        </div>
+      );
+    } else {
+      return (
+        <div key="1" className="intro">
+          <h3> Step 1. Add your national identity number</h3>
+          <p>Your number can be used to connect eduID to your person.</p>
+          <div key="1" id="add-nin-number">
+            <div key="1">{this.props.l10n("nins.help_text")}</div>
+            <div key="2" id="nin-form-container">
+              <NinForm addNin={this.addNin} {...this.props} />
+            </div>
           </div>
         </div>
-      </div>
-    );
-   
+      );
+    }
 
     // if (this.props.valid_nin) {
     //   console.log("is the nin valid? (AddNin.js)", this.props.valid_nin);

--- a/src/components/NinDisplay.js
+++ b/src/components/NinDisplay.js
@@ -9,62 +9,49 @@ import EduIDButton from "components/EduIDButton";
 
 import "style/Nins.scss";
 
-let NinNumber = props => {
-  return (
-    <div data-ninnumber={props.nin} id="nin-number-container">
-      <p id="nin-number">{props.nin}</p>
-    </div>
-  );
-};
-
 let RemoveButton = props => {
   console.log("these are the props in remove button:", props);
   return (
-    <EduIDButton
-      className="btn-danger btn-sm"
-      onClick={e => {
-        props.removeNin();
-        props.handleDelete(e);
-      }}
-    >
+    <EduIDButton className="btn-danger btn-sm" onClick={props.handleDelete}>
       X
-</EduIDButton>
+    </EduIDButton>
   );
 };
 
 class NinDisplay extends Component {
   render() {
-    if (this.props.nins) {
-      // if (this.props.nins[0].verified) {
-      // console.log(this.props.nins.verified);
-      // return (
-      // <div key="1" className="intro">
-      // <h3> Step 1. Add your national identity number</h3>
-      // <p>Your id number has been added and connected to your person.</p>
-      // <div key="1" id="add-nin-number">
-      // <div key="1" id="nin-form-container">
-      // <div key="1" id="add-nin-number" className="verified">
-      // <NinNumber {...this.props} />
-      // <RemoveButton {...this.props} />
-      // </div>
-      // </div>
-      // </div>
-      // </div>
-      // );
-      // }
+    if (this.props.nins[0].verified) {
+      console.log(this.props.nins[0].verified);
+      return (
+        <div key="1" className="intro">
+          <h3> Step 1. Add your national identity number</h3>
+          <p>Your id number has been added and connected to your person.</p>
+          <div key="1" id="add-nin-number">
+            <div key="1" id="nin-form-container">
+              <div key="1" id="add-nin-number" className="verified">
+                <div data-ninnumber={this.props.nin} id="nin-number-container">
+                  <p id="nin-number">{this.props.nin}</p>
+                </div>
+                <RemoveButton {...this.props} />
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    } else {
       return (
         <div key="1" className="intro">
           <h3> Step 1. Add your national id number</h3>
           <p>
-            Your id number has been added,
-<Link id="verify-id-link" to="/profile/verify-identity/step2">
-              but you still need to connect it to your person
-</Link>
+            Your id number has been added, but you still need to connect it to
+            your person
           </p>
           <div key="1" id="add-nin-number">
             <div key="1" id="nin-form-container">
               <div key="1" id="add-nin-number" className="unverified">
-                <NinNumber {...this.props} />
+                <div data-ninnumber={this.props.nin} id="nin-number-container">
+                  <p id="nin-number">{this.props.nin}</p>
+                </div>
                 <RemoveButton {...this.props} />
               </div>
             </div>
@@ -89,7 +76,7 @@ const mapStateToProps = (state, props) => {
 
 const mapDispatchToProps = (dispatch, props) => {
   return {
-    handleDelete: function (e) {
+    handleDelete: function(e) {
       console.log("you're in handleDelete through ninDisplay!");
       const ninNumber = e.target.previousSibling.dataset.ninnumber;
       dispatch(actions.startRemove(ninNumber));

--- a/src/components/NinDisplay.js
+++ b/src/components/NinDisplay.js
@@ -1,0 +1,103 @@
+import React, { Component } from "react";
+import PropTypes from "prop-types";
+import { connect } from "react-redux";
+import { Link } from "react-router-dom";
+import * as actions from "actions/Nins";
+import i18n from "i18n-messages";
+
+import EduIDButton from "components/EduIDButton";
+
+import "style/Nins.scss";
+
+let NinNumber = props => {
+  return (
+    <div data-ninnumber={props.nin} id="nin-number-container">
+      <p id="nin-number">{props.nin}</p>
+    </div>
+  );
+};
+
+let RemoveButton = props => {
+  console.log("these are the props in remove button:", props);
+  return (
+    <EduIDButton
+      className="btn-danger btn-sm"
+      onClick={e => {
+        props.removeNin();
+        props.handleDelete(e);
+      }}
+    >
+      X
+</EduIDButton>
+  );
+};
+
+class NinDisplay extends Component {
+  render() {
+    if (this.props.nins) {
+      // if (this.props.nins[0].verified) {
+      // console.log(this.props.nins.verified);
+      // return (
+      // <div key="1" className="intro">
+      // <h3> Step 1. Add your national identity number</h3>
+      // <p>Your id number has been added and connected to your person.</p>
+      // <div key="1" id="add-nin-number">
+      // <div key="1" id="nin-form-container">
+      // <div key="1" id="add-nin-number" className="verified">
+      // <NinNumber {...this.props} />
+      // <RemoveButton {...this.props} />
+      // </div>
+      // </div>
+      // </div>
+      // </div>
+      // );
+      // }
+      return (
+        <div key="1" className="intro">
+          <h3> Step 1. Add your national id number</h3>
+          <p>
+            Your id number has been added,
+<Link id="verify-id-link" to="/profile/verify-identity/step2">
+              but you still need to connect it to your person
+</Link>
+          </p>
+          <div key="1" id="add-nin-number">
+            <div key="1" id="nin-form-container">
+              <div key="1" id="add-nin-number" className="unverified">
+                <NinNumber {...this.props} />
+                <RemoveButton {...this.props} />
+              </div>
+            </div>
+          </div>
+        </div>
+      );
+    }
+  }
+}
+
+// NinDisplay.propTypes = {
+// nin: PropTypes.string,
+// nins: PropTypes.array,
+// validateNin: PropTypes.func,
+// handleDelete: PropTypes.func,
+// proofing_methods: PropTypes.array
+// };
+
+const mapStateToProps = (state, props) => {
+  return {};
+};
+
+const mapDispatchToProps = (dispatch, props) => {
+  return {
+    handleDelete: function (e) {
+      console.log("you're in handleDelete through ninDisplay!");
+      const ninNumber = e.target.previousSibling.dataset.ninnumber;
+      dispatch(actions.startRemove(ninNumber));
+    }
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(NinDisplay);

--- a/src/components/NinForm.js
+++ b/src/components/NinForm.js
@@ -112,4 +112,23 @@ NinForm.propTypes = {
   proofing_methods: PropTypes.array
 };
 
-export default NinForm;
+// export default NinForm;
+
+const mapStateToProps = (state, props) => {
+  return {
+    initialValues: { nin: state.nins.nin }
+  };
+};
+
+const mapDispatchToProps = (dispatch, props) => {
+  return {
+    addNin: function (e) {
+      console.log("you're in addNin!");
+    }
+  };
+};
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(NinForm);

--- a/src/components/NinForm.js
+++ b/src/components/NinForm.js
@@ -100,9 +100,9 @@ NinForm = reduxForm({
   validate: validate
 })(NinForm);
 
-// NinForm = connect(state => ({
-//   initialValues: { nin: state.nins.nin }
-// }))(NinForm);
+NinForm = connect(state => ({
+  initialValues: { nin: state.nins.nin }
+}))(NinForm);
 
 NinForm.propTypes = {
   nin: PropTypes.string,

--- a/src/components/NinForm.js
+++ b/src/components/NinForm.js
@@ -124,6 +124,14 @@ const mapDispatchToProps = (dispatch, props) => {
   return {
     addNin: function (e) {
       console.log("you're in addNin!");
+      console.log(
+        "this is the nin from component",
+        e.target.previousElementSibling.firstElementChild.children[0].value
+      );
+      const nin = e.target.previousElementSibling.firstElementChild.children[0].value
+      // console.log("this is valid nin:", validNin);
+      dispatch(actions.postNin(nin));
+      // dispatch(letterActions.stopLetterConfirmation());
     }
   };
 };

--- a/src/components/NinForm.js
+++ b/src/components/NinForm.js
@@ -38,8 +38,8 @@ const validate = values => {
 };
 
 class NinForm extends Component {
-  addNin(e) {
-    console.log("you've clicked the button");
+  // addNin(e) {
+  //   console.log("you've clicked the button");
   //   console.log("this is ninInput", e.target);
   //   const ninInput = e.target.previousSibling.firstChild.children[0];
   //   // console.log("this is ninInput", ninInput)
@@ -65,7 +65,7 @@ class NinForm extends Component {
       console.log("is the nin valid? (AddNin.js)", this.props.valid_nin);
       // validNin = this.props.nin;
       formButton = [
-        <button onClick={this.addNin} key="1">
+        <button onClick={this.props.addNin} key="1">
           ADD
         </button>
       ];

--- a/src/components/NinForm.js
+++ b/src/components/NinForm.js
@@ -4,6 +4,7 @@ import { connect } from "react-redux";
 import { Field, reduxForm } from "redux-form";
 // import { Link } from "react-router-dom";
 import { ButtonGroup, Form } from "reactstrap";
+import * as actions from "actions/Nins";
 
 import TextInput from "components/EduIDTextInput";
 // import EduIDButton from "components/EduIDButton";
@@ -122,13 +123,14 @@ const mapStateToProps = (state, props) => {
 
 const mapDispatchToProps = (dispatch, props) => {
   return {
-    addNin: function (e) {
+    addNin: function(e) {
       console.log("you're in addNin!");
       console.log(
         "this is the nin from component",
         e.target.previousElementSibling.firstElementChild.children[0].value
       );
-      const nin = e.target.previousElementSibling.firstElementChild.children[0].value
+      const nin =
+        e.target.previousElementSibling.firstElementChild.children[0].value;
       // console.log("this is valid nin:", validNin);
       dispatch(actions.postNin(nin));
       // dispatch(letterActions.stopLetterConfirmation());

--- a/src/components/NinForm.js
+++ b/src/components/NinForm.js
@@ -2,11 +2,11 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { Field, reduxForm } from "redux-form";
-import { Link } from "react-router-dom";
+// import { Link } from "react-router-dom";
 import { ButtonGroup, Form } from "reactstrap";
 
 import TextInput from "components/EduIDTextInput";
-import EduIDButton from "components/EduIDButton";
+// import EduIDButton from "components/EduIDButton";
 // import vettingRegistry from "vetting-registry";
 
 import "style/Nins.scss";

--- a/src/components/Nins.js
+++ b/src/components/Nins.js
@@ -1,13 +1,8 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-// import { connect } from "react-redux";
-// import { Field, reduxForm } from "redux-form";
-// import { Link } from "react-router-dom";
-import { ButtonGroup, Form } from "reactstrap";
+import { ButtonGroup } from "reactstrap";
 
 import AddNin from "./AddNin";
-// import TextInput from "components/EduIDTextInput";
-// import EduIDButton from "components/EduIDButton";
 import vettingRegistry from "vetting-registry";
 
 import "style/Nins.scss";
@@ -38,7 +33,7 @@ class Nins extends Component {
           <p>
             Choose a way below to verify that the given identity number belongs
             to you.
-</p>
+          </p>
           <div>
             <ButtonGroup vertical={true} id="nins-btn-group">
               {vettingButtons}
@@ -61,26 +56,12 @@ class Nins extends Component {
   }
 }
 
-// NinForm = reduxForm({
-//   form: "nins",
-//   destroyOnUnmount: false,
-//   enableReinitialize: true,
-//   keepDirtyOnReinitialize: true,
-//   keepValuesOnReinitialize: true,
-//   updateUnregisteredFields: true,
-//   validate: validate
-// })(NinForm);
-
-// NinForm = connect(state => ({
-//   initialValues: { nin: state.nins.nin }
-// }))(NinForm);
-
-Nins.propTypes = {
-  nin: PropTypes.string,
-  nins: PropTypes.array,
-  validateNin: PropTypes.func,
-  handleDelete: PropTypes.func,
-  proofing_methods: PropTypes.array
-};
+// Nins.propTypes = {
+//   nin: PropTypes.string,
+//   nins: PropTypes.array,
+//   validateNin: PropTypes.func,
+//   handleDelete: PropTypes.func,
+//   proofing_methods: PropTypes.array
+// };
 
 export default Nins;

--- a/src/components/Nins.js
+++ b/src/components/Nins.js
@@ -3,6 +3,7 @@ import PropTypes from "prop-types";
 import { ButtonGroup } from "reactstrap";
 
 import AddNin from "./AddNin";
+import NotificationsContainer from "containers/Notifications";
 import vettingRegistry from "vetting-registry";
 
 import "style/Nins.scss";
@@ -45,6 +46,7 @@ class Nins extends Component {
 
     return (
       <div>
+        <NotificationsContainer />
         <div id="nin-process">
           <div id="add-nin-number-container">
             <AddNin {...this.props} />

--- a/src/components/Nins.js
+++ b/src/components/Nins.js
@@ -206,14 +206,14 @@ class Nins extends Component {
     //   ninInput = ninVerified;
     // }
 
-    if (url.includes("settings")) {
-      ninHeading = settingsStyle;
-    } else if (url.includes("step2")) {
-      ninButtons = vettingButtons;
-      ninHeading = verifyIdentityStyle;
-    } else {
-      ninHeading = verifyIdentityStyle;
-    }
+    // if (url.includes("settings")) {
+    //   ninHeading = settingsStyle;
+    // } else if (url.includes("step2")) {
+    //   ninButtons = vettingButtons;
+    //   ninHeading = verifyIdentityStyle;
+    // } else {
+    //   ninHeading = verifyIdentityStyle;
+    // }
 
     return (
       <div>

--- a/src/components/Nins.js
+++ b/src/components/Nins.js
@@ -1,108 +1,21 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { connect } from "react-redux";
-import { Field, reduxForm } from "redux-form";
-import { Link } from "react-router-dom";
+// import { connect } from "react-redux";
+// import { Field, reduxForm } from "redux-form";
+// import { Link } from "react-router-dom";
 import { ButtonGroup, Form } from "reactstrap";
 
 import AddNin from "./AddNin";
-import TextInput from "components/EduIDTextInput";
-import EduIDButton from "components/EduIDButton";
+// import TextInput from "components/EduIDTextInput";
+// import EduIDButton from "components/EduIDButton";
 import vettingRegistry from "vetting-registry";
 
 import "style/Nins.scss";
 
-// const validate = values => {
-//   let value = values.nin;
-//   // accept only digits
-//   if (/[^0-9]+/.test(value)) return { nin: "nins.illegal_chars" };
-//   if (value.length !== 12) return { nin: "nins.wrong_length" };
-
-  // The Luhn Algorithm. It's so pretty.
-  // taken from https://gist.github.com/DiegoSalazar/4075533/
-//   let nCheck = 0,
-//     bEven = false;
-//   value = value.slice(2); // To pass the Luhn check only use the 10 last digits
-//   for (let n = value.length - 1; n >= 0; n--) {
-//     let cDigit = value.charAt(n),
-//       nDigit = parseInt(cDigit, 10);
-//     if (bEven) {
-//       if ((nDigit *= 2) > 9) nDigit -= 9;
-//     }
-//     nCheck += nDigit;
-//     bEven = !bEven;
-//   }
-//   if (nCheck % 10 !== 0) {
-//     return { nin: "nins.invalid_nin" };
-//   }
-//   return {};
-// };
-
-// let NinForm = props => {
-//   return (
-//     <Form id="nin-form" role="form">
-//       <Field
-//         component={TextInput}
-//         componentClass="input"
-//         type="text"
-//         name="nin"
-//         className="nin-input"
-//         placeholder={props.l10n("nins.input_placeholder")}
-//         helpBlock={props.l10n("nins.input_help_text")}
-//       />
-//     </Form>
-//   );
-// };
-
-let NinButtons = props => {
-  return (
-    <ButtonGroup vertical={true} id="nins-btn-group">
-      {props.buttons}
-    </ButtonGroup>
-  );
-};
-
-// let NinNumber = props => {
-//   // look at a way to see verified status here? <span>{verifiedNin}</span>
-//   return (
-//     <div data-ninnumber={props.nins[0].number} id="nin-number-container">
-//       <p id="nin-number">{props.nins[0].number}</p>
-//     </div>
-//   );
-// };
-
-// let RemoveButton = props => {
-//   return (
-//     <EduIDButton
-//       className="btn-danger"
-//       className="btn-sm"
-//       id={"button-rm-nin-" + props.nins[0].number}
-//       onClick={props.handleDelete}
-//     >
-//       {props.l10n("nins.button_delete")}
-//     </EduIDButton>
-//   );
-// };
-
-// let VerifyButton = props => {
-//   return (
-//     <Link id="verify-button" to="/profile/verify-identity/step2">
-//       <button>
-//         <p>connect eduid to my person</p>
-//       </button>
-//     </Link>
-//   );
-// };
-
 class Nins extends Component {
   render() {
-    const url = window.location.href;
-    let ninStatus = "nonin",
-      ninHeading = "",
-      vettingButtons = "",
-      ninInput = "",
-      ninButtons = "",
-      verifiedNin = "";
+    let vettingButtons = "",
+      connectNin = "";
 
     if (this.props.is_configured) {
       const vettingBtns = vettingRegistry(!this.props.valid_nin);
@@ -118,112 +31,30 @@ class Nins extends Component {
       });
     }
 
-    // if (this.props.nins.length) {
-    //   ninStatus = "unverified";
-    //   const nins = this.props.nins.filter(nin => nin.verified);
-    //   if (nins.length === 1) {
-    //     ninStatus = "verified";
-    //     verifiedNin = nins[0].number;
-    //   }
-    // }
-
-    // let noNin = [
-    //   <div key="1" id="add-nin-number">
-    //     <div key="1">{this.props.l10n("nins.help_text")}</div>
-    //     <div key="2" id="nin-form-container">
-    //       <NinForm {...this.props} />
-    //     </div>
-    //     <div key="3">
-    //       <button key="1">ADD FUNCTIONALITY HERE</button>
-    //     </div>
-    //   </div>
-    // ];
-
-    // let ninUnverified = [
-    //   <div key="1" id="add-nin-number">
-    //     <div>
-    //       <NinNumber {...this.props} />
-    //     </div>
-    //     <div id="nin-buttons">
-    //       <div>
-    //         <VerifyButton {...this.props} />
-    //       </div>
-    //       <div>
-    //         <RemoveButton {...this.props} />
-    //       </div>
-    //     </div>
-    //   </div>
-    // ];
-
-    // let ninVerified = [
-    //   <div key="1" id="add-nin-number">
-    //     <div>
-    //       <NinNumber {...this.props} />
-    //     </div>
-    //     <div id="nin-buttons">
-    //       <div>
-    //         <RemoveButton {...this.props} />
-    //       </div>
-    //     </div>
-    //   </div>
-    // ];
-
-    let verifyIdentityStyle = [
-      <div key="1" className="intro">
-        <h3> Step 1. Add your national identity number</h3>
-        <p>Your number can be used to connect eduID to your person.</p>
-      </div>
-    ];
-
-    let settingsStyle = [
-      <div className="intro">
-        <h4>{this.props.l10n("nins.main_title")}</h4>
-        <p>{this.props.l10n("nins.justification")}</p>
-      </div>
-    ];
-
-    vettingButtons = [
-      <div key="1" id="connect-nin-number">
-        <h3> Step 2. Connect your national identity number to eduID</h3>
-        <p>
-          Choose a way below to verify that the given identity number belongs to
-          you.
-        </p>
-        <div>
-          <NinButtons buttons={vettingButtons} {...this.props} />
+    if (this.props.nins.length) {
+      connectNin = [
+        <div key="1" id="connect-nin-number">
+          <h3> Step 2. Connect your national identity number to eduID</h3>
+          <p>
+            Choose a way below to verify that the given identity number belongs
+            to you.
+</p>
+          <div>
+            <ButtonGroup vertical={true} id="nins-btn-group">
+              {vettingButtons}
+            </ButtonGroup>
+          </div>
         </div>
-      </div>
-    ];
-
-    // if (ninStatus === "nonin") {
-    //   ninInput = noNin;
-    // } else if (ninStatus === "unverified") {
-    //   ninInput = ninUnverified;
-    //   if (this.props.nins.length > 1) {
-    //     ninInput = this.props.l10n("nins.only_one_to_verify");
-    //   }
-    // } else if (ninStatus === "verified") {
-    //   ninInput = ninVerified;
-    // }
-
-    // if (url.includes("settings")) {
-    //   ninHeading = settingsStyle;
-    // } else if (url.includes("step2")) {
-    //   ninButtons = vettingButtons;
-    //   ninHeading = verifyIdentityStyle;
-    // } else {
-    //   ninHeading = verifyIdentityStyle;
-    // }
+      ];
+    }
 
     return (
       <div>
         <div id="nin-process">
           <div id="add-nin-number-container">
-            {ninHeading}
             <AddNin {...this.props} />
-            {/* {ninInput} */}
           </div>
-          <div id="connect-nin-number-container">{ninButtons}</div>
+          <div id="connect-nin-number-container">{connectNin}</div>
         </div>
       </div>
     );

--- a/src/dashboard-root-saga.js
+++ b/src/dashboard-root-saga.js
@@ -44,7 +44,7 @@ import {
   requestSuggestedPassword,
   postPasswordChange
 } from "sagas/ChangePassword";
-import { requestNins, requestRemoveNin } from "sagas/Nins";
+import { requestNins, requestRemoveNin, postNin } from "sagas/Nins”;
 import {
   sendLetterProofing,
   sendGetLetterProofing,
@@ -124,6 +124,8 @@ function* rootSaga() {
       sendGetLetterProofing
     ),
     takeLatest(letterActions.POST_LETTER_PROOFING_CODE, sendLetterCode),
+    takeLatest(ninActions.POST_NIN, postNin),
+    takeEvery(ninActions.POST_NIN_SUCCESS, requestNins),
     takeLatest(ninActions.POST_NIN_REMOVE, requestRemoveNin),
     takeEvery(ninActions.POST_NIN_REMOVE_SUCCESS, requestNins),
     takeEvery(letterActions.STOP_LETTER_VERIFICATION, requestNins),

--- a/src/dashboard-root-saga.js
+++ b/src/dashboard-root-saga.js
@@ -44,7 +44,7 @@ import {
   requestSuggestedPassword,
   postPasswordChange
 } from "sagas/ChangePassword";
-import { requestNins, requestRemoveNin, postNin } from "sagas/Nins”;
+import { requestNins, requestRemoveNin, postNin } from "sagas/Nins";
 import {
   sendLetterProofing,
   sendGetLetterProofing,
@@ -76,10 +76,7 @@ function* rootSaga() {
       openidActions.POST_OIDC_PROOFING_PROOFING,
       sagasOpenid.requestOpenidQRcode
     ),
-    takeLatest(
-      lmpActions.POST_LOOKUP_MOBILE_PROOFING_PROOFING,
-      saveLMPNinData
-    ),
+    takeLatest(lmpActions.POST_LOOKUP_MOBILE_PROOFING_PROOFING, saveLMPNinData),
     takeLatest(
       openidFrejaActions.POST_OIDC_PROOFING_FREJA_PROOFING,
       sagasOpenidFreja.initializeOpenidFrejaData

--- a/src/sagas/Nins.js
+++ b/src/sagas/Nins.js
@@ -30,6 +30,38 @@ export function fetchNins(config) {
     .then(response => response.json());
 }
 
+// function to post nins
+export function* postNin() {
+  console.log("you're in postNin");
+  try {
+    const state = yield select(state => state),
+      data = {
+        nin: state.nins.nin,
+        csrf_token: state.config.csrf_token
+      };
+    console.log("this is data in postNin:", data);
+    const resp = yield call(postNinFetch, state.config, data);
+    console.log("this is resp in postNin:", resp);
+    console.log("this is token in resp postNin:", resp.payload.csrf_token);
+    yield put(putCsrfToken(resp));
+    yield put(resp);
+  } catch (error) {
+    yield* failRequest(error, actions.postNinFail);
+  }
+}
+
+// function to reach endpoint to post nin
+export function postNinFetch(config, data) {
+  console.log("this is data in postNinFetch:", data);
+  return window
+    .fetch("/services/security/" + "add-nin", {
+      ...postRequest,
+      body: JSON.stringify(data)
+    })
+    .then(checkStatus)
+    .then(response => response.json());
+}
+
 export function* requestRemoveNin() {
   try {
     const state = yield select(state => state),

--- a/src/style/Nins.scss
+++ b/src/style/Nins.scss
@@ -1,3 +1,5 @@
+@import "../variables.scss";
+
 //--- STEP 1. ADD NIN STYLES ---//
 
 #add-nin-number {
@@ -12,8 +14,8 @@
   align-items: flex-end;
 }
 /*--- styles for form ---*/
-#nin-form-container {
-}
+// #nin-form-container {
+// }
 
 .nin-input {
   border: solid 30px green;
@@ -22,6 +24,14 @@
 /*--- styles for nin digits ---*/
 #nin-number {
   font-size: 24px;
+}
+
+.unverified {
+  color: $error-red;
+}
+
+.verified {
+  color: #3f5c57;
 }
 
 /*--- styles for nin buttons ---*/
@@ -75,30 +85,3 @@
 div.proofing-buttons {
   margin-top: 30px;
 }
-
-// @media only screen and (max-width: 991px) {
-//   div.btn-group-vertical#nins-btn-group div {
-//     width: 100%;
-//   }
-//   div.proofing-buttons {
-//     text-align: center;
-//   }
-//   div#nin,
-//   div#nin input {
-//     display: inline-block;
-//   }
-// }
-
-// @media only screen and (max-width: 767px) {
-//   fieldset#nins-form div#nin input,
-//   div.proofing-buttons button.eduid-button.proofing-button {
-//     max-width: 500px;
-//   }
-// }
-
-// @media only screen and (min-width: 768px) {
-//   fieldset#nins-form div#nin input,
-//   div.proofing-buttons button.eduid-button.proofing-button {
-//     width: 500px;
-//   }
-// }


### PR DESCRIPTION
**Background**:  The dashboard is being reengineered to make users aware that adding their nin is the first step in a 2-step process to complete their eduid.

What it should do: 
- ADD button under the input should only render when a user types a valid nin (otherwise should trigger the existing error messages about invalid input)
- ADD button onClick  > dispatch postNin() > POST_NIN action > postNin() saga (nin to backend and populated nin array returned) > both FAIL and SUCCESS responses should be handled 
- The render logic is dependent on the nin array being populated and its verification status
- Notifications have also been added to the dashboard to show feedback
- All changes to local state should have been removed

> Please let me know if you spot any bugs 🔍

What it does not do: 
- NOT final styling or arrangement of components, console logs still in code
- NOT yet fully investigated how this solution impacts the vetting process 
- NOT cleaned up the settings section 
- NOT refactored and I would like to look at doing so