### PR TITLE
Fix for mobile vetting (following change in css import for DashboardMain) 

### DIFF
--- a/src/components/NinDisplay.js
+++ b/src/components/NinDisplay.js
@@ -30,8 +30,12 @@ export class NinDisplay extends Component {
       } else {
         if (url.includes("verify-identity")) {
           userData = [
-            <div key="0" data-ninnumber={this.props.nins[0].number} className="data-with-delete">
-              <p key="1" className="display-data unverified">
+            <div
+              key="0"
+              data-ninnumber={this.props.nins[0].number}
+              className="data-with-delete"
+            >
+              <p key="1" id="nin-number" className="display-data unverified">
                 {this.props.nins[0].number}
               </p>
               <EduIDButton


### PR DESCRIPTION
#### Description: The vetting through phone number can no longer find the nin in the DOM after removal of an id during the css cleanup

**Summary:**
- id `nin-number` added in on `<p>` holding the user nin 

---
###### Verify Identity (verified nin)
<img width="300" alt="Screenshot 2020-04-24 at 16 30 47" src="https://user-images.githubusercontent.com/30963614/80224096-86c4cb00-8649-11ea-95fc-20dcb36b5f90.png">

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

