### PR TITLE
Rendering tests for components with forms

### DIFF
--- a/src/tests/ChangePasswordForm-test.js
+++ b/src/tests/ChangePasswordForm-test.js
@@ -1,0 +1,77 @@
+
+import React from "react";
+import expect from "expect";
+import { shallow, mount } from "enzyme/build";
+import { IntlProvider } from "react-intl";
+import { Provider } from "react-intl-redux";
+import { setupComponent, fakeStore, getState } from "tests/SignupMain-test";
+import ChangePasswordForm from "components/ChangePasswordForm";
+
+const mock = require("jest-mock");
+const messages = require("../../i18n/l10n/en");
+
+describe("ChangePasswordForm Component", () => {
+  it("The component does not render 'false' or 'null'", () => {
+    const wrapper = shallow(
+      <IntlProvider locale="en">
+        <ChangePasswordForm />
+      </IntlProvider>
+    );
+    expect(wrapper.isEmptyRender()).toEqual(false);
+  });
+});
+
+describe("ChangePasswordForm renders", () => {
+  const fakeStore = state => ({
+    default: () => { },
+    dispatch: mock.fn(),
+    subscribe: mock.fn(),
+    getState: () => ({ ...state })
+  });
+
+  const fakeState = {
+    security: {
+      confirming_change: false
+    },
+    chpass: {
+      suggested_password: true
+    },
+    intl: {
+      locale: "en",
+      messages: messages
+    },
+  };
+
+  const props = {
+    handleStartPasswordChange: mock.fn(),
+    handleStopPasswordChange: mock.fn()
+  }
+
+  function setupComponent() {
+    const wrapper = mount(
+      <Provider store={fakeStore(fakeState)}>
+        <ChangePasswordForm {...props} />
+      </Provider>
+    );
+    return {
+      wrapper
+    };
+  }
+
+  it("old and new password inputs render", () => {
+    const { wrapper } = setupComponent();
+    const oldPwInput = wrapper.find("input[name='old-password-field']");
+    const suggestedPwInput = wrapper.find(
+      "input[name='suggested-password-field']"
+    );
+    expect(oldPwInput.exists()).toEqual(true);
+    expect(suggestedPwInput.exists()).toEqual(true);
+  });
+
+  it("save password button renders", () => {
+    const { wrapper } = setupComponent();
+    const savePwButton = wrapper.find("EduIDButton#chpass-button");
+    expect(savePwButton.exists()).toEqual(true);
+    expect(savePwButton.text().includes("password")).toEqual(true);
+  });
+});

--- a/src/tests/ChangePasswordForm-test.js
+++ b/src/tests/ChangePasswordForm-test.js
@@ -1,4 +1,3 @@
-
 import React from "react";
 import expect from "expect";
 import { shallow, mount } from "enzyme/build";
@@ -23,7 +22,7 @@ describe("ChangePasswordForm Component", () => {
 
 describe("ChangePasswordForm renders", () => {
   const fakeStore = state => ({
-    default: () => { },
+    default: () => {},
     dispatch: mock.fn(),
     subscribe: mock.fn(),
     getState: () => ({ ...state })
@@ -39,13 +38,13 @@ describe("ChangePasswordForm renders", () => {
     intl: {
       locale: "en",
       messages: messages
-    },
+    }
   };
 
   const props = {
     handleStartPasswordChange: mock.fn(),
     handleStopPasswordChange: mock.fn()
-  }
+  };
 
   function setupComponent() {
     const wrapper = mount(

--- a/src/tests/ChangePasswordForm-test.js
+++ b/src/tests/ChangePasswordForm-test.js
@@ -33,7 +33,7 @@ describe("ChangePasswordForm renders", () => {
       confirming_change: false
     },
     chpass: {
-      suggested_password: true
+      suggested_password: "h3u r6 lo9"
     },
     intl: {
       locale: "en",

--- a/src/tests/NinForm-test.js
+++ b/src/tests/NinForm-test.js
@@ -1,0 +1,62 @@
+import React from "react";
+import expect from "expect";
+import { shallow, mount } from "enzyme/build";
+import { IntlProvider } from "react-intl";
+import { Provider } from "react-intl-redux";
+import NinForm from "components/NinForm";
+
+const mock = require("jest-mock");
+const messages = require("../../i18n/l10n/en");
+
+describe("NinForm Component", () => {
+  it("The component does not render 'false' or 'null'", () => {
+    const wrapper = shallow(
+      <IntlProvider locale="en">
+        <NinForm />
+      </IntlProvider>
+    );
+    expect(wrapper.isEmptyRender()).toEqual(false);
+  });
+});
+
+describe("Nin Form renders important elements", () => {
+  const fakeStore = state => ({
+    default: () => {},
+    dispatch: mock.fn(),
+    subscribe: mock.fn(),
+    getState: () => ({ ...state })
+  });
+
+  const fakeState = {
+    nins: {
+      nins: []
+    },
+    intl: {
+      locale: "en",
+      messages: messages
+    }
+  };
+
+  function setupComponent() {
+    const wrapper = mount(
+      <Provider store={fakeStore(fakeState)}>
+        <NinForm />
+      </Provider>
+    );
+    return {
+      wrapper
+    };
+  }
+
+  it("nin input renders", () => {
+    const { wrapper } = setupComponent();
+    const ninInput = wrapper.find("input");
+    expect(ninInput.exists()).toEqual(true);
+  });
+
+  it("add nin button renders", () => {
+    const { wrapper } = setupComponent();
+    const ninButton = wrapper.find("button");
+    expect(ninButton.exists()).toEqual(true);
+  });
+});


### PR DESCRIPTION
*Background:* Although testing of form input will be done manually, these tests ensure expected render of the most crucial elements of the components with a form 

*Summary:*
- NinForm: renders input (for nin) and button (to add nin to user)
- ChangePasswordForm: renders inputs (for old/new passwords) and button (for saving new password)