### PR TITLE
Fix for broken security key table 

### DIFF
--- a/i18n/src/login/translation/defaultMessages/errors.json
+++ b/i18n/src/login/translation/defaultMessages/errors.json
@@ -1,0 +1,166 @@
+[
+  {
+    "id": "unexpected-success",
+    "defaultMessage": "Success"
+  },
+  {
+    "id": "out_of_sync",
+    "defaultMessage": "User data is out of sync. Reload page to re-sync."
+  },
+  {
+    "id": "required",
+    "defaultMessage": "Field cannot be empty"
+  },
+  {
+    "id": "user-out-of-sync",
+    "defaultMessage": "User data is out of sync. Reload page to re-sync."
+  },
+  {
+    "id": "Missing error message",
+    "defaultMessage": "Missing error message"
+  },
+  {
+    "id": "Temporary technical problems",
+    "defaultMessage": "Temporary technical problems, please try again later"
+  },
+  {
+    "id": "unexpected-problem",
+    "defaultMessage": "There was an unexpected problem servicing your request, please try again or contact the site administrators"
+  },
+  {
+    "id": "code.unknown-code",
+    "defaultMessage": "Unknown verification code"
+  },
+  {
+    "id": "error_navet_task",
+    "defaultMessage": "Communication problem with Navet"
+  },
+  {
+    "id": "error_lookup_mobile_task",
+    "defaultMessage": "Your phone number could not be found in the registry. Please try another method."
+  },
+  {
+    "id": "Error: Gateway Time-out",
+    "defaultMessage": "The remote service is taking too long to respond, please try again"
+  },
+  {
+    "id": "No connection to authorization endpoint",
+    "defaultMessage": "No connection to authorization endpoint, please try again later"
+  },
+  {
+    "id": "CSRF failed to validate",
+    "defaultMessage": "CSRF failed to validate, please reload the page"
+  },
+  {
+    "id": "csrf.try-again",
+    "defaultMessage": "There was a problem with your submission, please try again"
+  },
+  {
+    "id": "Error: NOT FOUND",
+    "defaultMessage": "There was an error (404) servicing your request. The administrator has been alerted. Please try again later."
+  },
+  {
+    "id": "Error: Internal Server Error",
+    "defaultMessage": "There was an error (500) servicing your request. The administrator has been alerted. Please try again later."
+  },
+  {
+    "id": "Error: Service Unavailable",
+    "defaultMessage": "Service Unavailable. Check your internet connection."
+  },
+  {
+    "id": "error_in_form",
+    "defaultMessage": "Check the form below for errors."
+  },
+  {
+    "id": "Missing data for required field.",
+    "defaultMessage": "Missing data for required field"
+  },
+  {
+    "id": "Not a valid email address.",
+    "defaultMessage": "Not a valid email address."
+  },
+  {
+    "id": "email.invalid_email",
+    "defaultMessage": "The entered email is invalid"
+  },
+  {
+    "id": "eidas.error_missing_nin",
+    "defaultMessage": "Please add a national identity number and try again"
+  },
+  {
+    "id": "eidas.error_unknown_error",
+    "defaultMessage": "Temporary technical difficulties, please try again later"
+  },
+  {
+    "id": "oc.error_missing_nin",
+    "defaultMessage": "Please add a national identity number and try again"
+  },
+  {
+    "id": "oc.error_unknown_error",
+    "defaultMessage": "Temporary technical difficulties, please try again later"
+  },
+  {
+    "id": "ocf.error_missing_nin",
+    "defaultMessage": "Please add a national identity number and try again"
+  },
+  {
+    "id": "ocf.error_unknown_error",
+    "defaultMessage": "Temporary technical difficulties, please try again later"
+  },
+  {
+    "id": "mfa.no-webauthn-support",
+    "defaultMessage": "No support for security keys"
+  },
+  {
+    "id": "mfa.no-webauthn-support-text",
+    "defaultMessage": "You have registered a security key for authentication, but this browser does not support them. Please use another browser to use your security keys."
+  },
+  {
+    "id": "mfa.freja-eid",
+    "defaultMessage": "Use Freja eID instead"
+  },
+  {
+    "id": "mfa.problems-heading",
+    "defaultMessage": "Problems?"
+  },
+  {
+    "id": "mfa.error-getting-token",
+    "defaultMessage": "There was a problem using your security key"
+  },
+  {
+    "id": "mfa.edge-no-u2f",
+    "defaultMessage": "There is a problem with the Edge browser and U2F security keys. Please try with Firefox or Chrome."
+  },
+  {
+    "id": "security.u2f_registration_error_unknown",
+    "defaultMessage": "U2F error: Unknown error"
+  },
+  {
+    "id": "security.u2f_registration_error_bad",
+    "defaultMessage": "U2F error: Bad request"
+  },
+  {
+    "id": "security.u2f_registration_error_unsupported",
+    "defaultMessage": "U2F error: Configuration unsupported"
+  },
+  {
+    "id": "security.u2f_registration_error_device",
+    "defaultMessage": "U2F error: Device ineligible"
+  },
+  {
+    "id": "security.u2f_registration_error_timeout",
+    "defaultMessage": "U2F error: Timeout"
+  },
+  {
+    "id": "security.u2f_registration_error_code",
+    "defaultMessage": "U2F failed with error code: {errorCode}"
+  },
+  {
+    "id": "signup.recaptcha-not-verified",
+    "defaultMessage": "There was a problem verifying that you are a human. Please try again"
+  },
+  {
+    "id": "mail_duplicated",
+    "defaultMessage": "Added email is duplicated"
+  }
+]

--- a/i18n/src/login/translation/defaultMessages/generalApp.json
+++ b/i18n/src/login/translation/defaultMessages/generalApp.json
@@ -1,0 +1,106 @@
+[
+  {
+    "id": "header.signup",
+    "defaultMessage": "SIGN UP"
+  },
+  {
+    "id": "header.signin",
+    "defaultMessage": "Log in"
+  },
+  {
+    "id": "header.faq",
+    "defaultMessage": "Help"
+  },
+  {
+    "id": "header.logout",
+    "defaultMessage": "Logout"
+  },
+  {
+    "id": "main.welcome",
+    "defaultMessage": "Welcome to eduID"
+  },
+  {
+    "id": "banner.tagline",
+    "defaultMessage": "eduID is easier and safer login."
+  },
+  {
+    "id": "main.copyright",
+    "defaultMessage": "SUNET 2013-2019"
+  },
+  {
+    "id": "beta-link.to-stable",
+    "defaultMessage": "The new eduID is under development, click here to go back to the stable version"
+  },
+  {
+    "id": "foot.change-version-tip",
+    "defaultMessage": "This is an experimental version. If you experience any problem while using the app, you can switch to the old version."
+  },
+  {
+    "id": "button_save",
+    "defaultMessage": "Save"
+  },
+  {
+    "id": "button_add",
+    "defaultMessage": "Add"
+  },
+  {
+    "id": "mfa.fake-authn",
+    "defaultMessage": "Fake authn while testing"
+  },
+  {
+    "id": "mfa.two-factor-authn",
+    "defaultMessage": "Two-factor authentication"
+  },
+  {
+    "id": "mfa.extra-security-enabled",
+    "defaultMessage": "Extra security enabled for this account"
+  },
+  {
+    "id": "mfa.login-tapit",
+    "defaultMessage": "Use your security key to log in. If it has a button, tap it."
+  },
+  {
+    "id": "actions.action-completed",
+    "defaultMessage": "Success"
+  },
+  {
+    "id": "cm.ok",
+    "defaultMessage": "OK"
+  },
+  {
+    "id": "cm.finish",
+    "defaultMessage": "FINISH"
+  },
+  {
+    "id": "cm.cancel",
+    "defaultMessage": "CANCEL"
+  },
+  {
+    "id": "cm.accept",
+    "defaultMessage": "ACCEPT"
+  },
+  {
+    "id": "cm.close",
+    "defaultMessage": "CLOSE"
+  },
+  {
+    "id": "cm.enter_code",
+    "defaultMessage": "Enter your confirmation code below"
+  },
+  {
+    "id": "still-valid-code",
+    "defaultMessage": "You have recently been sent a verification code. Please wait at least 5 minutes to request a new one."
+  },
+  {
+    "id": "tl.primary",
+    "defaultMessage": "PRIMARY"
+  },
+  {
+    "id": "tl.make_primary",
+    "defaultMessage": "MAKE PRIMARY"
+  },
+  {
+    "id": "tl.pending",
+    "defaultMessage": "confirm"
+  }
+]

