### PR TITLE
Fix for validation of save button (when password is suggested)

### DIFF
--- a/src/components/ChangePasswordForm.js
+++ b/src/components/ChangePasswordForm.js
@@ -122,10 +122,16 @@ class ChangePasswordForm extends Component {
       );
     } else {
       form = (
-        <Fragment>
-          <label>{this.props.translate("chpass.suggested_password")}</label>
-          <p id="suggested-password">{this.props.suggested_password}</p>
-        </Fragment>
+        <Field
+          className="suggetsed-password"
+          component={TextInput}
+          componentClass="input"
+          type="text"
+          name={pwFieldSuggestedName}
+          id={pwFieldSuggestedName}
+          label={this.props.translate("chpass.suggested_password")}
+          disabled={true}
+        />
       );
       button = (
         <EduIDButton

--- a/src/tests/ChangePasswordForm-test.js
+++ b/src/tests/ChangePasswordForm-test.js
@@ -60,7 +60,9 @@ describe("ChangePasswordForm renders", () => {
   it("old and new password inputs render", () => {
     const { wrapper } = setupComponent();
     const oldPwInput = wrapper.find("input[name='old-password-field']");
-    const suggestedPwInput = wrapper.find("#suggested-password");
+    const suggestedPwInput = wrapper.find(
+      "input[name='suggested-password-field']"
+    );
     expect(oldPwInput.exists()).toEqual(true);
     expect(suggestedPwInput.exists()).toEqual(true);
   });


### PR DESCRIPTION
#### Description: Disabling of "Save" button is dependent on a value in the "current password" input and the presence of a `pwFieldSuggestedName` input.

**Summary**:
- Display of a suggested value has been reverted back to a disabled input

--- 
###### Change password: suggested password (before and after)
<img width="300" alt="Screenshot 2020-04-23 at 16 55 42" src="https://user-images.githubusercontent.com/30963614/80362649-4486ce00-8883-11ea-80dc-315f755fd3f3.png"> <img width="300" alt="Screenshot 2020-04-27 at 12 28 32" src="https://user-images.githubusercontent.com/30963614/80362565-2325e200-8883-11ea-9be4-6ef238eb4280.png">

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

