### PR TITLE
Fix to update Footers across website

### DIFF
--- a/i18n/l10n/sv.json
+++ b/i18n/l10n/sv.json
@@ -133,7 +133,7 @@
   "finish.unconfirmed-identities": "Obekräftade identiteter",
   "foot.change-version": "Byt till en tidigare version Dashboard",
   "foot.change-version-tip": "Om du stöter på något problem så kan du byta till en tidigare version av Dashboard.",
-  "header.faq": "Vanliga frågor",
+  "header.faq": "Hjälp",
   "header.logout": "Logga ut",
   "header.signin": "LOGGA IN",
   "header.signup": "REGISTRERING",

--- a/plugins/eduid_action.mfa/test.js
+++ b/plugins/eduid_action.mfa/test.js
@@ -61,7 +61,7 @@ describe("Some Component", () => {
     expect(title.length).toEqual(1);
     expect(fallback.length).toEqual(1);
     expect(animation.length).toEqual(0);
-    expect(title.text()).toEqual("No support for Security Keys");
+    expect(title.text()).toEqual("No support for security keys");
 
     Object.defineProperty(window.navigator, "credentials", {
       value: creds,

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
+import Questions from "./Questions";
 import "style/Footer.scss";
 
 class Footer extends Component {
@@ -9,17 +10,15 @@ class Footer extends Component {
     if (this.props.is_configured) {
       const langs = Object.getOwnPropertyNames(this.props.languages);
       langElems = langs.map((lang, index) => {
-        console.lo;
         if (lang === this.props.language) {
-          // the non-chosen language is hidden with css for now 
           return (
-            <p className="non-selected" key={index}>
+            <p key="0" className="non-selected" key={index}>
               <span key="0">{this.props.languages[lang]}</span>
             </p>
           );
         } else {
           return (
-            <p className="lang-selected" data-lang={lang} key={index}>
+            <p key="0" className="lang-selected" data-lang={lang} key={index}>
               <a key="0" onClick={this.props.changeLanguage}>
                 {this.props.languages[lang]}
               </a>

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -11,7 +11,7 @@ class Footer extends Component {
       langElems = langs.map((lang, index) => {
         console.lo;
         if (lang === this.props.language) {
-          // the non-chosen language is hidden with css for now className="non-selected"
+          // the non-chosen language is hidden with css for now 
           return (
             <p className="non-selected" key={index}>
               <span key="0">{this.props.languages[lang]}</span>
@@ -33,7 +33,6 @@ class Footer extends Component {
 
     return (
       <footer key="0" id="footer">
-        {/* <div key="0" id="footer-content"> */}
         <p key="0" id="copyright">
           <span>&copy;{this.props.l10n("main.copyright")}</span>
         </p>
@@ -50,7 +49,6 @@ class Footer extends Component {
           </ul>
         </nav>
       </footer>
-      // </div>
     );
   }
 }

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,28 +1,25 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import Questions from "./Questions";
 import "style/Footer.scss";
 
 class Footer extends Component {
   render() {
-    const url = window.location.href;
     let langElems = "";
-    let languageSelect = "";
-    let navMenu = "";
 
     if (this.props.is_configured) {
       const langs = Object.getOwnPropertyNames(this.props.languages);
-
       langElems = langs.map((lang, index) => {
+        console.lo;
         if (lang === this.props.language) {
+          // the non-chosen language is hidden with css for now className="non-selected"
           return (
-            <p key="0" className="langselector" key={index}>
-              <span key="0" >{this.props.languages[lang]}</span>
+            <p className="non-selected" key={index}>
+              <span key="0">{this.props.languages[lang]}</span>
             </p>
           );
         } else {
           return (
-            <p key="0"  className="langselector" data-lang={lang} key={index}>
+            <p className="lang-selected" data-lang={lang} key={index}>
               <a key="0" onClick={this.props.changeLanguage}>
                 {this.props.languages[lang]}
               </a>
@@ -33,51 +30,27 @@ class Footer extends Component {
     } else {
       langElems = "";
     }
-    languageSelect = [<div key="1" id="language-selector">{langElems}</div>];
 
-    if (url.includes("register") || url.includes("services")) {
-      navMenu = (
-        // <div id="eduid-navbar">
-        <nav key="2" id="eduid-navbar">
+    return (
+      <footer key="0" id="footer">
+        {/* <div key="0" id="footer-content"> */}
+        <p key="0" id="copyright">
+          <span>&copy;{this.props.l10n("main.copyright")}</span>
+        </p>
+        <nav key="1">
           <ul>
-            {/* <li>
-              <a href={this.props.students_link}>
-                {this.props.l10n("header.students")}
+            <li key="0" className="langselector">
+              <a className="help-link" href={this.props.faq_link}>
+                {this.props.l10n("header.faq")}
               </a>
             </li>
-            <li>
-              <a href={this.props.technicians_link}>
-                {this.props.l10n("header.technicians")}
-              </a>
-            </li>
-
-            <li>
-              <a href={this.props.staff_link}>
-                {this.props.l10n("header.staff")}
-              </a>
-            </li> */}
-            <li>
-              <a href={this.props.faq_link}>{this.props.l10n("header.faq")}</a>
+            <li key="1" id="language-selector">
+              {langElems}
             </li>
           </ul>
         </nav>
-        // </div>
-      );
-    }
-    return (
-      <div key="0" id="footer">
-        {/* <Questions {...this.props} /> */}
-        <div id="footer-content">
-          <p id="copyright">
-            <span>&copy;{this.props.l10n("main.copyright")}</span>
-          </p>
-          {/* <p>
-            <span id="language-selector">{langElems}</span>
-          </p> */}
-          {languageSelect}
-          {navMenu}
-        </div>
-      </div>
+      </footer>
+      // </div>
     );
   }
 }

--- a/src/containers/Footer.js
+++ b/src/containers/Footer.js
@@ -29,7 +29,7 @@ const mapStateToProps = (state, props) => {
 const mapDispatchToProps = (dispatch, props) => {
   return {
     changeLanguage: function(e) {
-      const lang = e.target.closest(".langselector").dataset.lang;
+      const lang = e.target.closest(".lang-selected").dataset.lang;
       const msgs = LOCALIZED_MESSAGES[lang];
       dispatch(
         updateIntl({

--- a/src/containers/Footer.js
+++ b/src/containers/Footer.js
@@ -17,12 +17,7 @@ const mapStateToProps = (state, props) => {
     language: state.intl.locale,
     languages: languages,
     reload_to: state.config.DASHBOARD_URL,
-    // dashboard_url: state.config.dashboard_url,
-    // students_link: state.config.students_link,
-    // technicians_link: state.config.technicians_link,
-    // staff_link: state.config.staff_link,
     faq_link: state.config.faq_link
-    // size: state.config.window_size
   };
 };
 

--- a/src/containers/Footer.js
+++ b/src/containers/Footer.js
@@ -18,9 +18,9 @@ const mapStateToProps = (state, props) => {
     languages: languages,
     reload_to: state.config.DASHBOARD_URL,
     // dashboard_url: state.config.dashboard_url,
-    students_link: state.config.students_link,
-    technicians_link: state.config.technicians_link,
-    staff_link: state.config.staff_link,
+    // students_link: state.config.students_link,
+    // technicians_link: state.config.technicians_link,
+    // staff_link: state.config.staff_link,
     faq_link: state.config.faq_link
     // size: state.config.window_size
   };

--- a/src/style/Footer.scss
+++ b/src/style/Footer.scss
@@ -2,158 +2,85 @@
 
 #footer {
   display: flex;
-  flex-direction: column;
+  justify-content: space-between;
   padding: 16px;
   border-top: 8px solid #ff4500;
   background-color: #f4f4f4;
 }
 
-#footer p {
+#copyright,
+nav a {
   font-size: 16px;
   line-height: 1.5;
-  margin-top: 0;
+  margin: 0;
+  border-bottom: solid 1px transparent;
 }
 
-#footer-content {
+nav a:hover {
+  color: $orange-highlight;
+  border-bottom: solid 1px $orange-highlight;
+}
+
+footer nav ul {
   display: flex;
-  justify-content: space-between;
-  flex-wrap: wrap-reverse;
+  align-items: baseline;
+  margin: 0;
+  padding: 0;
 }
 
-#footer-content p {
-  margin-bottom: 0;
+footer nav .help-link {
+  padding: 0;
+  margin-right: 1rem;
+}
+
+footer nav .help-link span {
+  color: #ff4500;
+}
+
+footer nav .lang-selected {
+  margin: 0;
+  cursor: pointer;
+  color: #ff4500;
 }
 
 #language-selector {
   display: flex;
 }
 
-#footer .langselector {
-  font-family: "Akkurat";
-  margin-right: 2px;
-  padding: 0 10px;
-  border-right: 1px solid #d8d8d8;
-}
-#footer .langselector:last-child {
-  border-right: none;
-}
-#footer .langselector span {
-  font-family: "Akkurat";
-  color: #ff4500;
-}
-#footer .langselector a {
-  cursor: pointer;
-  color: #161616;
+.non-selected {
+  margin: 0;
+
+  display: none;
 }
 
-// #eduid-button {
-//   display: flex;
-//   justify-content: flex-end;
-//   align-items: center;
+// @media (max-width: 765px) {
+//   #eduid-navbar {
+//     // margin: 5px 0 15px 0;
+//   }
+//   #eduid-navbar ul {
+//     justify-content: space-between;
+//   }
 // }
 
-// #eduid-navbar {
-//   width: 100%;
-// }
-
-#eduid-navbar ul {
-  display: flex;
-  padding-left: 0;
-  margin-bottom: 0;
-  justify-content: flex-end;
-}
-
-#eduid-navbar li {
-  //  margin-right: 20px;
-  // width: 100%;
-  // justify-content: space-around;
-}
-
-#eduid-navbar a:hover {
-  color: $orange-highlight;
-  border-bottom: solid 1px $orange-highlight;
-}
-/* styles for moving questions to footer */
-// #question-wrapper {
-//   display: grid;
-//   grid-template-columns: 50% 50%;
-//   // display: flex;
-//   width: 58.3333%;
-//   margin: auto;
-// }
-
-// .question-container {
-//   margin-right: 30px;
-//   margin-top: 3rem;
-// }
-
-// p .question {
-//   margin-bottom: 30px;
-// }
-
-// #footer ul {
-//   margin: 50px auto;
-//   // display: grid;
-//   // grid-template-columns: 50% 50%;
-//   // grid-template-rows: auto;
-//   // grid-gap: 30px;
-
-//   width: 58.333333%;
-// }
-
-// #footer li {
-//   cursor: pointer;
-//   // background-color: yellow;
-//   list-style: none;
-//   border-bottom: solid 1px #d8d8d8;
-// }
-
-// .accordion {
-//   // line-height: 1.5;
-//   padding: 30px 0;
-//   margin-top: 0;
-//   display: flex;
-//   justify-content: space-between;
-// }
-
-// #footer .answer {
-//   margin-bottom: 30px;
-// }
-@media (max-width: 765px) {
-  #eduid-navbar {
-    // margin: 5px 0 15px 0;
-  }
-  #eduid-navbar ul {
-    justify-content: space-between;
-  }
-}
-
-@media (max-width: 414px) {
-  #eduid-navbar {
-    margin: 5px 0;
-  }
-  #eduid-navbar ul {
-    justify-content: space-between;
-    flex-direction: row;
-    flex-wrap: wrap;
-  }
-  #eduid-navbar li {
-    flex: 50%;
-    margin-right: 0;
-    margin-bottom: 10px;
-  }
-  #footer-content p {
-    margin-top: 10px;
-    font-size: 0.9rem;
-  }
-  #footer .langselector {
-    padding: 0 5px;
-  }
-}
-
-// @media (max-width: 375px) {
-//   #footer-content p,
-//   #footer-content {
-//     font-size: 0.8rem;
+// @media (max-width: 414px) {
+//   #eduid-navbar {
+//     margin: 5px 0;
+//   }
+//   #eduid-navbar ul {
+//     justify-content: space-between;
+//     flex-direction: row;
+//     flex-wrap: wrap;
+//   }
+//   #eduid-navbar li {
+//     flex: 50%;
+//     margin-right: 0;
+//     margin-bottom: 10px;
+//   }
+//   #footer-content p {
+//     margin-top: 10px;
+//     font-size: 0.9rem;
+//   }
+//   #footer .langselector {
+//     padding: 0 5px;
 //   }
 // }

--- a/src/style/Footer.scss
+++ b/src/style/Footer.scss
@@ -3,6 +3,7 @@
 #footer {
   display: flex;
   justify-content: space-between;
+  align-items: baseline;
   padding: 16px;
   border-top: 8px solid #ff4500;
   background-color: #f4f4f4;
@@ -49,38 +50,5 @@ footer nav .lang-selected {
 
 .non-selected {
   margin: 0;
-
   display: none;
 }
-
-// @media (max-width: 765px) {
-//   #eduid-navbar {
-//     // margin: 5px 0 15px 0;
-//   }
-//   #eduid-navbar ul {
-//     justify-content: space-between;
-//   }
-// }
-
-// @media (max-width: 414px) {
-//   #eduid-navbar {
-//     margin: 5px 0;
-//   }
-//   #eduid-navbar ul {
-//     justify-content: space-between;
-//     flex-direction: row;
-//     flex-wrap: wrap;
-//   }
-//   #eduid-navbar li {
-//     flex: 50%;
-//     margin-right: 0;
-//     margin-bottom: 10px;
-//   }
-//   #footer-content p {
-//     margin-top: 10px;
-//     font-size: 0.9rem;
-//   }
-//   #footer .langselector {
-//     padding: 0 5px;
-//   }
-// }

--- a/src/tests/Footer-test.js
+++ b/src/tests/Footer-test.js
@@ -55,15 +55,15 @@ describe("Footer Component", () => {
   //   expect(link.length).toEqual(4);
   // });
 
-  it("Renders the lanuage selector component", () => {
+  it("Renders the language selector component", () => {
     const wrapper = setupComponent({
         component: <FooterContainer />,
         overrides: state
       }),
-      p = wrapper.find("p.langselector"),
-      link = wrapper.find("p.langselector").find("a");
+      p = wrapper.find("p.lang-selected"),
+      link = wrapper.find("p.lang-selected").find("a");
 
-    expect(p.length).toEqual(2);
+    expect(p.length).toEqual(1);
     expect(link.length).toEqual(1);
     expect(link.text()).toEqual("Svenska");
   });


### PR DESCRIPTION
**Background**: Footers across the website are inconsistent. This is a proposal of a standard way to fit all of the current info (see screenshot).

<img width="774" alt="Screenshot 2019-11-06 at 11 37 44" src="https://user-images.githubusercontent.com/30963614/68291356-fccc7a00-0089-11ea-968d-6adfdcb249bf.png">

**Summary**: 
- I have removed the information links (from component and the container), excluding the 'FAQ' which is now renamed to 'Help'
- I have hidden the non-selected language with css, so that only the clickable option is visible (i.e. it shows the language you are not using so you can switch to it)
- I have refactored the component and the css (media queries not needed anymore)

**Next steps**: 
- As a standard footer this is what we should aim for all pages to look in the long term
- Pages that differ are: 
     - TOU for existing users (outdated - needs updating)
     - Home (currently does not have copyright - needs updating)   
     - Login/Signup (do not need translation button - ok for now)