--- a/i18n/src/login/translation/defaultMessages/instructions.json
+++ b/i18n/src/login/translation/defaultMessages/instructions.json
@@ -1,0 +1,30 @@
+[
+  {
+    "id": "faq_link",
+    "defaultMessage": "For more information see the"
+  },
+  {
+    "id": "resend.link-sent",
+    "defaultMessage": "A link has been sent to your email address."
+  },
+  {
+    "id": "resend.email-label",
+    "defaultMessage": "Complete registration by clicking the link sent to:"
+  },
+  {
+    "id": "resend.button",
+    "defaultMessage": "Send a new confirmation link"
+  },
+  {
+    "id": "signup.verification-resent",
+    "defaultMessage": "Verification email resent"
+  },
+  {
+    "id": "signup.registering-resend-code",
+    "defaultMessage": "Verification email resent"
+  },
+  {
+    "id": "mfa.try-again",
+    "defaultMessage": "Try again"
+  }
+]

--- a/i18n/src/login/translation/defaultMessages/password.json
+++ b/i18n/src/login/translation/defaultMessages/password.json
@@ -1,0 +1,142 @@
+[
+  {
+    "id": "chpass.help-text-general",
+    "defaultMessage": "You can change your current password using this form. A strong password has been generated for you. You can accept the generated password by clicking \"Change password\" or you can opt to choose your own password using the checkbox."
+  },
+  {
+    "id": "chpass.main_title",
+    "defaultMessage": "Change your current password"
+  },
+  {
+    "id": "chpass.old_password",
+    "defaultMessage": "Current password"
+  },
+  {
+    "id": "chpass.suggested_password",
+    "defaultMessage": "Suggested password"
+  },
+  {
+    "id": "chpass.button_custom_password",
+    "defaultMessage": "I don't want a suggested password"
+  },
+  {
+    "id": "chpass.form_custom_password",
+    "defaultMessage": "Enter new password"
+  },
+  {
+    "id": "chpass.form_custom_password_repeat",
+    "defaultMessage": "Repeat new password"
+  },
+  {
+    "id": "chpass.button_suggest_password",
+    "defaultMessage": "Suggest a password for me"
+  },
+  {
+    "id": "chpass.button_save_password",
+    "defaultMessage": "Save"
+  },
+  {
+    "id": "chpass.no_old_pw",
+    "defaultMessage": "Please enter your old password"
+  },
+  {
+    "id": "chpass.no_reauthn",
+    "defaultMessage": "You must re-authenticate to change your password"
+  },
+  {
+    "id": "chpass.stale_reauthn",
+    "defaultMessage": "Stale re-authentication. Please re-initiate the process."
+  },
+  {
+    "id": "chpass.stale_authn_info",
+    "defaultMessage": "Stale re-authentication. Please re-initiate the process."
+  },
+  {
+    "id": "chpass.password-changed",
+    "defaultMessage": "Your password has been changed"
+  },
+  {
+    "id": "chpass.different-repeat",
+    "defaultMessage": "The two passwords are different"
+  },
+  {
+    "id": "chpass.unable-to-verify-old-password",
+    "defaultMessage": "There were problems trying to verify your old credentials. If you are certain that they are correct, please contact the administrator"
+  },
+  {
+    "id": "chpass.low-password-entropy",
+    "defaultMessage": "Please provide a stronger password"
+  },
+  {
+    "id": "settings.main_title",
+    "defaultMessage": "Change password"
+  },
+  {
+    "id": "settings.long_description",
+    "defaultMessage": "Click the link to change your eduID password."
+  },
+  {
+    "id": "settings.change_password",
+    "defaultMessage": "Change password"
+  },
+  {
+    "id": "settings.confirm_title_chpass",
+    "defaultMessage": "For security reasons..."
+  },
+  {
+    "id": "settings.change_info",
+    "defaultMessage": "You will need to log in again to change your password."
+  },
+  {
+    "id": "pwfield.terrible",
+    "defaultMessage": "Extremely weak password"
+  },
+  {
+    "id": "pwfield.bad",
+    "defaultMessage": "Very weak password"
+  },
+  {
+    "id": "pwfield.weak",
+    "defaultMessage": "Weak password"
+  },
+  {
+    "id": "pwfield.good",
+    "defaultMessage": "Fairly strong password"
+  },
+  {
+    "id": "pwfield.strong",
+    "defaultMessage": "Strong password"
+  },
+  {
+    "id": "pwfield.repeat_different",
+    "defaultMessage": "The repeated password is different from the first"
+  },
+  {
+    "id": "used.forgot-password",
+    "defaultMessage": "Forgot your password?"
+  },
+  {
+    "id": "used.reset-password",
+    "defaultMessage": "Reset your password"
+  },
+  {
+    "id": "security.password_credential_type",
+    "defaultMessage": "Password"
+  },
+  {
+    "id": "resetpw.get-email-link_heading",
+    "defaultMessage": "Request a password reset link to your email address."
+  },
+  {
+    "id": "resetpw.get-email-link_text",
+    "defaultMessage": "Enter the email address registered to your eduID. You will be sent a link to reset your password."
+  },
+  {
+    "id": "resetpw.email-link-sent_heading",
+    "defaultMessage": "You should have recieved a link to reset your password."
+  },
+  {
+    "id": "resetpw.email-link-sent_text",
+    "defaultMessage": "Click the link in your email to reset the password for your eduID. Alternatively, you can copy the link in your email and paste it into a browser window."
+  }
+]

