### PR TITLE
Apparently importing public-path in plugin-common did not cut it

### DIFF
--- a/plugins/eduid_action.mfa/index.js
+++ b/plugins/eduid_action.mfa/index.js
@@ -1,3 +1,4 @@
+import './public-path';
 try {
   require("entry-points/plugin-common");
 } catch (error) {

--- a/plugins/eduid_action.mfa/public-path.js
+++ b/plugins/eduid_action.mfa/public-path.js
@@ -1,0 +1,7 @@
+import Cookies from "js-cookie";
+
+let cookie = Cookies.get('bundle-version');
+if (cookie) {
+  let current_public_path = new URL(__webpack_public_path__);
+  __webpack_public_path__ = current_public_path.origin + '/' + cookie + current_public_path.pathname;
+}

--- a/plugins/eduid_action.tou/index.js
+++ b/plugins/eduid_action.tou/index.js
@@ -1,3 +1,4 @@
+import './public-path';
 try {
   require("entry-points/plugin-common");
 } catch (error) {

--- a/plugins/eduid_action.tou/public-path.js
+++ b/plugins/eduid_action.tou/public-path.js
@@ -1,0 +1,7 @@
+import Cookies from "js-cookie";
+
+let cookie = Cookies.get('bundle-version');
+if (cookie) {
+  let current_public_path = new URL(__webpack_public_path__);
+  __webpack_public_path__ = current_public_path.origin + '/' + cookie + current_public_path.pathname;
+}

--- a/src/entry-points/plugin-common.js
+++ b/src/entry-points/plugin-common.js
@@ -1,4 +1,3 @@
-import './public-path';
 import "babel-polyfill";
 
 // Polyfill for Element.closest for IE9+


### PR DESCRIPTION
#### Description:
Apparently importing public-path in plugin-common did not cut it. If there is a better way to achieve a "direct import" than triplicating the public-path.js file, please advise :)

I should say that I tried require("entry-points/public-path") but it did not change the path.

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

