### PR TITLE
Adds href to help/FAQ link in footer

### DIFF
--- a/src/containers/Footer.js
+++ b/src/containers/Footer.js
@@ -17,7 +17,7 @@ const mapStateToProps = (state, props) => {
     language: state.intl.locale,
     languages: languages,
     reload_to: state.config.DASHBOARD_URL,
-    faq_link: state.config.faq_link
+    faq_link: state.config.static_faq_url
   };
 };
 
@@ -44,9 +44,6 @@ const mapDispatchToProps = (dispatch, props) => {
   };
 };
 
-const FooterContainer = connect(
-  mapStateToProps,
-  mapDispatchToProps
-)(Footer);
+const FooterContainer = connect(mapStateToProps, mapDispatchToProps)(Footer);
 
 export default i18n(FooterContainer);


### PR DESCRIPTION
#### Description: The Help/FAQ link in the footer is a dead link.
- Updates the naming of the faq link in the container to match the name in the store

:warning: **Users will be navigated to the Swedish FAQ regardless of what language is set in the dashboard. Users will then have to scroll to the bottom of the FAQ to change the language.**

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

