### PR TITLE
Mobile fixes: Reduces spacing in the Profile (issue #220)

### DIFF
--- a/src/style/DashboardMain.scss
+++ b/src/style/DashboardMain.scss
@@ -431,7 +431,7 @@ a#go-to-mobiles-tab {
 
   #dashboard-nav {
     width: 75%;
-    margin: 20px auto;
+    // margin: 20px auto;
   }
   #dashboard-nav.nav-back {
     max-width: 75%;
@@ -465,7 +465,12 @@ a#go-to-mobiles-tab {
   #profile-detail-grid {
     width: calc(100% - 30px);
     grid-template-columns: 100%;
+    grid-row-gap: 0;
+    grid-column-gap: 0;
     padding: 0 20px;
+  }
+  #profile-container {
+    margin: 0 0 2rem 0;
   }
   #profile-prompt span {
     max-width: 100%;
@@ -478,13 +483,17 @@ a#go-to-mobiles-tab {
   #dashboard-nav.nav-back {
     max-width: calc(100% - 15px);
     padding: 0;
+    margin: 0;
   }
 }
 
-@media (max-width: 414px) {
+@media (max-width: 568px) {
   #dashboard-nav ul {
     display: grid;
     grid-template-columns: auto;
+  }
+   #profile-container {
+    margin: -2rem 0 2rem 0;
   }
   #dashboard-nav.nav-back {
     max-width: calc(100% - 15px);

--- a/src/style/Nins.scss
+++ b/src/style/Nins.scss
@@ -175,5 +175,6 @@
   }
   #nin-number {
     font-size: 32px;
+    line-height: 1.2;
   }
 }


### PR DESCRIPTION
#### Description:
Large spacing between data listed in profile: name, national identity number, email address and phone number (as described in [issue 220](https://github.com/SUNET/eduid-front/issues/220)). 

> Note: This only fixes this issue in mobile (`max-width: 786px`) as I have deemed that to be more urgent than nay other format. I am aware that any large and awkward spacing also needs to be addressed in desktop at a later stage.

issue and fix: 
<img width="150" alt="Screenshot 2020-03-16 at 16 21 05" src="https://user-images.githubusercontent.com/30963614/76773114-3896ef00-67a2-11ea-8fe2-3d2f7ed0da74.png"> <img width="150" alt="Screenshot 2020-03-16 at 15 17 15" src="https://user-images.githubusercontent.com/30963614/76771305-6fb7d100-679f-11ea-92bc-c52a06c5fd4e.png">

**Summary:** 
- narrowed space between the data elements (`grid-row-gap` and `grid-column-gap` to 0)
- narrowed the line height of the actual data (from `line-height: 1.5` to `line-height: 1.2`)
- reduced the space around the nav (removed `margin: 20px 0` ) and made the nav stack at a wider screen width (from `414px` to `568px`)

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

