### PR TITLE
Fixes styling of overlapping h3 header 

### DIFF
--- a/src/style/DashboardMain.scss
+++ b/src/style/DashboardMain.scss
@@ -158,15 +158,7 @@ h1.banner-tagline {
 }
 
 h3.verify-identity-header {
-  font-family: "ProximaNova-Bold";
-  margin-top: 0;
-  line-height: 1.2;
-  font-size: 22px;
-  padding-bottom: 0;
-  margin-bottom: 0;
-  margin-top: 53px;
-  position: absolute;
-  top: 100px;
+  margin-top: 0px;
 }
 
 #verify-identity-container label {


### PR DESCRIPTION
#### Description:
Fixed styling of h3 headers so they don't overlap with other text as per the image (seen on in Change Password and Verify Identity pages)
<img width="1397" alt="Screenshot 2019-12-11 at 10 13 22" src="https://user-images.githubusercontent.com/30963614/70617077-170cf100-1c10-11ea-9832-6ae3f48c908f.png">



#### For reviewer:
- [x] Read the above description
- [x] Reviewed the code changes
- [x] Navigate to the branch (pulled the latest version)
- [x] Run the code and been able to execute the expected function

