### PR TITLE
Eperez login app 11 1

### DIFF
--- a/src/components/ChangePassword.js
+++ b/src/components/ChangePassword.js
@@ -10,9 +10,13 @@ import ChangePasswordForm from "./ChangePasswordForm";
 import DashboardNav from "./DashboardNav";
 
 import "style/ChangePassword.scss";
+
+
 class ChangePassword extends Component {
-  componentWillMount() {
-    this.props.loadZxcvbn();
+
+  constructor(props) {
+    super(props);
+    props.loadZxcvbn();
   }
 
   render() {

--- a/src/components/ChangePasswordForm.js
+++ b/src/components/ChangePasswordForm.js
@@ -185,14 +185,35 @@ ChangePasswordForm = reduxForm({
   validate
 })(ChangePasswordForm);
 
-ChangePasswordForm = connect(state => {
+
+const mapStateToProps = (state, props) => {
   const initialValues = {};
-  initialValues[pwFieldSuggestedName] = state.chpass.suggested_password;
+  const suggested = state.chpass ? state.chpass.suggested_password : state.config.suggested_password;
+  initialValues[pwFieldSuggestedName] = suggested;
   return {
     initialValues: initialValues,
     enableReinitialize: true
   };
-})(ChangePasswordForm);
+};
+
+const mapDispatchToProps = (dispatch, props) => {
+  return {
+    loadZxcvbn: function() {
+      return new Promise(resolve => {
+        require.ensure([], () => {
+          const module = require("zxcvbn");
+          dispatch(actions.setZxcvbn(module));
+          resolve();
+        });
+      });
+    }
+  };
+};
+
+ChangePasswordForm = connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ChangePasswordForm);
 
 ChangePasswordForm = i18n(ChangePasswordForm);
 

--- a/src/components/ChangePasswordForm.js
+++ b/src/components/ChangePasswordForm.js
@@ -26,7 +26,7 @@ const validate = (values, props) => {
   if (!values[pwFieldOldName]) {
     errors[pwFieldOldName] = "required";
   }
-  if (values.hasOwnProperty(pwFieldCustomName)) {
+  if (props.registeredFields && !props.registeredFields.hasOwnProperty(pwFieldSuggestedName)) {
     if (!values[pwFieldCustomName]) {
       errors[pwFieldCustomName] = "required";
     } else if (props.custom_ready) {
@@ -163,6 +163,7 @@ class ChangePasswordForm extends Component {
           <EduIDButton
             id="chpass-button"
             className="settings-button ok-button"
+            disabled={this.props.submitting || this.props.pristine || this.props.invalid}
             onClick={this.props.handleStartPasswordChange.bind(this)}
           >
             {this.props.l10n("chpass.button_save_password")}

--- a/src/components/ChangePasswordForm.js
+++ b/src/components/ChangePasswordForm.js
@@ -199,6 +199,9 @@ const mapStateToProps = (state, props) => {
 const mapDispatchToProps = (dispatch, props) => {
   return {
     loadZxcvbn: function() {
+      // The zxcvbn module is quite heavy, so we only load it if necessary (i.e., if the password change
+      // form is visited). Here we load it and send it in an action to the central strore, from which
+      // components that need it can grab it.
       return new Promise(resolve => {
         require.ensure([], () => {
           const module = require("zxcvbn");

--- a/src/login/LoginMain/LoginMain_reducer.js
+++ b/src/login/LoginMain/LoginMain_reducer.js
@@ -1,4 +1,5 @@
 import * as actions from "login/LoginMain/LoginMain_actions";
+import * as chpass_actions from "actions/ChangePassword";
 
 
 const loginData = {
@@ -37,6 +38,11 @@ let loginReducer = (state = loginData, action) => {
         ...state,
         ...action.payload,
         // is_fetching: false
+      };
+    case chpass_actions.SET_ZXCVBN:
+      return {
+        ...state,
+        zxcvbn_module: action.payload.module
       };
     default:
       //if (action.type.endsWith("_SUCCESS") || action.type.endsWith("_FAIL")) {


### PR DESCRIPTION
#### Description:
Small PR preparing the password change form to be reused resetting the password.
- Load the zxcvbn module when the password change form is rendered;
- Properly disable the submit button when the form is not valid

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

