### PR TITLE
Updates sign in footer in line with homepage and login 

### DIFF
--- a/i18n/src/i18n-messages.json
+++ b/i18n/src/i18n-messages.json
@@ -265,7 +265,7 @@
   },
   {
     "id": "mfa.login-tapit",
-    "defaultMessage": "Use your Security Key to log in. If it has a button, tap it."
+    "defaultMessage": "Use your security key to log in. If it has a button, tap it."
   },
   {
     "id": "mfa.fake-authn",
@@ -273,11 +273,11 @@
   },
   {
     "id": "mfa.no-webauthn-support",
-    "defaultMessage": "No support for Security Keys"
+    "defaultMessage": "No support for security keys"
   },
   {
     "id": "mfa.no-webauthn-support-text",
-    "defaultMessage": "You have registered a Security Key for authentication, but this browser does not support them. Please use another browser to use your Security Keys."
+    "defaultMessage": "You have registered a security key for authentication, but this browser does not support them. Please use another browser to use your security keys."
   },
   {
     "id": "mfa.problems-heading",
@@ -293,11 +293,11 @@
   },
   {
     "id": "mfa.error-getting-token",
-    "defaultMessage": "There was a problem using your Security Key"
+    "defaultMessage": "There was a problem using your security key"
   },
   {
     "id": "mfa.edge-no-u2f",
-    "defaultMessage": "There is a problem with the Edge browser and U2F Security Keys. Please try with Firefox or Chrome."
+    "defaultMessage": "There is a problem with the Edge browser and U2F security keys. Please try with Firefox or Chrome."
   },
   {
     "id": "actions.action-completed",
@@ -445,11 +445,11 @@
   },
   {
     "id": "verify-identity.vetting_freja_tagline",
-    "defaultMessage": "For those able to create a Freja eID by passing by one of the authorised agents"
+    "defaultMessage": "For those able to create a Freja eID by passing one of the authorised agents"
   },
   {
     "id": "verify-identity.connect_nin_title",
-    "defaultMessage": "Choose a way to verify that the id number\n            belongs to you"
+    "defaultMessage": "Choose a way to verify that the id number belongs to you"
   },
   {
     "id": "add_nin.main_title",
@@ -492,6 +492,10 @@
     "defaultMessage": "Valid national id number"
   },
   {
+    "id": "nins.successfully_added",
+    "defaultMessage": "Your id number was added."
+  },
+  {
     "id": "nins.only_one_to_verify",
     "defaultMessage": "You can only have one unverified national id number to verify it. Please remove the unwanted ones."
   },
