### PR TITLE
Refactor Header to allow different styles across website

### DIFF
--- a/src/components/ActionWrapper.js
+++ b/src/components/ActionWrapper.js
@@ -50,7 +50,7 @@ class ActionWrapper extends Component {
         <SplashContainer />
         <Router history={history}>
           <div className="dashboard-wrapper">
-            <HeaderContainer />
+            <HeaderContainer {...this.props} />
             <div id="dashboard-text">
               <div id="welcome">
                 <h1>{this.props.l10n("main.welcome")}</h1>

--- a/src/components/ActionWrapper.js
+++ b/src/components/ActionWrapper.js
@@ -6,7 +6,7 @@ import { createBrowserHistory } from "history";
 import SplashContainer from "containers/Splash";
 import NotificationsContainer from "containers/Notifications";
 import FooterContainer from "containers/Footer";
-import HeaderContainer from "containers/HeaderAnon";
+import HeaderContainer from "containers/Header";
 
 import "../../node_modules/bootstrap/dist/css/bootstrap.min.css";
 import "style/SignupMain.scss";

--- a/src/components/DashboardMain.js
+++ b/src/components/DashboardMain.js
@@ -60,7 +60,7 @@ class Main extends Component {
         <SplashContainer />
         <Router history={history}>
           <div className="dashboard-wrapper">
-            <HeaderContainer />
+            <HeaderContainer {...this.props} />
             <div id="dashboard-text">
               <div id="welcome">
                 <h1>

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,50 +1,48 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-
 import "style/Header.scss";
 
 class Header extends Component {
   render() {
-    let login = (
-      <div data-dashboard_url={this.props.dashboard_url}>
-        <a onClick={this.props.gotoSignin}>
-          <button id="login" className="btn">
-            {this.props.l10n("header.signin")}
+    const url = location.pathname;
+    let button = "";
+    if (url.includes("register")) {
+      button = (
+        <div data-dashboard_url={this.props.dashboard_url}>
+          <a onClick={this.props.gotoSignin}>
+            <button id="login" className="btn">
+              {this.props.l10n("header.signin")}
+            </button>
+          </a>
+        </div>
+      );
+    } else if (url.includes("profile")) {
+      button = (
+        <div id="eduid-button">
+          <button id="logout" className="btn" onClick={this.props.handleLogout}>
+            {this.props.l10n("header.logout")}
           </button>
-        </a>
-      </div>
-    );
-
-    const logout = (
-      <div id="eduid-button">
-        <button id="logout" className="btn" onClick={this.props.handleLogout}>
-          {this.props.l10n("header.logout")}
-        </button>
-      </div>
-    );
+        </div>
+      );
+    } else {
+      button = <div />;
+    }
 
     return (
       <header>
         <a href="http://html.eduid.docker/">
           <div id="eduid-logo" />
         </a>
-        {logout}
+        {button}
       </header>
     );
   }
 }
 
 Header.propTypes = {
-  withButtons: PropTypes.bool,
-  size: PropTypes.string,
-  // gotoSignup: PropTypes.func,
   gotoSignin: PropTypes.func,
   l10n: PropTypes.func,
   confirmed: PropTypes.string
-  // studentsLink: PropTypes.string,
-  // techniciansLink: PropTypes.string,
-  // staffLink: PropTypes.string,
-  // faqLink: PropTypes.string
 };
 
 export default Header;

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -5,6 +5,16 @@ import "style/Header.scss";
 
 class Header extends Component {
   render() {
+    let login = (
+      <div data-dashboard_url={this.props.dashboard_url}>
+        <a onClick={this.props.gotoSignin}>
+          <button id="login" className="btn">
+            {this.props.l10n("header.signin")}
+          </button>
+        </a>
+      </div>
+    );
+
     const logout = (
       <div id="eduid-button">
         <button id="logout" className="btn" onClick={this.props.handleLogout}>
@@ -25,11 +35,16 @@ class Header extends Component {
 }
 
 Header.propTypes = {
-  confirmed: PropTypes.string,
-  studentsLink: PropTypes.string,
-  techniciansLink: PropTypes.string,
-  staffLink: PropTypes.string,
-  faqLink: PropTypes.string
+  withButtons: PropTypes.bool,
+  size: PropTypes.string,
+  // gotoSignup: PropTypes.func,
+  gotoSignin: PropTypes.func,
+  l10n: PropTypes.func,
+  confirmed: PropTypes.string
+  // studentsLink: PropTypes.string,
+  // techniciansLink: PropTypes.string,
+  // staffLink: PropTypes.string,
+  // faqLink: PropTypes.string
 };
 
 export default Header;

--- a/src/components/HeaderAnon.js
+++ b/src/components/HeaderAnon.js
@@ -1,37 +1,37 @@
-import React, { Component } from "react";
-import PropTypes from "prop-types";
+// import React, { Component } from "react";
+// import PropTypes from "prop-types";
 
-import "style/Header.scss";
+// import "style/Header.scss";
 
-class Header extends Component {
-  render() {
-    let  login = (
-        <div data-dashboard_url={this.props.dashboard_url}>
-          <a onClick={this.props.gotoSignin}>
-            <button id="login" className="btn">
-              {this.props.l10n("header.signin")}
-            </button>
-          </a>
-        </div>
-      );
+// class Header extends Component {
+//   render() {
+//     let  login = (
+//         <div data-dashboard_url={this.props.dashboard_url}>
+//           <a onClick={this.props.gotoSignin}>
+//             <button id="login" className="btn">
+//               {this.props.l10n("header.signin")}
+//             </button>
+//           </a>
+//         </div>
+//       );
 
-    return (
-      <header>
-        <a href="http://html.eduid.docker/">
-          <div id="eduid-logo" />
-        </a>
-        {login}
-      </header>
-    );
-  }
-}
+//     return (
+//       <header>
+//         <a href="http://html.eduid.docker/">
+//           <div id="eduid-logo" />
+//         </a>
+//         {login}
+//       </header>
+//     );
+//   }
+// }
 
-Header.propTypes = {
-  withButtons: PropTypes.bool,
-  size: PropTypes.string,
-  l10n: PropTypes.func,
-  gotoSignup: PropTypes.func,
-  gotoSignin: PropTypes.func
-};
+// Header.propTypes = {
+//   withButtons: PropTypes.bool,
+//   size: PropTypes.string,
+//   l10n: PropTypes.func,
+//   gotoSignup: PropTypes.func,
+//   gotoSignin: PropTypes.func
+// };
 
-export default Header;
+// export default Header;

--- a/src/components/SignupMain.js
+++ b/src/components/SignupMain.js
@@ -6,7 +6,7 @@ import { createBrowserHistory } from "history";
 import FetchingContext from "components/FetchingContext";
 import SplashContainer from "containers/Splash";
 import FooterContainer from "containers/Footer";
-import HeaderContainer from "containers/HeaderAnon";
+import HeaderContainer from "containers/Header";
 // import HeaderContainer from "containers/Header";
 import EmailContainer from "containers/Email";
 import AccountCreatedContainer from "containers/AccountCreated";

--- a/src/components/SignupMain.js
+++ b/src/components/SignupMain.js
@@ -85,7 +85,7 @@ class SignupMain extends Component {
         <SplashContainer />
         <Router history={history}>
           <div className="dashboard-wrapper">
-            <HeaderContainer/>
+            <HeaderContainer {...this.props} />
             <div id="dashboard-text">
               <div id="welcome">
                 <h1>{this.props.l10n("main.welcome")}</h1>

--- a/src/containers/Header.js
+++ b/src/containers/Header.js
@@ -4,33 +4,10 @@ import { startLogout } from "actions/Header";
 import i18n from "i18n-messages";
 
 const mapStateToProps = (state, props) => {
-  let email, confirmed;
-  // if (state.emails.emails.length >= 1) {
-  //   email = state.emails.emails.filter(mail => mail.primary)[0].email;
-  // } else {
-  //   email = "";
-  // }
-  // const nins = state.nins.nins.filter(nin => nin.verified);
-  // if (nins.length >= 1) {
-  //   confirmed = "main.confirmed";
-  // } else {
-  //   confirmed = "main.unconfirmed";
-  // }
-
-
+  let confirmed;
   return {
     dashboard_url: state.config.dashboard_url,
-    // students_link: state.config.students_link,
-    // technicians_link: state.config.technicians_link,
-    // staff_link: state.config.staff_link,
-    // faq_link: state.config.faq_link,
-    // email: email,
     confirmed: confirmed,
-    // studentsLink: state.config.STATIC_STUDENTS_URL,
-    // techniciansLink: state.config.STATIC_TECHNICIANS_URL,
-    // staffLink: state.config.STATIC_STAFF_URL,
-    // faqLink: state.config.STATIC_FAQ_URL,
-    // size: state.config.window_size
   };
 };
 
@@ -39,10 +16,6 @@ const mapDispatchToProps = (dispatch, props) => {
     handleLogout: function(e) {
       dispatch(startLogout());
     },
-    // gotoSignup: function (e) {
-    //   e.preventDefault();
-    //   document.location.href = "/";
-    // },
     gotoSignin: function (e) {
       e.preventDefault();
       const dataNode = e.target.closest("div"),

--- a/src/containers/Header.js
+++ b/src/containers/Header.js
@@ -16,7 +16,14 @@ const mapStateToProps = (state, props) => {
   // } else {
   //   confirmed = "main.unconfirmed";
   // }
+
+
   return {
+    dashboard_url: state.config.dashboard_url,
+    students_link: state.config.students_link,
+    technicians_link: state.config.technicians_link,
+    staff_link: state.config.staff_link,
+    faq_link: state.config.faq_link,
     // email: email,
     confirmed: confirmed,
     studentsLink: state.config.STATIC_STUDENTS_URL,
@@ -31,6 +38,16 @@ const mapDispatchToProps = (dispatch, props) => {
   return {
     handleLogout: function(e) {
       dispatch(startLogout());
+    },
+    gotoSignup: function (e) {
+      e.preventDefault();
+      document.location.href = "/";
+    },
+    gotoSignin: function (e) {
+      e.preventDefault();
+      const dataNode = e.target.closest("div"),
+        url = dataNode.dataset.dashboard_url;
+      document.location.href = url;
     }
   };
 };
@@ -41,3 +58,4 @@ const HeaderContainer = connect(
 )(Header);
 
 export default i18n(HeaderContainer);
+

--- a/src/containers/Header.js
+++ b/src/containers/Header.js
@@ -20,17 +20,17 @@ const mapStateToProps = (state, props) => {
 
   return {
     dashboard_url: state.config.dashboard_url,
-    students_link: state.config.students_link,
-    technicians_link: state.config.technicians_link,
-    staff_link: state.config.staff_link,
-    faq_link: state.config.faq_link,
+    // students_link: state.config.students_link,
+    // technicians_link: state.config.technicians_link,
+    // staff_link: state.config.staff_link,
+    // faq_link: state.config.faq_link,
     // email: email,
     confirmed: confirmed,
-    studentsLink: state.config.STATIC_STUDENTS_URL,
-    techniciansLink: state.config.STATIC_TECHNICIANS_URL,
-    staffLink: state.config.STATIC_STAFF_URL,
-    faqLink: state.config.STATIC_FAQ_URL,
-    size: state.config.window_size
+    // studentsLink: state.config.STATIC_STUDENTS_URL,
+    // techniciansLink: state.config.STATIC_TECHNICIANS_URL,
+    // staffLink: state.config.STATIC_STAFF_URL,
+    // faqLink: state.config.STATIC_FAQ_URL,
+    // size: state.config.window_size
   };
 };
 

--- a/src/containers/Header.js
+++ b/src/containers/Header.js
@@ -39,10 +39,10 @@ const mapDispatchToProps = (dispatch, props) => {
     handleLogout: function(e) {
       dispatch(startLogout());
     },
-    gotoSignup: function (e) {
-      e.preventDefault();
-      document.location.href = "/";
-    },
+    // gotoSignup: function (e) {
+    //   e.preventDefault();
+    //   document.location.href = "/";
+    // },
     gotoSignin: function (e) {
       e.preventDefault();
       const dataNode = e.target.closest("div"),

--- a/src/containers/HeaderAnon.js
+++ b/src/containers/HeaderAnon.js
@@ -1,37 +1,37 @@
-import { connect } from "react-redux";
+// import { connect } from "react-redux";
 
-import i18n from "i18n-messages";
-import Header from "components/HeaderAnon";
+// import i18n from "i18n-messages";
+// import Header from "components/HeaderAnon";
 
-const mapStateToProps = (state, props) => {
-  return {
-    dashboard_url: state.config.dashboard_url,
-    students_link: state.config.students_link,
-    technicians_link: state.config.technicians_link,
-    staff_link: state.config.staff_link,
-    faq_link: state.config.faq_link
-    // size: state.config.window_size
-  };
-};
+// const mapStateToProps = (state, props) => {
+//   return {
+//     dashboard_url: state.config.dashboard_url,
+//     students_link: state.config.students_link,
+//     technicians_link: state.config.technicians_link,
+//     staff_link: state.config.staff_link,
+//     faq_link: state.config.faq_link
+//     // size: state.config.window_size
+//   };
+// };
 
-const mapDispatchToProps = (dispatch, props) => {
-  return {
-    gotoSignup: function(e) {
-      e.preventDefault();
-      document.location.href = "/";
-    },
-    gotoSignin: function(e) {
-      e.preventDefault();
-      const dataNode = e.target.closest("div"),
-        url = dataNode.dataset.dashboard_url;
-      document.location.href = url;
-    }
-  };
-};
+// const mapDispatchToProps = (dispatch, props) => {
+//   return {
+//     gotoSignup: function(e) {
+//       e.preventDefault();
+//       document.location.href = "/";
+//     },
+//     gotoSignin: function(e) {
+//       e.preventDefault();
+//       const dataNode = e.target.closest("div"),
+//         url = dataNode.dataset.dashboard_url;
+//       document.location.href = url;
+//     }
+//   };
+// };
 
-const HeaderContainer = connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Header);
+// const HeaderContainer = connect(
+//   mapStateToProps,
+//   mapDispatchToProps
+// )(Header);
 
-export default i18n(HeaderContainer);
+// export default i18n(HeaderContainer);

--- a/src/tests/Header-test.js
+++ b/src/tests/Header-test.js
@@ -2,7 +2,7 @@ import React from "react";
 import expect from "expect";
 import { shallow } from "../../node_modules/enzyme";
 import { IntlProvider } from "react-intl";
-import HeaderAnonContainer from "containers/HeaderAnon";
+// import HeaderAnonContainer from "containers/HeaderAnon";
 import HeaderContainer from "containers/Header";
 import { setupComponent } from "tests/SignupMain-test";
 
@@ -24,41 +24,41 @@ describe("Header Component", () => {
     expect(logo.length).toEqual(1);
   });
 
-  it("Component renders the LOGOUT button", () => {
-    const fullWrapper = setupComponent({
-      component: <HeaderContainer />
-    });
-    const button = fullWrapper.find("#logout");
-    expect(button.exists()).toEqual(true);
-    expect(button.length).toEqual(1);
-    // expect(button.text()).toContain("Logout");
-  });
+  // it("Component renders the LOGOUT button", () => {
+  //   const fullWrapper = setupComponent({
+  //     component: <HeaderContainer />
+  //   });
+  //   const button = fullWrapper.find("#logout");
+  //   expect(button.exists()).toEqual(true);
+  //   expect(button.length).toEqual(1);
+  //   // expect(button.text()).toContain("Logout");
+  // });
 });
 
-describe("HeaderAnon Component", () => {
-  it("Component does not render 'false' or 'null'", () => {
-    const wrapper = shallow(
-      <IntlProvider locale="en">
-        <HeaderAnonContainer />
-      </IntlProvider>
-    );
-    expect(wrapper.isEmptyRender()).toEqual(false);
-  });
-  it("Component renders the eduID logo", () => {
-    const wrapper = setupComponent({
-        component: <HeaderAnonContainer />
-      }),
-      logo = wrapper.find("#eduid-logo");
-    expect(logo.length).toEqual(1);
-  });
+// describe("HeaderAnon Component", () => {
+//   it("Component does not render 'false' or 'null'", () => {
+//     const wrapper = shallow(
+//       <IntlProvider locale="en">
+//         <HeaderAnonContainer />
+//       </IntlProvider>
+//     );
+//     expect(wrapper.isEmptyRender()).toEqual(false);
+//   });
+//   it("Component renders the eduID logo", () => {
+//     const wrapper = setupComponent({
+//         component: <HeaderAnonContainer />
+//       }),
+//       logo = wrapper.find("#eduid-logo");
+//     expect(logo.length).toEqual(1);
+//   });
 
-  it("Component renders the LOGIN button", () => {
-    const fullWrapper = setupComponent({
-      component: <HeaderAnonContainer />
-    });
-    const button = fullWrapper.find("#login");
-    expect(button.exists()).toEqual(true);
-    expect(button.length).toEqual(1);
-    // expect(button.text()).toContain("Log in");
-  });
-});
+//   it("Component renders the LOGIN button", () => {
+//     const fullWrapper = setupComponent({
+//       component: <HeaderAnonContainer />
+//     });
+//     const button = fullWrapper.find("#login");
+//     expect(button.exists()).toEqual(true);
+//     expect(button.length).toEqual(1);
+//     // expect(button.text()).toContain("Log in");
+//   });
+// });


### PR DESCRIPTION
**Background**:  The updated app requires a more flexible header. 
- Outside of the app, buttons need to navigate to signup or login 
- Inside the app, a button needs to log users out
- Some pages (TOU for existing users or reset password) should not have any button

**Summary**: 
- I have refactored the `<Header />` component to display different buttons based on URL (location.pathname)
- I have moved the code and proptypes from `<HeaderAnon />` to `<Header />` (component and container)
- I have commented out the code in `<HeaderAnon />` (component and container)
- I have removed all imports of `<HeaderAnon />`
-  I have also updated the test in line with these changes