### PR TITLE
Fix for mobile vetting (following change in css import for DashboardMain)

### DIFF
--- a/src/sagas/LookupMobileProofing.js
+++ b/src/sagas/LookupMobileProofing.js
@@ -5,23 +5,24 @@ import {
   putCsrfToken,
   postRequest,
   saveData,
-  failRequest
+  failRequest,
 } from "sagas/common";
 import { postLookupMobileFail } from "actions/LookupMobileProofing";
 import * as ninActions from "actions/Nins";
 
 export function* requestLookupMobileProof() {
   try {
-    const state = yield select(state => state),
-      // input = document.getElementsByName("nin")[0],
-      unconfirmed = document.getElementById("nin-number"),
-      // console.log("this is unconfirmed", unconfirmed);
-      // nin = input ? input.value : unconfirmed ? state.nins.nin : "testing",
-      nin = unconfirmed ? state.nins.nin : "testing",
-      data = {
-        nin: nin,
-        csrf_token: state.config.csrf_token
-      };
+    const state = yield select((state) => state);
+    // input = document.getElementsByName("nin")[0],
+    const unconfirmed = document.querySelector(".display-data").parentElement
+      .dataset.ninnumber;
+    // console.log("this is unconfirmed", unconfirmed);
+    // nin = input ? input.value : unconfirmed ? state.nins.nin : "testing",
+    const nin = unconfirmed ? state.nins.nin : "testing";
+    const data = {
+      nin: nin,
+      csrf_token: state.config.csrf_token,
+    };
 
     const lookupMobileData = yield call(
       fetchLookupMobileProof,
@@ -40,20 +41,21 @@ export function fetchLookupMobileProof(config, data) {
   return window
     .fetch(url, {
       ...postRequest,
-      body: JSON.stringify(data)
+      body: JSON.stringify(data),
     })
     .then(checkStatus)
-    .then(response => response.json());
+    .then((response) => response.json());
 }
-const getData = state => {
+const getData = (state) => {
   // const input = document.getElementsByName("nin")[0],
   // unconfirmed = document.getElementById("eduid-unconfirmed-nin"),
-  const unconfirmed = document.getElementById("nin-number"),
-    // nin = input ? input.value : unconfirmed ? state.nins.nin : "testing";
-    nin = unconfirmed ? state.nins.nin : "testing";
+  const unconfirmed = document.querySelector(".display-data").parentElement
+    .dataset.ninnumber;
+  // nin = input ? input.value : unconfirmed ? state.nins.nin : "testing";
+  const nin = unconfirmed ? state.nins.nin : "testing";
   return {
     nin: nin,
-    csrf_token: state.config.csrf_token
+    csrf_token: state.config.csrf_token,
   };
 };
 


### PR DESCRIPTION
#### Description: The vetting through phone number can no longer find the nin in the DOM after removal of an id during the css cleanup

**Summary:** 
- DOM traversal now relies: 
      - on the one class used for the number
      - the data-attribute in the parent <div>

---

###### Verify Identity (verified nin)
<img width="300" alt="Screenshot 2020-04-24 at 14 30 10" src="https://user-images.githubusercontent.com/30963614/80213134-04340f80-8639-11ea-8341-817f51f92dd4.png">

----

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

