### PR TITLE
NIN input fix: values in the URL and console.error

### DIFF
--- a/src/components/NinForm.js
+++ b/src/components/NinForm.js
@@ -114,8 +114,8 @@ const mapStateToProps = (state, props) => {
 const mapDispatchToProps = (dispatch, props) => {
   return {
     addNin: function(e) {
-      const nin =
-        e.target.previousElementSibling.firstElementChild.children[0].value;
+      const nin = e.target.closest("#nin-form-container").firstElementChild
+        .firstElementChild.children[0].value;
       dispatch(actions.postNin(nin));
     }
   };

--- a/src/components/NinForm.js
+++ b/src/components/NinForm.js
@@ -59,7 +59,13 @@ class NinForm extends Component {
 
     return (
       <div key="2" id="nin-form-container">
-        <Form id="nin-form" role="form">
+        <Form
+          id="nin-form"
+          role="form"
+          onSubmit={e => {
+            e.preventDefault();
+          }}
+        >
           <Field
             component={TextInput}
             componentClass="input"
@@ -68,8 +74,8 @@ class NinForm extends Component {
             placeholder={this.props.l10n("nins.input_placeholder")}
             helpBlock={this.props.l10n("nins.input_help_text")}
           />
+          {formButton}
         </Form>
-        {formButton}
       </div>
     );
   }


### PR DESCRIPTION
Background: The input accepting national identity numbers has the following bugs:
1. Adds incorrect nin values to the URL if user presses Enter
<img width="538" alt="Screenshot 2019-11-04 at 16 22 51" src="https://user-images.githubusercontent.com/30963614/68132883-b824cf80-ff1f-11e9-90c6-a6e0e0aa9eab.png">
2. Results in the following console.error after stalling and not saving the number when user clicks the ADD button 
<img width="538" alt="Screenshot 2019-11-04 at 16 23 49" src="https://user-images.githubusercontent.com/30963614/68132932-cd016300-ff1f-11e9-8bad-354a69f03c78.png">

Summary: 
- Moved `<button>` inside the `<Form>` component
- Added `e.preventDefault()` to the `onSubmit` event of the `<Form>` component 
- Added more robust DOM traversal to read the nin `<input>` value

