### PR TITLE
Fixes narrow modals: freja and delete eduid

### DIFF
--- a/src/style/base.scss
+++ b/src/style/base.scss
@@ -743,6 +743,9 @@ svg.remove:hover {
   .container {
     max-width: 100%;
   }
+  .modal-dialog {
+    max-width: 100%;
+  }
 }
 
 @media (max-width: 823px) {

--- a/src/style/base.scss
+++ b/src/style/base.scss
@@ -552,11 +552,7 @@ h5.modal-title {
 }
 
 #confirm-user-data-modal,
-#register-modal {
-  width: 50vw;
-  margin: auto;
-}
-
+#register-modal,
 #eidas-modal,
 #delete-account-modal {
   width: 70vw;

--- a/src/style/base.scss
+++ b/src/style/base.scss
@@ -552,14 +552,14 @@ h5.modal-title {
 }
 
 #confirm-user-data-modal,
-#register-modal,
-#eidas-modal {
+#register-modal {
   width: 50vw;
   margin: auto;
 }
 
+#eidas-modal,
 #delete-account-modal {
-  width: 30vw;
+  width: 70vw;
   margin: auto;
 }
 

--- a/src/style/base.scss
+++ b/src/style/base.scss
@@ -747,7 +747,13 @@ svg.remove:hover {
 
 @media (max-width: 823px) {
   // ---- modals ----- //
-
+  #register-modal,
+  #delete-account-modal,
+  #eidas-modal,
+  .modal-dialog {
+    width: calc(100% - 40px);
+    margin: auto 20px;
+  }
   .modal-header {
     padding: 20px;
   }
@@ -803,11 +809,6 @@ svg.remove:hover {
     font-size: 25px;
     line-height: 30px;
     margin-top: 10px;
-  }
-  #register-modal,
-  .modal-dialog {
-    width: calc(100% - 40px);
-    margin: auto 20px;
   }
   .modal-dialog {
     max-width: calc(100% - 40px);


### PR DESCRIPTION
**Background**: The freja and delete eduid modals are too narrow 

![Screenshot 2019-11-07 at 14 23 05](https://user-images.githubusercontent.com/30963614/68392481-2a88f000-016a-11ea-93d0-7bc2c626f88d.png)

**Summary**:
- I have added the freja and delete eduID modals to fullscreen styling at 823 px
- I have added code to override bootstrap styling @ 576px
- I have made all modals wider in fullscreen 

**Next steps**: 
- There seems to be an issue with breakpoints here as styling set @ 823px does not take effect, but randomly comes into play @ 741px
- Not too sure if it's bootstrap or other stylesheets that are overriding these styles
- Don't know if this affects all modals (most noticeable in Freja and Delete eduID - possibly because they have the most text)