@@ -517,7 +521,7 @@
   },
   {
     "id": "letter.initialize_proofing_help_text",
-    "defaultMessage": "The letter will contain a code that for security reasons expire in two weeks."
+    "defaultMessage": "The letter will contain a code that for security reasons expires in two weeks."
   },
   {
     "id": "letter.no_state_found",
@@ -573,11 +577,11 @@
   },
   {
     "id": "lmp.initialize_proofing_help_text",
-    "defaultMessage": "The phone number registry is maintained by phone operators at their conveninece and may not include all registered phone numbers."
+    "defaultMessage": "The phone number registry is maintained by phone operators at their convenience and may not include all registered phone numbers."
   },
   {
     "id": "lmp.initialize_proofing_help_text_tip_1",
-    "defaultMessage": "Tip: The registry is updated by phone operators at their conveninece and may not include all registered phone numbers"
+    "defaultMessage": "Tip: The registry is updated by phone operators at their convenience and may not include all registered phone numbers"
   },
   {
     "id": "lmp.modal_add_number_title",
@@ -877,7 +881,7 @@
   },
   {
     "id": "security.webauthn_credential_type",
-    "defaultMessage": "Security Key"
+    "defaultMessage": "Security key"
   },
   {
     "id": "security.add_webauthn_token_key",
@@ -885,7 +889,7 @@
   },
   {
     "id": "security.add_webauthn_token_device",
-    "defaultMessage": "Register this device as Security Key"
+    "defaultMessage": "Register this device as security key"
   },
   {
     "id": "security.security-key_title",
@@ -893,27 +897,27 @@
   },
   {
     "id": "security.second-factor",
-    "defaultMessage": "Add a Security Key as a second layer of identification, beyond email and password, to prove you are \n    the owner of your eduID."
+    "defaultMessage": "Add a security key as a second layer of identification, beyond email and password, to prove you are \n    the owner of your eduID."
   },
   {
     "id": "security.webauthn-describe-title",
-    "defaultMessage": "Add a name for your Security Key"
+    "defaultMessage": "Add a name for your security key"
   },
   {
     "id": "security.webauthn.max_allowed_tokens",
-    "defaultMessage": "You are not allowed to register more Security Keys"
+    "defaultMessage": "You are not allowed to register more security keys"
   },
   {
     "id": "security.webauthn_register_success",
-    "defaultMessage": "Security Key added"
+    "defaultMessage": "Security key added"
   },
   {
     "id": "security.webauthn-token-removed",
-    "defaultMessage": "Security Key removed"
+    "defaultMessage": "Security key removed"
   },
   {
     "id": "security.webauthn-missing-pdata",
-    "defaultMessage": "You should add your personal data before adding a Security Key"
+    "defaultMessage": "You should add your personal data before adding a security key"
   },
   {
     "id": "security.webauthn-token-notfound",
@@ -921,15 +925,15 @@
   },
   {
     "id": "security.webauthn-noremove-last",
-    "defaultMessage": "You are not allowed to remove your only Security Key"
+    "defaultMessage": "You are not allowed to remove your only security key"
   },
   {
     "id": "account_linking.main_title",
-    "defaultMessage": "Connect an ORCID account"
+    "defaultMessage": "ORCID account"
   },
   {
     "id": "account_linking.long_description",
-    "defaultMessage": "If you are a reseacher with an ORCID iD, you can connect it to eduID and only use one set of login details for both services."
+    "defaultMessage": "If you are a reseacher with an ORCID iD you can share it with your eduID."
   },
   {
     "id": "orc.authorization_success",
@@ -1373,7 +1377,7 @@
   },
   {
     "id": "settings.modal_delete_title",
-    "defaultMessage": "Are you sure you want to delete eduID?"
+    "defaultMessage": "Are you sure you want to delete your eduID?"
   },
   {
     "id": "delete.modal_info",

--- a/i18n/src/i18n-messages.json
+++ b/i18n/src/i18n-messages.json
@@ -445,7 +445,7 @@
   },
   {
     "id": "verify-identity.vetting_freja_tagline",
-    "defaultMessage": "For those able to create a Freja eID by passing one of the authorised agents"
+    "defaultMessage": "For those able to create a Freja eID by visiting one of the authorised agents"
   },
   {
     "id": "verify-identity.connect_nin_title",

--- a/i18n/src/i18n-messages.json
+++ b/i18n/src/i18n-messages.json
@@ -1393,7 +1393,7 @@
   },
   {
     "id": "header.faq",
-    "defaultMessage": "FAQ"
+    "defaultMessage": "Help"
   },
   {
     "id": "header.logout",

--- a/src/components/Email.js
+++ b/src/components/Email.js
@@ -5,19 +5,14 @@ import TextInput from "components/EduIDTextInput";
 import { Field, reduxForm } from "redux-form";
 import {
   Form,
-  FormGroup,
   FormFeedback,
-  Input,
   Modal,
   ModalHeader,
   ModalBody,
   ModalFooter
 } from "reactstrap";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faEnvelope } from "@fortawesome/free-solid-svg-icons/faEnvelope";
 
 import EduIDButton from "components/EduIDButton";
-
 import "style/Email.scss";
 
 /* FORM */