--- a/i18n/src/login/translation/defaultMessages/register.json
+++ b/i18n/src/login/translation/defaultMessages/register.json
@@ -1,0 +1,122 @@
+[
+  {
+    "id": "register.create-account",
+    "defaultMessage": "Sign up with your email address to start."
+  },
+  {
+    "id": "email.sign-up-email",
+    "defaultMessage": "Create eduID"
+  },
+  {
+    "id": "tou.header",
+    "defaultMessage": "General rules for eduID users"
+  },
+  {
+    "id": "tou.cancel",
+    "defaultMessage": "Cancel"
+  },
+  {
+    "id": "tou.accept",
+    "defaultMessage": "Accept"
+  },
+  {
+    "id": "tou.must-accept",
+    "defaultMessage": "You must accept the new terms of use before continuing"
+  },
+  {
+    "id": "tou.not-tou",
+    "defaultMessage": "There were problems retrieving the current ToU, please contact the site administrators."
+  },
+  {
+    "id": "captcha.one-step-left",
+    "defaultMessage": "Only one more step left!"
+  },
+  {
+    "id": "captcha.verify-human",
+    "defaultMessage": "Confirm that you are a human."
+  },
+  {
+    "id": "captcha.submit",
+    "defaultMessage": "Done"
+  },
+  {
+    "id": "captcha.cancel",
+    "defaultMessage": "Cancel"
+  },
+  {
+    "id": "created.confirm-registration",
+    "defaultMessage": "Confirm your email to log in to eduID."
+  },
+  {
+    "id": "created.email-sent",
+    "defaultMessage": "Click the confirmation link sent to {email} to be able log in to eduID"
+  },
+  {
+    "id": "created.account-created",
+    "defaultMessage": "A link has been sent to your email address."
+  },
+  {
+    "id": "created.email-label",
+    "defaultMessage": "Complete registration by clicking the link sent to:"
+  },
+  {
+    "id": "created.back_to_signup",
+    "defaultMessage": "Back to signup"
+  },
+  {
+    "id": "signup.registering-new",
+    "defaultMessage": "Email address successfully registered"
+  },
+  {
+    "id": "signup.registering-address-used",
+    "defaultMessage": "The email address you entered is already in use"
+  },
+  {
+    "id": "used.email-label",
+    "defaultMessage": "If this is your eduID, you can reset your password to log back in."
+  },
+  {
+    "id": "used.email-in-use",
+    "defaultMessage": "An eduID is already using {email}"
+  },
+  {
+    "id": "finish.registration-complete",
+    "defaultMessage": "You have completed the registration for eduID."
+  },
+  {
+    "id": "finish.registration-details",
+    "defaultMessage": "These are your login details for eduID."
+  },
+  {
+    "id": "finish.got-it",
+    "defaultMessage": "go to my eduid"
+  },
+  {
+    "id": "finish.can-now-login",
+    "defaultMessage": "You can now log in"
+  },
+  {
+    "id": "finish.sites-accept",
+    "defaultMessage": "Your account is now ready for use with sites that accept"
+  },
+  {
+    "id": "finish.unconfirmed-identities",
+    "defaultMessage": "unconfirmed identities"
+  },
+  {
+    "id": "finish.finish",
+    "defaultMessage": "FINISH"
+  },
+  {
+    "id": "finish.access-more",
+    "defaultMessage": "Access more"
+  },
+  {
+    "id": "finish.to-dashboard",
+    "defaultMessage": "To get access to additional sites that require a confirmed identity, proceed to the dashboard."
+  },
+  {
+    "id": "finish.confirm-identity",
+    "defaultMessage": "CONFIRM IDENTITY"
+  }
+]

