### PR TITLE
Modal from reactstrap has no handleConfirm prop

### DIFF
--- a/src/components/ConfirmModal.js
+++ b/src/components/ConfirmModal.js
@@ -38,7 +38,6 @@ class ConfirmModal extends Component {
         <Modal
           id="confirm-user-data-modal"
           isOpen={this.props.showModal}
-          handleConfirm={this.props.handleConfirm}
         >
           <ModalHeader>{this.props.title}</ModalHeader>
           <ModalBody>


### PR DESCRIPTION
#### Description:
The `Modal` component from reactstrap does not have a handleConfirm prop. 

#### For reviewer:
- [x] Read the above description
- [x] Reviewed the code changes
- [x] Navigate to the branch (pulled the latest version)
- [x] Run the code and been able to execute the expected function
- [x] Check any styling on both desktop and mobile sizes

