### PR TITLE
Fixes broken styling on Register page

### DIFF
--- a/src/components/Email.js
+++ b/src/components/Email.js
@@ -8,7 +8,7 @@ import {
   Modal,
   ModalHeader,
   ModalBody,
-  ModalFooter
+  ModalFooter,
 } from "reactstrap";
 
 import EduIDButton from "components/EduIDButton";
@@ -16,7 +16,7 @@ import "style/Email.scss";
 
 /* FORM */
 
-export const validate = values => {
+export const validate = (values) => {
   const errors = {},
     email = values.email,
     pattern = /^(([^<>()\[\]\.,;:\s@\"]+(\.[^<>()\[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
@@ -28,19 +28,17 @@ export const validate = values => {
   return errors;
 };
 
-let EmailForm = props => (
-  <form id="register-input-group" onSubmit={props.handleEmail}>
-    <fieldset id="register-form">
-      <Field
-        type="email"
-        name="email"
-        componentClass="input"
-        id="email-input"
-        component={TextInput}
-        translate={props.translate}
-        placeholder="example@email.com"
-      />
-    </fieldset>
+let EmailForm = (props) => (
+  <form id="register-form" onSubmit={props.handleEmail}>
+    <Field
+      type="email"
+      name="email"
+      componentClass="input"
+      id="email-input"
+      component={TextInput}
+      translate={props.translate}
+      placeholder="example@email.com"
+    />
     <EduIDButton
       className="settings-button"
       id="register-button"
@@ -55,11 +53,11 @@ let EmailForm = props => (
 
 EmailForm = reduxForm({
   form: "emailForm",
-  validate
+  validate,
 })(EmailForm);
 
-EmailForm = connect(state => ({
-  enableReinitialize: true
+EmailForm = connect((state) => ({
+  enableReinitialize: true,
 }))(EmailForm);
 
 /* COMPONENT */
@@ -92,7 +90,7 @@ class Email extends Component {
             </EduIDButton>
           </ModalFooter>
         </Modal>
-      </div>
+      </div>,
     ];
   }
 }
@@ -102,7 +100,7 @@ Email.propTypes = {
   tou: PropTypes.string,
   translate: PropTypes.func,
   handleAccept: PropTypes.func,
-  handleReject: PropTypes.func
+  handleReject: PropTypes.func,
 };
 
 export default Email;

--- a/src/components/SignupMain.js
+++ b/src/components/SignupMain.js
@@ -15,7 +15,11 @@ import NotificationsContainer from "containers/Notifications";
 import EmailInUseContainer from "containers/EmailInUse";
 
 import "../../node_modules/bootstrap/dist/css/bootstrap.min.css";
+import "style/base.scss";
+import "style/DashboardMain.scss";
 import "style/SignupMain.scss";
+import "../login/styles/index.scss";
+import "style/Header.scss";
 
 export const history = createBrowserHistory();
 
@@ -113,7 +117,7 @@ class SignupMain extends Component {
           </div>
           <FooterContainer {...this.props} />
         </div>
-      </Router>
+      </Router>,
     ];
   }
 }

--- a/src/style/SignupMain.scss
+++ b/src/style/SignupMain.scss
@@ -18,13 +18,20 @@
   font-size: 24px;
 }
 
+#email {
+  padding: 0;
+}
+
 #register-form {
   display: flex;
-  flex: 1;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-top: 0;
 }
 
 #register-button {
-  margin-left: 10px;
+  margin-left: 1rem;
 }
 
 .form-control {
@@ -96,11 +103,20 @@
   #register-container {
     width: 75%;
   }
+  #register-form {
+    flex-direction: column;
+  }
+  #register-button {
+    margin-left: 0;
+  }
 }
 
 @media (max-width: 768px) {
   #register-container {
     width: calc(100% - 40px);
+  }
+  #register-button {
+    width: 100%;
   }
 }
 


### PR DESCRIPTION
#### Description: Imports missing stylesheets to Register page (as described in issue #269 )

**Summary:** 
- imported missing stylesheets
- adds similar styling to before break 
   - stacks input and button @ `823px`
   - button has full width @ `768px`


---
###### Signup (before and after)
<img width="300" alt="Screenshot 2020-04-17 at 11 32 06" src="https://user-images.githubusercontent.com/30963614/79560866-ad628f00-80a8-11ea-8548-865a0f182d9b.png"> <img width="300" alt="Screenshot 2020-04-17 at 13 50 19" src="https://user-images.githubusercontent.com/30963614/79566172-67122d80-80b2-11ea-89f6-30b33dfb712a.png">

---

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

