### PR TITLE
Fix remove button for ORCID account

### DIFF
--- a/src/components/Orcid.js
+++ b/src/components/Orcid.js
@@ -45,7 +45,17 @@ class Orcid extends Component {
                     id="remove-orcid-button"
                     onClick={this.props.handleOrcidDelete}
                   >
-                    {this.props.l10n("tl.remove")}
+                    <svg
+                      className="remove"
+                      width="16"
+                      height="16"
+                      viewBox="0 0 16 16"
+                      fill="none"
+                      xmlns="http://www.w3.org/2000/svg"
+                    >
+                      <path d="M7 0h2v16H7z" />
+                      <path d="M0 9V7h16v2z" />
+                    </svg>
                   </EduIDButton>
                 </td>
               </tr>


### PR DESCRIPTION
Background: For added ORCID accounts the remove button renders a string with an unknown id (tl.remove) instead of the intended text.

Summary: 
-  I have replaced the text with the svg symbol used elsewhere in the app for removing data