--- a/i18n/src/login/translation/defaultMessages/userProfile.json
+++ b/i18n/src/login/translation/defaultMessages/userProfile.json
@@ -1,0 +1,906 @@
+[
+  {
+    "id": "dashboard.welcome",
+    "defaultMessage": "eduID for"
+  },
+  {
+    "id": "profile.name_display_title",
+    "defaultMessage": "Name"
+  },
+  {
+    "id": "profile.name_display_no_data",
+    "defaultMessage": "no name added"
+  },
+  {
+    "id": "profile.phone_display_title",
+    "defaultMessage": "Phone number"
+  },
+  {
+    "id": "profile.phone_display_unconfirmed_data",
+    "defaultMessage": "confirm added number"
+  },
+  {
+    "id": "profile.phone_display_non-primary_data",
+    "defaultMessage": "make number primary"
+  },
+  {
+    "id": "profile.phone_display_no_data",
+    "defaultMessage": "no phone number added"
+  },
+  {
+    "id": "profile.email_display_title",
+    "defaultMessage": "Email address"
+  },
+  {
+    "id": "profile.eppn_display_title",
+    "defaultMessage": "eppn"
+  },
+  {
+    "id": "profile.email_display_no_data",
+    "defaultMessage": "no email added"
+  },
+  {
+    "id": "dashboard.tagline_unverified",
+    "defaultMessage": "Don't forget to connect your identity to eduID"
+  },
+  {
+    "id": "dashboard.tagline_verified",
+    "defaultMessage": "Make eduID more secure"
+  },
+  {
+    "id": "dashboard_nav.profile",
+    "defaultMessage": "Profile"
+  },
+  {
+    "id": "dashboard_nav.identity",
+    "defaultMessage": "Identity"
+  },
+  {
+    "id": "dashboard_nav.settings",
+    "defaultMessage": "Settings"
+  },
+  {
+    "id": "dashboard_nav.advanced-settings",
+    "defaultMessage": "Advanced settings"
+  },
+  {
+    "id": "dashboard_nav.back",
+    "defaultMessage": "< Back"
+  },
+  {
+    "id": "verify-identity.unverified_main_title",
+    "defaultMessage": "Connect your identity to your eduID"
+  },
+  {
+    "id": "verify-identity.add-nin_heading",
+    "defaultMessage": "1. Add\n            your id number"
+  },
+  {
+    "id": "verify-identity.page-description",
+    "defaultMessage": "To be able\n            to use eduID you have to prove your identity. Add your national id number and verify it in real life."
+  },
+  {
+    "id": "verify-identity.verified_main_title",
+    "defaultMessage": "Your eduID is ready to use"
+  },
+  {
+    "id": "verify-identity.vetting_post_tagline",
+    "defaultMessage": "For those registered at their current address"
+  },
+  {
+    "id": "verify-identity.vetting_phone_tagline",
+    "defaultMessage": "For those with a phone registered in their name"
+  },
+  {
+    "id": "verify-identity.vetting_freja_tagline",
+    "defaultMessage": "For those able to create a Freja eID by visiting one of the authorised agents"
+  },
+  {
+    "id": "verify-identity.connect-nin_heading",
+    "defaultMessage": "2. Verify your id number"
+  },
+  {
+    "id": "verify-identity.connect-nin_description",
+    "defaultMessage": "Choose a method to verify that you have access to the added id number. If you are unable to use a method you need to try another."
+  },
+  {
+    "id": "letter.button_text_request",
+    "defaultMessage": "by post"
+  },
+  {
+    "id": "letter.button_text_code",
+    "defaultMessage": "Enter confirmation code here"
+  },
+  {
+    "id": "letter.initialize_proofing_help_text",
+    "defaultMessage": "The letter will contain a code that for security reasons expires in two weeks."
+  },
+  {
+    "id": "letter.no_state_found",
+    "defaultMessage": "No state found"
+  },
+  {
+    "id": "letter.letter_sent_msg",
+    "defaultMessage": "You have been sent a verification letter"
+  },
+  {
+    "id": "letter.already-sent",
+    "defaultMessage": "You have already been sent a verification letter"
+  },
+  {
+    "id": "letter.no-address-found",
+    "defaultMessage": "No postal address found"
+  },
+  {
+    "id": "letter.bad-postal-address",
+    "defaultMessage": "The registered postal address is not a valid address"
+  },
+  {
+    "id": "letter.saved-unconfirmed",
+    "defaultMessage": "A letter is on it's way to your house"
+  },
+  {
+    "id": "letter.wrong-code",
+    "defaultMessage": "Incorrect verification code"
+  },
+  {
+    "id": "letter.verification_success",
+    "defaultMessage": "Successfully verified national id number"
+  },
+  {
+    "id": "letter.modal_confirm_title",
+    "defaultMessage": "Use a confirmation code sent by post to your house"
+  },
+  {
+    "id": "letter.modal_confirm_info",
+    "defaultMessage": "The letter will contain a code that you enter here to verify your identity. The code sent to you will expire in 2 weeks starting from now"
+  },
+  {
+    "id": "letter.verify_title",
+    "defaultMessage": "Add the code you have received by post"
+  },
+  {
+    "id": "lmp.button_text_request",
+    "defaultMessage": "by phone"
+  },
+  {
+    "id": "lmp.button_text_code",
+    "defaultMessage": "Enter confirmation code here"
+  },
+  {
+    "id": "lmp.initialize_proofing_help_text",
+    "defaultMessage": "The phone number registry is maintained by phone operators at their convenience and may not include all registered phone numbers."
+  },
+  {
+    "id": "lmp.initialize_proofing_help_text_tip_1",
+    "defaultMessage": "Tip: The registry is updated by phone operators at their convenience and may not include all registered phone numbers"
+  },
+  {
+    "id": "lmp.modal_add_number_title",
+    "defaultMessage": "Add your mobile number to continue"
+  },
+  {
+    "id": "lmp.modal_add_number_info",
+    "defaultMessage": "Go to Settings to add your phone number. Do not forget to also confirm it! You can only use this option with a confirmed number!"
+  },
+  {
+    "id": "lmp.modal_reminder_to_confirm_title",
+    "defaultMessage": "Your number also needs to be confrimed"
+  },
+  {
+    "id": "lmp.modal_reminder_to_confirm_info",
+    "defaultMessage": "Go to Settings to confirm your number. You can only use this option with a confirmed number."
+  },
+  {
+    "id": "lmp.modal_confirm_title",
+    "defaultMessage": "Check if your phone number is connected to your id number."
+  },
+  {
+    "id": "lmp.confirm_info",
+    "defaultMessage": "This check will be done in a registry updated by the phone operators. If they have not added your details, we won't be able to find you and you need to choose another way to verify your identity."
+  },
+  {
+    "id": "lmp.verification_success",
+    "defaultMessage": "Your national id number has been successfully verified"
+  },
+  {
+    "id": "eidas.vetting_button_freja",
+    "defaultMessage": "with a digital ID-card"
+  },
+  {
+    "id": "eidas.initialize_proofing_help_text",
+    "defaultMessage": "To use this option you will need to first create a digital ID-card in the <a href=\"https://frejaeid.com/skaffa-freja-eid/\" target=\"_blank\">Freja eID</a> app."
+  },
+  {
+    "id": "eidas.modal_title",
+    "defaultMessage": "Use Freja eID+ and pass a local authorised agent"
+  },
+  {
+    "id": "eidas.freja_instructions_step1",
+    "defaultMessage": "Install the app"
+  },
+  {
+    "id": "eidas.freja_instructions_step2",
+    "defaultMessage": "Create a Freja eID Plus account (awarded the ‘Svensk e-legitimation’ quality mark)"
+  },
+  {
+    "id": "eidas.freja_instructions_step3",
+    "defaultMessage": "The app will generate a QR-code"
+  },
+  {
+    "id": "eidas.freja_instructions_step4",
+    "defaultMessage": "Find a local authorised agent, show them a valid ID together with the QR-code and they will be able to verify your identity"
+  },
+  {
+    "id": "eidas.freja_instructions_tip_1",
+    "defaultMessage": "Tip: Use the app to find your nearest agent"
+  },
+  {
+    "id": "eidas.freja_instructions_step5",
+    "defaultMessage": "Freja eID is now ready to be used with your eduID"
+  },
+  {
+    "id": "eidas.freja_instructions_install_link",
+    "defaultMessage": "What is Freja eID?"
+  },
+  {
+    "id": "eidas.freja_eid_ready",
+    "defaultMessage": "Use my Freja eID"
+  },
+  {
+    "id": "eidas.token_not_found",
+    "defaultMessage": "U2F token not found"
+  },
+  {
+    "id": "eidas.token_not_in_credentials_used",
+    "defaultMessage": "U2F token not used for login"
+  },
+  {
+    "id": "eidas.nin_not_matching",
+    "defaultMessage": "Asserted identity not matching the current accounts verified identity"
+  },
+  {
+    "id": "eidas.nin_already_verified",
+    "defaultMessage": "You have already verified your identity"
+  },
+  {
+    "id": "eidas.nin_verify_success",
+    "defaultMessage": "Identity verified successfully"
+  },
+  {
+    "id": "eidas.token_verify_success",
+    "defaultMessage": "U2F token verified successfully"
+  },
+  {
+    "id": "eidas.authn_context_mismatch",
+    "defaultMessage": "Wrong authentication context received"
+  },
+  {
+    "id": "eidas.reauthn_expired",
+    "defaultMessage": "Authentication has expired. Please try again."
+  },
+  {
+    "id": "oc.initialize_proofing",
+    "defaultMessage": "SE-LEG"
+  },
+  {
+    "id": "oc.initialize_proofing_help_text",
+    "defaultMessage": "To use this option you need to visit a <a href=\"https://www.sunet.se/samarbeten/projekt-nationell-tjanst-for-grundidentifiering/\" target=\"_blank\">SE-LEG RA</a> and show identification."
+  },
+  {
+    "id": "oc.modal_title",
+    "defaultMessage": "Confirm using SE-LEG"
+  },
+  {
+    "id": "oc.instructions_title",
+    "defaultMessage": "How to confirm your account using SE-LEG"
+  },
+  {
+    "id": "oc.instructions_step_1",
+    "defaultMessage": "Visit the nearest library on this list: <ul><li>Mjölby: Burensköldsvägen 13</li><li>Motala: Repslagaregatan 1</li><li>Söderköping: Margaretagatan 19</li><li>Åtvidaberg: B-fabriksgränd 4</li></ul>"
+  },
+  {
+    "id": "oc.instructions_step_2",
+    "defaultMessage": "Bring your chosen form of ID and the QR code below and ask the librarian for a verification of your eduID account."
+  },
+  {
+    "id": "oc.instructions_step_3",
+    "defaultMessage": "Within a couple of hours you account should be verified."
+  },
+  {
+    "id": "ocf.initialize_proofing",
+    "defaultMessage": "with Freja eID"
+  },
+  {
+    "id": "ocf.initialize_proofing_help_text",
+    "defaultMessage": "To use this option you need to have the <a href=\"https://frejaeid.com/skaffa-freja-eid/\" target=\"_blank\">Freja eID app</a> installed on your device."
+  },
+  {
+    "id": "ocf.modal_title",
+    "defaultMessage": "Confirm using Freja eID"
+  },
+  {
+    "id": "ocf.freja_instructions_title",
+    "defaultMessage": "How to confirm your account using Freja eID"
+  },
+  {
+    "id": "ocf.freja_instructions_step_1",
+    "defaultMessage": "Install the Freja eID app on your mobile device."
+  },
+  {
+    "id": "ocf.freja_instructions_step_2",
+    "defaultMessage": "Open the app and follow the instructions to reach Freja eID+ (Plus) status."
+  },
+  {
+    "id": "ocf.freja_instructions_step_3",
+    "defaultMessage": "Bring your chosen form of ID to an authorized agent and ask them to scan the QR-code in the Freja eID app. There is a map function in the Freja eID app to help you locate your nearest agent."
+  },
+  {
+    "id": "ocf.freja_instructions_step_4",
+    "defaultMessage": "Return here using your mobile phone and click the link at the bottom of the page. The app will open."
+  },
+  {
+    "id": "ocf.freja_instructions_step_5",
+    "defaultMessage": "Approve that Freja eID sends your personal identity number to eduID. Done!"
+  },
+  {
+    "id": "ocf.freja_instructions_install_link",
+    "defaultMessage": "I need to install Freja eID"
+  },
+  {
+    "id": "ocf.open_app",
+    "defaultMessage": "I have Freja eID installed"
+  },
+  {
+    "id": "ocf.not_on_mobile_title",
+    "defaultMessage": "Not using your phone?"
+  },
+  {
+    "id": "ocf.not_on_mobile_message",
+    "defaultMessage": "You need to switch to a mobile device (iOS or Android) with <a href=\"https://frejaeid.com/skaffa-freja-eid/\" target=\"_blank\">Freja eID</a> installed before you will be able to confirm your account using Freja eID."
+  },
+  {
+    "id": "add_nin.main_title",
+    "defaultMessage": "1. Add your id number"
+  },
+  {
+    "id": "nin_display.verify-identity_unverified_main_title",
+    "defaultMessage": "1. Your added id number"
+  },
+  {
+    "id": "nin_display.verify-identity_verified_main_title",
+    "defaultMessage": "id number"
+  },
+  {
+    "id": "nin_display.profile.main_title",
+    "defaultMessage": "id number"
+  },
+  {
+    "id": "nin_display.profile.no_nin",
+    "defaultMessage": "add id number"
+  },
+  {
+    "id": "nins.input_help_text",
+    "defaultMessage": "National identity number with 12 digits"
+  },
+  {
+    "id": "nins.invalid_nin",
+    "defaultMessage": "Invalid national id number"
+  },
+  {
+    "id": "nins.wrong_length",
+    "defaultMessage": "A national id number must have 12 digits"
+  },
+  {
+    "id": "nins.illegal_chars",
+    "defaultMessage": "A national id number can only have digits"
+  },
+  {
+    "id": "nins.valid_nin",
+    "defaultMessage": "Valid national id number"
+  },
+  {
+    "id": "nins.successfully_added",
+    "defaultMessage": "Your id number was added."
+  },
+  {
+    "id": "nins.only_one_to_verify",
+    "defaultMessage": "You can only have one unverified national id number to verify it. Please remove the unwanted ones."
+  },
+  {
+    "id": "nins.success_removal",
+    "defaultMessage": "Successfully removed national id number"
+  },
+  {
+    "id": "nins.no-mobile-match",
+    "defaultMessage": "No phone number matching the given national id number"
+  },
+  {
+    "id": "nins.verified_no_rm",
+    "defaultMessage": "You cannot remove your verified national id number"
+  },
+  {
+    "id": "phone_duplicated",
+    "defaultMessage": "Added number is duplicated"
+  },
+  {
+    "id": "phone_format",
+    "defaultMessage": "Invalid telephone number. It must be a valid Swedish number, or written\n                            using international notation, starting with '+' and followed by 10-20 digits."
+  },
+  {
+    "id": "still-valid-code",
+    "defaultMessage": "You have recently been sent a verification code. Please wait at least 5 minutes to request a new one."
+  },
+  {
+    "id": "phones.long_description",
+    "defaultMessage": "You can connect one or more mobile phone numbers to\n           your eduID, but one has to be set as primary."
+  },
+  {
+    "id": "phones.add_new",
+    "defaultMessage": "A new phone number will receive a confirmation code for you to use by clicking Confirm in the list of numbers."
+  },
+  {
+    "id": "phones.input_help_text",
+    "defaultMessage": "Phone number starting with 0 or +"
+  },
+  {
+    "id": "phones.main_title",
+    "defaultMessage": "Mobile phone numbers"
+  },
+  {
+    "id": "phones.button_add_more",
+    "defaultMessage": "+ add more"
+  },
+  {
+    "id": "phones.get-success",
+    "defaultMessage": "Successfully retrieved phone numbers"
+  },
+  {
+    "id": "phones.duplicated",
+    "defaultMessage": "That phone number is already in use, please choose another"
+  },
+  {
+    "id": "phones.save-success",
+    "defaultMessage": "The phone number was saved"
+  },
+  {
+    "id": "phones.unconfirmed_number_not_primary",
+    "defaultMessage": "An unconfirmed phone number cannot be set as primary"
+  },
+  {
+    "id": "phones.primary-success",
+    "defaultMessage": "The phone number was set as primary"
+  },
+  {
+    "id": "phones.code_expired_send_new",
+    "defaultMessage": "Expired verification code, sending another"
+  },
+  {
+    "id": "phones.code_invalid",
+    "defaultMessage": "Invalid verification code"
+  },
+  {
+    "id": "phones.invalid_phone",
+    "defaultMessage": "Invalid phone number"
+  },
+  {
+    "id": "phones.unknown_phone",
+    "defaultMessage": "We have no record of the phone number you provided"
+  },
+  {
+    "id": "phones.code_invalid_or_expired",
+    "defaultMessage": "The confirmation code is invalid or it has expired, please try again or request a new code"
+  },
+  {
+    "id": "phones.verification-success",
+    "defaultMessage": "Successfully verified phone number"
+  },
+  {
+    "id": "phones.cannot_remove_unique",
+    "defaultMessage": "You must have at least one phone number"
+  },
+  {
+    "id": "phones.cannot_remove_primary",
+    "defaultMessage": "You cannot remove your primary phone number"
+  },
+  {
+    "id": "phones.removal-success",
+    "defaultMessage": "Successfully removed phone number"
+  },
+  {
+    "id": "phones.code-sent",
+    "defaultMessage": "Successfully sent verification code"
+  },
+  {
+    "id": "phone.e164_format",
+    "defaultMessage": "Invalid telephone number. It must be a valid Swedish number, or written\n                            using international notation, starting with '+' and followed by 10-20 digits."
+  },
+  {
+    "id": "phone.swedish_mobile_format",
+    "defaultMessage": "Invalid telephone number. It must be a valid Swedish number, or written\n                            using international notation, starting with '+' and followed by 10-20 digits."
+  },
+  {
+    "id": "mobile.resend_success",
+    "defaultMessage": "New code sent to {email}"
+  },
+  {
+    "id": "mobile.mobile",
+    "defaultMessage": "mobile"
+  },
+  {
+    "id": "mobile.button_add",
+    "defaultMessage": "Add"
+  },
+  {
+    "id": "mobile.confirm_title",
+    "defaultMessage": "Enter the code sent to {phone} here"
+  },
+  {
+    "id": "pfilled.completion",
+    "defaultMessage": "Completion"
+  },
+  {
+    "id": "pd.long_description",
+    "defaultMessage": "Your name and preferred language will be used to personalise some services that you access with eduID."
+  },
+  {
+    "id": "pd.main_title",
+    "defaultMessage": "Name & language"
+  },
+  {
+    "id": "pd.all-data-success",
+    "defaultMessage": "Successfully retrieved personal information"
+  },
+  {
+    "id": "pd.pdata-success",
+    "defaultMessage": "Successfully retrieved personal information"
+  },
+  {
+    "id": "pd.save-success",
+    "defaultMessage": "Personal information updated"
+  },
+  {
+    "id": "pdata.field_required",
+    "defaultMessage": "This field is required"
+  },
+  {
+    "id": "pd.display_name_input_help_text",
+    "defaultMessage": "Some services will show this instead of your first and last name."
+  },
+  {
+    "id": "emails.resend_success",
+    "defaultMessage": "New code sent to {email}"
+  },
+  {
+    "id": "emails.email",
+    "defaultMessage": "Email"
+  },
+  {
+    "id": "emails.input_help_text",
+    "defaultMessage": "A valid email address"
+  },
+  {
+    "id": "emails.code_invalid",
+    "defaultMessage": "The confirmation code is invalid, please try again or request a new code"
+  },
+  {
+    "id": "emails.code_invalid_or_expired",
+    "defaultMessage": "The confirmation code is invalid or has expired, please try again or request a new code"
+  },
+  {
+    "id": "emails.button_add",
+    "defaultMessage": "Add"
+  },
+  {
+    "id": "emails.confirm_title",
+    "defaultMessage": "Click the link or enter the code sent to {email} here"
+  },
+  {
+    "id": "emails.long_description",
+    "defaultMessage": "You can connect one or more email addresses with your eduID \n          account and select one to be your primary email address."
+  },
+  {
+    "id": "emails.add_new",
+    "defaultMessage": "A new email address will recieve a link to click or a confirmation code that can be used by clicking Confirm in the list of email addresses."
+  },
+  {
+    "id": "emails.main_title",
+    "defaultMessage": "Email addresses"
+  },
+  {
+    "id": "emails.button_add_more",
+    "defaultMessage": "+ add more"
+  },
+  {
+    "id": "emails.get-success",
+    "defaultMessage": "Successfully retrieved Email addresses"
+  },
+  {
+    "id": "emails.duplicated",
+    "defaultMessage": "That email address is already in use, please choose another"
+  },
+  {
+    "id": "emails.save-success",
+    "defaultMessage": "The email address was saved"
+  },
+  {
+    "id": "emails.unconfirmed_address_not_primary",
+    "defaultMessage": "You need to confim and email address before it can be made primary"
+  },
+  {
+    "id": "emails.primary-success",
+    "defaultMessage": "The primary email address was updated"
+  },
+  {
+    "id": "emails.code_expired_send_new",
+    "defaultMessage": "Expired verification code, sending another"
+  },
+  {
+    "id": "emails.verification-success",
+    "defaultMessage": "Successfully verified email address"
+  },
+  {
+    "id": "emails.cannot_remove_unique",
+    "defaultMessage": "You must have at least one email address"
+  },
+  {
+    "id": "emails.cannot_remove_unique_verified",
+    "defaultMessage": "You must have at least one verified email address"
+  },
+  {
+    "id": "emails.removal-success",
+    "defaultMessage": "Successfully removed email address"
+  },
+  {
+    "id": "emails.code-sent",
+    "defaultMessage": "Successfully sent verification code"
+  },
+  {
+    "id": "emails.cannot_remove_primary",
+    "defaultMessage": "You can not delete the primary email"
+  },
+  {
+    "id": "emails.invalid_email",
+    "defaultMessage": "The entered value does not look like an email"
+  },
+  {
+    "id": "emails.missing",
+    "defaultMessage": "You must provide an email address"
+  },
+  {
+    "id": "emails.unknown_email",
+    "defaultMessage": "We have no record of the email address you provided"
+  },
+  {
+    "id": "InvalidStateError: The user attempted to register an authenticator that contains one of the credentials already registered with the relying party.",
+    "defaultMessage": "You are attempting to register an authenticator that contains one of the credentials already registered with the relying party"
+  },
+  {
+    "id": "cred.credential_type",
+    "defaultMessage": "Credential type."
+  },
+  {
+    "id": "security.description",
+    "defaultMessage": "Name"
+  },
+  {
+    "id": "security.remove",
+    "defaultMessage": "Remove"
+  },
+  {
+    "id": "security.verify",
+    "defaultMessage": "Verify key"
+  },
+  {
+    "id": "security.verified",
+    "defaultMessage": "Verified"
+  },
+  {
+    "id": "security.main_title",
+    "defaultMessage": "Security"
+  },
+  {
+    "id": "security.credential",
+    "defaultMessage": "Credential"
+  },
+  {
+    "id": "security.last-used.date",
+    "defaultMessage": "Never used"
+  },
+  {
+    "id": "security.creation_date",
+    "defaultMessage": "Created on"
+  },
+  {
+    "id": "security.last_used",
+    "defaultMessage": "Used on"
+  },
+  {
+    "id": "security.u2f.max_allowed_tokens",
+    "defaultMessage": "You already have the maximum allowed number of tokens"
+  },
+  {
+    "id": "security.u2f.missing_enrollment_data",
+    "defaultMessage": "Found no U2F enrollment data in your session"
+  },
+  {
+    "id": "security.u2f.no_token_found",
+    "defaultMessage": "No U2F token found in your session"
+  },
+  {
+    "id": "security.u2f.missing_token",
+    "defaultMessage": "No U2F token found in your session"
+  },
+  {
+    "id": "security.u2f.missing_challenge_data",
+    "defaultMessage": "Found no U2F challenge data in your session"
+  },
+  {
+    "id": "security.u2f.description_to_long",
+    "defaultMessage": "You tried to set a U2F token description long"
+  },
+  {
+    "id": "security.add_u2f_token",
+    "defaultMessage": "Add U2F token"
+  },
+  {
+    "id": "security.u2f_credential_type",
+    "defaultMessage": "U2F token"
+  },
+  {
+    "id": "security.u2f_register_success",
+    "defaultMessage": "U2F token successfully registered"
+  },
+  {
+    "id": "u2f.action-required",
+    "defaultMessage": "Action required for multi factor authentication"
+  },
+  {
+    "id": "u2f.push-the-button",
+    "defaultMessage": "Please touch the button in your U2F key"
+  },
+  {
+    "id": "security.u2f-token-removed",
+    "defaultMessage": "U2F token successfully removed"
+  },
+  {
+    "id": "security.u2f-describe-title",
+    "defaultMessage": "Enter a description for the U2F token you are about to register"
+  },
+  {
+    "id": "security.webauthn_credential_type",
+    "defaultMessage": "Security key"
+  },
+  {
+    "id": "security.add_webauthn_token_key",
+    "defaultMessage": "Add security key"
+  },
+  {
+    "id": "security.add_webauthn_token_device",
+    "defaultMessage": "Register this device as security key"
+  },
+  {
+    "id": "security.security-key_title",
+    "defaultMessage": "Make your eduID more secure"
+  },
+  {
+    "id": "security.second-factor",
+    "defaultMessage": "Add a security key as a second layer of identification, beyond email and password, to prove you are \n    the owner of your eduID."
+  },
+  {
+    "id": "security.webauthn-describe-title",
+    "defaultMessage": "Add a name for your security key"
+  },
+  {
+    "id": "security.webauthn.max_allowed_tokens",
+    "defaultMessage": "You are not allowed to register more security keys"
+  },
+  {
+    "id": "security.webauthn_register_success",
+    "defaultMessage": "Security key added"
+  },
+  {
+    "id": "security.webauthn-token-removed",
+    "defaultMessage": "Security key removed"
+  },
+  {
+    "id": "security.webauthn-missing-pdata",
+    "defaultMessage": "You should add your personal data before adding a security key"
+  },
+  {
+    "id": "security.webauthn-token-notfound",
+    "defaultMessage": "Security token not found"
+  },
+  {
+    "id": "security.webauthn-noremove-last",
+    "defaultMessage": "You are not allowed to remove your only security key"
+  },
+  {
+    "id": "account_linking.main_title",
+    "defaultMessage": "ORCID account"
+  },
+  {
+    "id": "account_linking.long_description",
+    "defaultMessage": "If you are a reseacher with an ORCID iD you can share it with your eduID."
+  },
+  {
+    "id": "orc.authorization_success",
+    "defaultMessage": "ORCID connected successfully"
+  },
+  {
+    "id": "orc.already_connected",
+    "defaultMessage": "ORCID already connected to this account"
+  },
+  {
+    "id": "orc.unknown_state",
+    "defaultMessage": "State was unknown when trying to connect ORCID account"
+  },
+  {
+    "id": "orc.sub_missmatch",
+    "defaultMessage": "Subject mismatch when trying to connect ORCID account"
+  },
+  {
+    "id": "orc.title",
+    "defaultMessage": "ORCID"
+  },
+  {
+    "id": "orc.long_description",
+    "defaultMessage": "ORCID iD distinguishes you from other researchers and allows linking of your research outputs and activities to your identity, regardless of the organisation you are working with."
+  },
+  {
+    "id": "orc.about_link",
+    "defaultMessage": "Learn more about ORCID in eduID from our <a href=\"https://www.eduid.se/en/faq.html\">FAQ</a>."
+  },
+  {
+    "id": "orc.button_connect",
+    "defaultMessage": "Add ORCID account"
+  },
+  {
+    "id": "accountId.main_title",
+    "defaultMessage": "Unique ID"
+  },
+  {
+    "id": "accountId.long_description",
+    "defaultMessage": "This is an automatically generated unique identifier for your eduID."
+  },
+  {
+    "id": "accountId.short_description",
+    "defaultMessage": "You might be asked to share this information if you need technical support."
+  },
+  {
+    "id": "accountId.accountId_display_title",
+    "defaultMessage": "Unique ID"
+  },
+  {
+    "id": "orc.authorization_fail",
+    "defaultMessage": "ORCID authentication failed"
+  },
+  {
+    "id": "settings.account_title",
+    "defaultMessage": "Delete eduID"
+  },
+  {
+    "id": "settings.account_description",
+    "defaultMessage": "Click the link to permanently delete your eduID."
+  },
+  {
+    "id": "security.button_delete_account",
+    "defaultMessage": "Delete eduID"
+  },
+  {
+    "id": "settings.modal_delete_title",
+    "defaultMessage": "Are you sure you want to delete your eduID?"
+  },
+  {
+    "id": "delete.modal_info",
+    "defaultMessage": "Deleting your eduID will permanently remove all your saved information."
+  },
+  {
+    "id": "delete.modal_tip",
+    "defaultMessage": "After clicking the button you need to use your log in details one final time."
+  },
+  {
+    "id": "delete.confirm_button",
+    "defaultMessage": "Delete my eduID"
+  }
+]

