### PR TITLE
Set publicPath dynamically if the bundle-version cookie is set

### DIFF
--- a/src/entry-points/dashboard.js
+++ b/src/entry-points/dashboard.js
@@ -1,3 +1,4 @@
+import './public-path';
 import "babel-polyfill";
 
 // Polyfill for Element.closest for IE9+

--- a/src/entry-points/public-path.js
+++ b/src/entry-points/public-path.js
@@ -1,0 +1,7 @@
+import Cookies from "js-cookie";
+
+let cookie = Cookies.get('bundle-version');
+if (cookie) {
+  let current_public_path = new URL(__webpack_public_path__);
+  __webpack_public_path__ = current_public_path.origin + '/' + cookie + current_public_path.pathname;
+}


### PR DESCRIPTION
#### Description:
This PR inserts the cookie value of the bundle-version cookie between the host and the path configured as webpacks publicPath.

No cookie:
http://html.eduid.docker/static/front-build/1fafbdf8698be516791daafcbfef5104.ttf

bundle-version=beta1
http://html.eduid.docker/beta1/static/front-build/1fafbdf8698be516791daafcbfef5104.ttf

#### For reviewer:
- [x] Read the above description
- [x] Reviewed the code changes
- [x] Navigate to the branch (pulled the latest version)
- [x] Run the code and been able to execute the expected function
- [x] Check any styling on both desktop and mobile sizes

