### PR TITLE
Tighter spacing for Dashboard and Register pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ npm-debug.log
 build/
 dist/
 .npm
+.DS_Store

--- a/src/style/DashboardMain.scss
+++ b/src/style/DashboardMain.scss
@@ -218,7 +218,7 @@ aside li:hover a {
 #dashboard-nav {
   // font-family: "ProximaNova-Bold";
   width: 58%;
-  margin: 70px auto;
+  margin: 6px auto;
 }
 
 #dashboard-nav ul {
@@ -259,7 +259,7 @@ aside li:hover a {
 #dashboard-nav.nav-back {
   display: flex;
   justify-content: flex-end;
-  max-width: 58.33333%;
+  max-width: 58%;
 }
 
 #dashboard-nav.nav-back ul {

--- a/src/style/DashboardMain.scss
+++ b/src/style/DashboardMain.scss
@@ -71,7 +71,7 @@ h1.banner-tagline {
 }
 #settings-content,
 #profile-container {
-  margin: 5rem 0;
+  margin: 3rem 0 3rem 3px;
 }
 
 #profile-container {

--- a/src/style/DashboardMain.scss
+++ b/src/style/DashboardMain.scss
@@ -44,8 +44,8 @@ h1.banner-tagline {
 
 // remove this from the test of the app
 #welcome {
-  padding: 7rem 0 5rem;
-  width: 58.3333333333%;
+  padding: 6rem 0 3rem 0;
+  width: 58%;
   margin: 0 auto;
 }
 

--- a/src/style/base.scss
+++ b/src/style/base.scss
@@ -173,7 +173,7 @@ small,
 .intro h4 {
   font-size: 1.5rem;
   line-height: 34px;
-  margin-top: 56px;
+  margin-top: 36px;
   font-weight: 700;
 }
 

--- a/src/style/base.scss
+++ b/src/style/base.scss
@@ -36,6 +36,7 @@ h1 {
   font-size: 36px;
   line-height: 44px;
   margin-top: 0;
+  font-weight: 700;
   font-family: "ProximaNova-Regular";
 }
 

--- a/src/style/base.scss
+++ b/src/style/base.scss
@@ -42,7 +42,7 @@ h1 {
 h2 {
   font-size: 28px;
   line-height: 42px;
-  margin-top: 24px;
+  margin-top: 0;
 }
 
 h3 {
@@ -68,8 +68,9 @@ h6 {
 
 p {
   font-size: 20px;
-  line-height: 32px;
-  margin-top: 24px;
+  line-height: 1.5;
+  margin-top: 16px;
+  margin-bottom: 16px;
 }
 
 header {
@@ -177,9 +178,9 @@ small,
   font-weight: 700;
 }
 
-.intro {
-  margin: 0 0 10px 0;
-}
+// .intro {
+//   margin: 0 0 10px 0;
+// }
 
 /* Main marketing message and sign up button */
 // #content-block > h3:first-child {


### PR DESCRIPTION
Background: makes layout less bloated for Dashboard and signup, more in line with login and home pages

bloated vs tighter spacing register: 
<img width="400" alt="Screenshot 2019-11-22 at 12 21 01" src="https://user-images.githubusercontent.com/30963614/69422008-de6dac00-0d22-11ea-9cf9-1a71edc994a6.png">
<img width="400" alt="Screenshot 2019-11-22 at 12 18 36" src="https://user-images.githubusercontent.com/30963614/69422007-dca3e880-0d22-11ea-97ea-e8d14437c852.png">

bloated vs tighter spacing dashboard: 
<img width="400" alt="Screenshot 2019-11-22 at 12 21 54" src="https://user-images.githubusercontent.com/30963614/69422188-605dd500-0d23-11ea-95f4-09fa06d328ba.png">
<img width="400" alt="Screenshot 2019-11-22 at 12 21 38" src="https://user-images.githubusercontent.com/30963614/69422176-589e3080-0d23-11ea-93ed-fb6220be3a8a.png">