--- a/i18n/src/login/translation/messageIndex.json
+++ b/i18n/src/login/translation/messageIndex.json
@@ -1,0 +1,74 @@
+[
+  {
+    "id": "pd.choose-language",
+    "defaultMessage": "Choose language"
+  },
+  {
+    "id": "emails.confirm_email_placeholder",
+    "description": "Placeholder for email text input",
+    "defaultMessage": "Email confirmation code"
+  },
+  {
+    "id": "mobile.confirm_mobile_placeholder",
+    "description": "Placeholder for phone text input",
+    "defaultMessage": "Phone confirmation code"
+  },
+  {
+    "id": "chpass.help-text-newpass",
+    "description": "help text for custom password",
+    "defaultMessage": "<label>Tip: Choose a strong password</label>\n            <ul id=\"password-custom-help\">\n\t            <li>Use upper- and lowercase characters, but not at the beginning or end</li>\n\t            <li>Add digits somewhere, but not at the beginning or end</li>\n                <li>Add special characters, such as &#64; &#36; &#92; &#43; &#95; &#37;</li>\n\t            <li>Spaces are ignored</li>\n            </ul>"
+  },
+  {
+    "id": "cm.lost_code",
+    "description": "Lost code problem description",
+    "defaultMessage": "Is the code not working?"
+  },
+  {
+    "id": "cm.resend_code",
+    "description": "Lost code problem solution",
+    "defaultMessage": "Send a new confirmation code"
+  },
+  {
+    "id": "letter.lost_code",
+    "description": "Text for letter proofing confirm dialog",
+    "defaultMessage": "When you click on the \"Send code\" link a letter with a verification code will be sent to your official post address."
+  },
+  {
+    "id": "letter.resend_code",
+    "description": "Text for letter code resend button",
+    "defaultMessage": "Send code"
+  },
+  {
+    "id": "letter.placeholder",
+    "description": "Placeholder for letter proofing text input",
+    "defaultMessage": "Letter confirmation code"
+  },
+  {
+    "id": "pd.given_name",
+    "defaultMessage": "First name"
+  },
+  {
+    "id": "pd.surname",
+    "defaultMessage": "Last name"
+  },
+  {
+    "id": "pd.display_name",
+    "defaultMessage": "Display Name"
+  },
+  {
+    "id": "pd.language",
+    "defaultMessage": "Language"
+  },
+  {
+    "id": "pd.display_name_inputplaceholder",
+    "defaultMessage": "First and last name"
+  },
+  {
+    "id": "nins.input_placeholder",
+    "defaultMessage": "yyyymmddnnnn"
+  },
+  {
+    "id": "phones.input_placeholder",
+    "defaultMessage": "phone number"
+  }
+]

