### PR TITLE
Mobile fix: Button text too big on smallest screen (Iphone 5/SE, 320x568)

### DIFF
--- a/src/login/styles/_buttons.scss
+++ b/src/login/styles/_buttons.scss
@@ -159,8 +159,11 @@ button.btn-link {
 }
 
 @media (max-width: 414px) {
-  button.btn.btn-primary,
-  button.btn.btn-secondary {
+  button.btn {
+    font-size: 0.9rem;
+  }
+  button.btn-primary,
+  button.btn-secondary {
     width: 100%;
   }
   button.btn.btn-link,

--- a/src/style/EduIDButton.scss
+++ b/src/style/EduIDButton.scss
@@ -252,6 +252,9 @@ button.eduid-button.btn-warning {
 }
 
 @media (max-width: 414px) {
+  button.btn {
+    font-size: 0.9rem;
+  }
   button.btn-primary,
   button.btn-secondary {
     width: 100%;


### PR DESCRIPTION
#### Description: 
One remaining button still has overflowing text in the Swe translation (as described in [issue 222](https://github.com/SUNET/eduid-front/issues/222)).

Screenshots of issue and fix:
<img width="150" alt="Screenshot 2020-03-16 at 10 02 11" src="https://user-images.githubusercontent.com/30963614/76741310-a249d580-676f-11ea-838f-54050b7619e1.png">      <img width="150" alt="Screenshot 2020-03-16 at 10 03 41" src="https://user-images.githubusercontent.com/30963614/76741322-a8d84d00-676f-11ea-8b0e-7dbdbb897147.png">

**Summary**: 
- `font-size: 0.9rem` on all buttons at screen sizes below 414px
- This fix has been added to two files:  
    - *src/style/EduIDButton.scss:* which currently is controlling the styling of this (and most) buttons 
    - *src/login/styles/_buttons.scss:* in preparation for the future when all buttons will be styled from here 

---

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes (complete GitHub review!) 
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
###### If labelled with styling:
- [ ] Check any styling on both desktop and mobile sizes
###### If labelled with copy:
- [ ] Check that text does not overflow elements in both Eng and Swe 