### PR TITLE
Hides opt-in beta link 

### DIFF
--- a/src/components/DashboardMain.js
+++ b/src/components/DashboardMain.js
@@ -59,9 +59,9 @@ class Main extends Component {
       <SplashContainer key="0" />,
       <Router key="1" history={history}>
         <div className="dashboard-wrapper">
-          <a id="stable-link" href="/feature/no-beta">
+          {/* <a id="stable-link" href="/feature/no-beta">
             {this.props.translate("beta-link.to-stable")}
-          </a>
+          </a> */}
           <HeaderContainer {...this.props} />
           <div id="dashboard-text">
             <div id="welcome">

--- a/src/components/DashboardMain.js
+++ b/src/components/DashboardMain.js
@@ -59,9 +59,9 @@ class Main extends Component {
       <SplashContainer key="0" />,
       <Router key="1" history={history}>
         <div className="dashboard-wrapper">
-          {/* <a id="stable-link" href="/feature/no-beta">
+          <a id="stable-link" className="hidden" href="/feature/no-beta">
             {this.props.translate("beta-link.to-stable")}
-          </a> */}
+          </a> 
           <HeaderContainer {...this.props} />
           <div id="dashboard-text">
             <div id="welcome">

--- a/src/style/base.scss
+++ b/src/style/base.scss
@@ -179,6 +179,10 @@ small,
   font-weight: 700;
 }
 
+#stable-link .hidden {
+  display: none;
+}
+
 // .intro {
 //   margin: 0 0 10px 0;
 // }


### PR DESCRIPTION
#### Description: Hides opt-in link upon launch of new design

<img width="1017" alt="Screenshot 2020-04-08 at 11 32 59" src="https://user-images.githubusercontent.com/30963614/78779660-94b5f300-799d-11ea-9332-73dfcbddd9fd.png">

Summary: 
 - adds a class to link with `display: none` 


#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

