### PR TITLE
disable change password button when form not ready

### DIFF
--- a/src/components/ChangePasswordForm.js
+++ b/src/components/ChangePasswordForm.js
@@ -26,7 +26,7 @@ const validate = (values, props) => {
   if (!values[pwFieldOldName]) {
     errors[pwFieldOldName] = "required";
   }
-  if (values.hasOwnProperty(pwFieldCustomName)) {
+  if (props.registeredFields && !props.registeredFields.hasOwnProperty(pwFieldSuggestedName)) {
     if (!values[pwFieldCustomName]) {
       errors[pwFieldCustomName] = "required";
     } else if (props.custom_ready) {
@@ -163,6 +163,7 @@ class ChangePasswordForm extends Component {
           <EduIDButton
             id="chpass-button"
             className="settings-button ok-button"
+            disabled={this.props.submitting || this.props.pristine || this.props.invalid}
             onClick={this.props.handleStartPasswordChange.bind(this)}
           >
             {this.props.l10n("chpass.button_save_password")}


### PR DESCRIPTION
#### Description:
Disable the button in the password change form when the form is invalid

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

