### PR TITLE
Actually hides opt-in beta link

### DIFF
--- a/src/style/base.scss
+++ b/src/style/base.scss
@@ -179,7 +179,7 @@ small,
   font-weight: 700;
 }
 
-#stable-link .hidden {
+#stable-link.hidden {
   display: none;
 }
 


### PR DESCRIPTION
#### Description: Hides opt-in link upon launch of new design

<img width="1017" alt="Screenshot 2020-04-08 at 11 32 59" src="https://user-images.githubusercontent.com/30963614/78795949-f1250c80-79b5-11ea-8333-deccfd5edc23.png">

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