@@ -36,7 +31,7 @@ const validate = values => {
 
 let EmailForm = props => (
   <div id="register-input-group">
-    <Form id="register-form">
+    <fieldset id="register-form">
       <Field
         type="email"
         name="email"
@@ -46,7 +41,7 @@ let EmailForm = props => (
         l10n={props.l10n}
         placeholder="example@email.com"
       />
-    </Form>
+    </fieldset>
     <EduIDButton
       className="settings-button"
       id="register-button"
@@ -72,43 +67,10 @@ EmailForm = connect(state => ({
 
 class Email extends Component {
   render() {
-    // const url = window.location.href;
-    // let buttons = "";
-    // if (this.props.withButtons) {  onClick={this.props.gotoSignin} onClick={this.props.gotoSignup} {this.props.l10n("header.signup")} data-dashboard_url={this.props.dashboard_url}
-    // if (url.includes("register")) {
-    //   buttons = (
-    //     <div data-dashboard_url={this.props.dashboard_url}>
-    //       <EduIDButton
-    //         className="btn-link "
-    //         onClick={this.props.gotoSignin}
-    //       >
-    //         {this.props.l10n("header.signin")}
-    //       </EduIDButton>
-    //     </div>
-    //   );
-    // } else {
-    //   buttons = (
-    //     <div>
-    //       <a onClick={this.props.gotoSignup}>
-    //         {this.props.l10n("header.signup")}
-    //       </a>
-    //     </div>
-    //   );
-    // }
     return [
       <div key="0" id="register-container">
         <label>Email address</label>
         <EmailForm {...this.props} />
-        {/* <div data-dashboard_url={this.props.dashboard_url}>
-          <EduIDButton
-            id="login-button"
-            className="btn-link"
-            onClick={this.props.gotoSignin}
-          >
-            {this.props.l10n("header.signin")}
-          </EduIDButton>
-        </div> */}
-        {/* <p>{this.props.l10n("register.why-account")}</p> */}
       </div>,
       <div key="1">
         <Modal isOpen={this.props.acceptingTOU} id="register-modal">

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -40,7 +40,7 @@ class Footer extends Component {
         // <div id="eduid-navbar">
         <nav key="2" id="eduid-navbar">
           <ul>
-            <li>
+            {/* <li>
               <a href={this.props.students_link}>
                 {this.props.l10n("header.students")}
               </a>
@@ -55,7 +55,7 @@ class Footer extends Component {
               <a href={this.props.staff_link}>
                 {this.props.l10n("header.staff")}
               </a>
-            </li>
+            </li> */}
             <li>
               <a href={this.props.faq_link}>{this.props.l10n("header.faq")}</a>
             </li>

--- a/src/i18n-messages.js
+++ b/src/i18n-messages.js
@@ -2770,7 +2770,7 @@ const msgs = {
   //   <FormattedMessage id="header.staff" defaultMessage={`Staff`} />
   // ),
 
-  "header.faq": <FormattedMessage id="header.faq" defaultMessage={`FAQ`} />,
+  "header.faq": <FormattedMessage id="header.faq" defaultMessage={`Help`} />,
 
   "header.logout": (
     <FormattedMessage id="header.logout" defaultMessage={`Logout`} />

--- a/src/i18n-messages.js
+++ b/src/i18n-messages.js
@@ -915,7 +915,7 @@ const msgs = {
   "verify-identity.vetting_freja_tagline": (
     <FormattedMessage
       id="verify-identity.vetting_freja_tagline"
-      defaultMessage={`For those able to create a Freja eID by passing one of the authorised agents`}
+      defaultMessage={`For those able to create a Freja eID by visiting one of the authorised agents`}
     />
   ),
 

--- a/src/style/Footer.scss
+++ b/src/style/Footer.scss
@@ -3,7 +3,7 @@
 #footer {
   display: flex;
   flex-direction: column;
-  padding: 20px 15px;
+  padding: 16px;
   border-top: 8px solid #ff4500;
   background-color: #f4f4f4;
 }
@@ -64,7 +64,7 @@
 }
 
 #eduid-navbar li {
-  margin-right: 20px;
+  //  margin-right: 20px;
   // width: 100%;
   // justify-content: space-around;
 }

--- a/src/style/Header.scss
+++ b/src/style/Header.scss
@@ -15,7 +15,7 @@
   background-image: url(../../img/ds-eduID-logo-black320x120px.png);
   background-size: contain;
   background-repeat: no-repeat;
-  margin: 5px 0;
+  margin: 16px 0;
 }
 
 @media (max-width: 414px) {

--- a/src/style/Header.scss
+++ b/src/style/Header.scss
@@ -15,7 +15,7 @@
   background-image: url(../../img/ds-eduID-logo-black320x120px.png);
   background-size: contain;
   background-repeat: no-repeat;
-  margin: 16px 0;
+  margin: 0;
 }
 
 @media (max-width: 414px) {

--- a/src/style/SignupMain.scss
+++ b/src/style/SignupMain.scss
@@ -36,6 +36,12 @@
   font-size: 24px;
 }
 
+#email {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+
 #login-button {
   cursor: pointer;
   padding-left: 0;
@@ -120,10 +126,10 @@
   // }
 }
 @media (max-width: 375px) {
- #resend-button {
+  #resend-button {
     font-size: 0.8rem;
   }
- }
+}
 
 // body,
 // div.jumbotron {

--- a/src/style/base.scss
+++ b/src/style/base.scss
@@ -75,7 +75,7 @@ p {
 header {
   display: flex;
   justify-content: space-between;
-  padding: 0 15px;
+  padding: 16px 16px 0 16px;
   align-items: center;
 }
 


### PR DESCRIPTION
**Background**: This is an update to the footer in sign up to remove info links. 

**Summary**: 
- I have removed the 4 info links
- I have renamed FAQ to Help (as per Home and Login)
- I have made the margin consistent with Home and Login (1rem/16px)
- I have also made the email input fill the entire page up to the REGISTER button
- I have cleaned out some commented out code from the component

---
> ⚠️ Ideally, **Signup** and **Login** would both have translation options in the footer. But because Login only exists in English I have chosen what is currently in use (i.e. Signup and Login only in Eng) until they are both translated.
---

**Next step**: 
- I would also like to make the white banner in the header consistent with the Login (not as high white background, make the white part only hold the tagline, and move the sign in one-liner text down to the gray part of the page) 