--- a/src/components/Security.js
+++ b/src/components/Security.js
@@ -1,7 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import EduIDButton from "components/EduIDButton";
-import TableList from "components/TableList";
 import GenericConfirmModal from "components/GenericConfirmModal";
 import ConfirmModal from "components/ConfirmModal";
 
@@ -51,14 +50,14 @@ class Security extends Component {
       // verify button/ verified badge
       if (cred.verified) {
         btnVerify = (
-          <EduIDButton className="btn-link verified" disabled>
+          <span className="nobutton verified" disabled>
             {this.props.translate("security.verified")}
-          </EduIDButton>
+          </span>
         );
       } else {
         btnVerify = (
           <EduIDButton
-            className="btn-link verify-status-label"
+            className="btn-link nobutton verify-status-label"
             onClick={this.props.handleVerifyWebauthnToken}
           >
             {this.props.translate("security.verify")}

--- a/src/components/Security.js
+++ b/src/components/Security.js
@@ -1,6 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import EduIDButton from "components/EduIDButton";
+import TableList from "components/TableList";
 import GenericConfirmModal from "components/GenericConfirmModal";
 import ConfirmModal from "components/ConfirmModal";
 
@@ -121,7 +122,7 @@ class Security extends Component {
     // show no table if no security keys
     if (tokens.length > 0) {
       securitykey_table = (
-        <table className="passwords">
+        <table className="table-form passwords">
           <tbody>
             <tr>
               <th>{this.props.translate("security.description")}</th>
@@ -143,7 +144,7 @@ class Security extends Component {
             <h4>{this.props.translate("security.security-key_title")}</h4>
             <p>{this.props.translate("security.second-factor")}</p>
           </div>
-          <div id="register-webauthn-tokens-area">
+          <div id="register-webauthn-tokens-area" className="table-responsive">
             {securitykey_table}
             <EduIDButton
               id="security-webauthn-button"

--- a/src/login/styles/_Security.scss
+++ b/src/login/styles/_Security.scss
@@ -1,7 +1,3 @@
-#security-webauthn-button {
-  margin-top: 0px;
-}
-
 td .passwords {
   background-color: white;
 }

--- a/src/login/styles/_tables.scss
+++ b/src/login/styles/_tables.scss
@@ -1,4 +1,3 @@
-
 /* styles for tables displaying userinfo on settings page */
 table {
   margin-bottom: 10px;
@@ -7,6 +6,7 @@ table {
   color: gray;
   font-size: 24px;
   font-family: "ProximaNova-Light";
+  margin: 1rem 0;
   // border-collapse: collapse;
 }
 
@@ -55,4 +55,12 @@ button.verify-status-label {
 
 span.nobutton {
   font-family: "ProximaNova-Regular";
+  text-transform: uppercase;
+}
+
+@media (max-width: 568px) {
+  table {
+    font-size: 1rem;
+    color: #161616;
+  }
 }

--- a/src/login/styles/index.scss
+++ b/src/login/styles/index.scss
@@ -11,6 +11,7 @@
 @import "nav";
 @import "img";
 @import "modals";
+@import "tables";
 
 /* replaces specific stylesheets */
 @import "AccountLinking";

--- a/src/style/base.scss
+++ b/src/style/base.scss
@@ -612,63 +612,63 @@ h5.modal-title {
   justify-content: center;
 }
 
-/* styles for tables displaying userinfo on settings page */
-table {
-  margin-bottom: 10px;
-  width: 100%;
-  // background-color: white;
-  color: gray;
-  font-size: 24px;
-  font-family: "ProximaNova-Light";
-  // border-collapse: collapse;
-}
-
-// table th {
-//   // border-bottom: #7c7c7c 1px solid;
+// /* styles for tables displaying userinfo on settings page */
+// table {
+//   margin-bottom: 10px;
+//   width: 100%;
+//   // background-color: white;
+//   color: gray;
+//   font-size: 24px;
+//   font-family: "ProximaNova-Light";
+//   // border-collapse: collapse;
 // }
 
-table th,
-table td {
-  padding: 0.75rem;
-  background-color: white;
-}
+// // table th {
+// //   // border-bottom: #7c7c7c 1px solid;
+// // }
 
-td.data {
-  width: 80%;
-}
+// table th,
+// table td {
+//   padding: 0.75rem;
+//   background-color: white;
+// }
 
-td.data-remove-button,
-td.status-label {
-  width: 10%;
-}
+// td.data {
+//   width: 80%;
+// }
 
-table th {
-  color: #171717;
-  font-size: 12px;
-  text-transform: uppercase;
-  padding: 0.75rem;
-  background-color: transparent;
-}
+// td.data-remove-button,
+// td.status-label {
+//   width: 10%;
+// }
 
-tbody {
-  margin-bottom: 10px;
-}
+// table th {
+//   color: #171717;
+//   font-size: 12px;
+//   text-transform: uppercase;
+//   padding: 0.75rem;
+//   background-color: transparent;
+// }
 
-span.nobutton,
-.primary,
-tr.primary {
-  font-weight: 300;
-  color: $black;
-}
+// tbody {
+//   margin-bottom: 10px;
+// }
 
-span.nobutton,
-button.verify-status-label {
-  font-size: 12px;
-}
+// span.nobutton,
+// .primary,
+// tr.primary {
+//   font-weight: 300;
+//   color: $black;
+// }
 
-span.nobutton {
-  font-family: "ProximaNova-Regular";
-}
+// span.nobutton,
+// button.verify-status-label {
+//   font-size: 12px;
+// }
+
+// span.nobutton {
+//   font-family: "ProximaNova-Regular";
+// }
 
 /* styles for remove svg icon */
 svg {


### PR DESCRIPTION
#### Description: The security key table needs same styling as email addresses and phone numbers tables

**Summary:**
- Made font smaller at smaller screen widths
- Made verified text into a badge instead of button
- Applied the same styling to the security key table as the email address and phone number tables 

---
###### Security key table (before and after)
Desktop: 
<img width="300" alt="Screenshot 2020-04-27 at 15 53 05" src="https://user-images.githubusercontent.com/30963614/80389761-cf7bbe80-88ab-11ea-9b7e-3bacbe401456.png"><img width="300" alt="Screenshot 2020-04-27 at 17 11 38" src="https://user-images.githubusercontent.com/30963614/80389711-b70ba400-88ab-11ea-98dc-33174e101648.png">

Mobile: 
<img width="200" alt="Screenshot 2020-04-27 at 15 56 00" src="https://user-images.githubusercontent.com/30963614/80389985-21244900-88ac-11ea-8ba7-179507923d35.png">   <img width="200" alt="Screenshot 2020-04-27 at 16 58 23" src="https://user-images.githubusercontent.com/30963614/80389999-25506680-88ac-11ea-8172-cfe7e1658aa1.png">




#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

