### PR TITLE
Adds full footer (with language options) to register page

### DIFF
--- a/i18n/src/login/translation/defaultMessages/register.json
+++ b/i18n/src/login/translation/defaultMessages/register.json
@@ -67,6 +67,11 @@
     "id": "signup.registering-new",
     "defaultMessage": "Email address successfully registered"
   },
+{
+  "id": "signup.registering-input",
+  "defaultMessage": "Email address"
+},
+ 
   {
     "id": "signup.registering-address-used",
     "defaultMessage": "The email address you entered is already in use"

--- a/src/components/Email.js
+++ b/src/components/Email.js
@@ -42,7 +42,7 @@ let EmailForm = (props) => (
     <EduIDButton
       className="settings-button"
       id="register-button"
-      disabled={props.invalid}
+      disabled={!props.valid_email}
       onClick={props.handleEmail}
     >
       {props.translate("email.sign-up-email")}

--- a/src/components/Email.js
+++ b/src/components/Email.js
@@ -42,7 +42,7 @@ let EmailForm = (props) => (
     <EduIDButton
       className="settings-button"
       id="register-button"
-      disabled={!props.valid_email}
+      disabled={props.invalid}
       onClick={props.handleEmail}
     >
       {props.translate("email.sign-up-email")}
@@ -58,6 +58,7 @@ EmailForm = reduxForm({
 
 EmailForm = connect((state) => ({
   enableReinitialize: true,
+  destroyOnUnmount: false,
 }))(EmailForm);
 
 /* COMPONENT */

--- a/src/components/Email.js
+++ b/src/components/Email.js
@@ -67,7 +67,7 @@ class Email extends Component {
   render() {
     return [
       <div key="0" id="register-container" className="vertical-content-margin">
-        <label>Email address</label>
+        <label>{this.props.translate("signup.registering-input")}</label>
         <EmailForm {...this.props} />
       </div>,
       <div key="1">

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -1,34 +1,29 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 
-import "../login/styles/index.scss"
+import "../login/styles/index.scss";
 
 class Footer extends Component {
   render() {
     let langElems = "";
-
-    // if (this.props.is_configured) {
-      const langs = Object.getOwnPropertyNames(this.props.languages);
-      langElems = langs.map((lang, index) => {
-        if (lang === this.props.language) {
-          return (
-            <p key="0" className="non-selected" key={index}>
-              <span key="0">{this.props.languages[lang]}</span>
-            </p>
-          );
-        } else {
-          return (
-            <p key="0" className="lang-selected" data-lang={lang} key={index}>
-              <a key="0" onClick={this.props.changeLanguage}>
-                {this.props.languages[lang]}
-              </a>
-            </p>
-          );
-        }
-      });
-    // } else {
-    //   langElems = "";
-    // }
+    const langs = Object.getOwnPropertyNames(this.props.languages);
+    langElems = langs.map((lang, index) => {
+      if (lang === this.props.language) {
+        return (
+          <p key="0" className="non-selected" key={index}>
+            <span key="0">{this.props.languages[lang]}</span>
+          </p>
+        );
+      } else {
+        return (
+          <p key="0" className="lang-selected" data-lang={lang} key={index}>
+            <a key="0" onClick={this.props.changeLanguage}>
+              {this.props.languages[lang]}
+            </a>
+          </p>
+        );
+      }
+    });
 
     return (
       <footer key="0" id="footer">
@@ -56,7 +51,7 @@ Footer.propTypes = {
   is_configured: PropTypes.bool,
   language: PropTypes.string,
   languages: PropTypes.object,
-  changeLanguage: PropTypes.func
+  changeLanguage: PropTypes.func,
 };
 
 export default Footer;

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -37,11 +37,6 @@ class Footer extends Component {
         </p>
         <nav key="1">
           <ul>
-            {/*  <li key="0">
-              <a id="stable-link" href="/feature/no-beta">
-                {this.props.translate("foot.change-version")}
-              </a> 
-            </li>*/}
             <li key="0">
               <a className="help-link" href={this.props.faq_link}>
                 {this.props.translate("header.faq")}

--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -7,7 +7,7 @@ class Footer extends Component {
   render() {
     let langElems = "";
 
-    if (this.props.is_configured) {
+    // if (this.props.is_configured) {
       const langs = Object.getOwnPropertyNames(this.props.languages);
       langElems = langs.map((lang, index) => {
         if (lang === this.props.language) {
@@ -26,9 +26,9 @@ class Footer extends Component {
           );
         }
       });
-    } else {
-      langElems = "";
-    }
+    // } else {
+    //   langElems = "";
+    // }
 
     return (
       <footer key="0" id="footer">

--- a/src/containers/Footer.js
+++ b/src/containers/Footer.js
@@ -13,7 +13,7 @@ const mapStateToProps = (state, props) => {
     });
   }
   return {
-    is_configured: state.config.is_configured,
+    // is_configured: state.config.is_configured,
     language: state.intl.locale,
     languages: languages,
     reload_to: state.config.DASHBOARD_URL,

--- a/src/containers/Footer.js
+++ b/src/containers/Footer.js
@@ -13,7 +13,6 @@ const mapStateToProps = (state, props) => {
     });
   }
   return {
-    // is_configured: state.config.is_configured,
     language: state.intl.locale,
     languages: languages,
     reload_to: state.config.DASHBOARD_URL,

--- a/src/login/translation/defaultMessages/register.js
+++ b/src/login/translation/defaultMessages/register.js
@@ -111,6 +111,13 @@ export const register = {
     />
   ),
 
+  "signup.registering-input": (
+    <FormattedMessage
+      id="signup.registering-input"
+      defaultMessage={`Email address`}
+    />
+  ),
+
   // eduID registration error: email already in use
   "signup.registering-address-used": (
     <FormattedMessage

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -352,6 +352,7 @@
   "settings.modal_delete_title": "Are you sure you want to delete your eduID?",
   "signup.recaptcha-not-verified": "There was a problem verifying that you are a human. Please try again",
   "signup.registering-address-used": "The email address you entered is already in use",
+  "signup.registering-input": "Email address",
   "signup.registering-new": "Email address successfully registered",
   "signup.registering-resend-code": "Verification email resent",
   "signup.verification-resent": "Verification email resent",

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -352,6 +352,7 @@
   "settings.modal_delete_title": "Är du säker på att du vill ta bort ditt eduID?",
   "signup.recaptcha-not-verified": "Vi kunde inte verifiera att du är människa. Var vänlig försök igen.",
   "signup.registering-address-used": "E-postadressen används redan",
+  "signup.registering-input": "E-postadress",
   "signup.registering-new": "E-postaddressen har registrerats",
   "signup.registering-resend-code": "Ett nytt verifieringsmeddelande har skickats",
   "signup.verification-resent": "Ett nytt verifieringsmeddelande har skickats",

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -138,7 +138,7 @@
   "foot.change-version-tip": "Om du stöter på något problem så kan du byta till en tidigare version av appen.",
   "header.faq": "Hjälp",
   "header.logout": "Logga ut",
-  "header.signin": "LOGGA IN",
+  "header.signin": "Logga in",
   "header.signup": "REGISTRERING",
   "letter.already-sent": "Ett brev är redan på väg till din folkbokföringsadress",
   "letter.bad-postal-address": "Ofullständig postadress",

--- a/src/login/translation/src/login/translation/defaultMessages/register.json
+++ b/src/login/translation/src/login/translation/defaultMessages/register.json
@@ -68,6 +68,10 @@
     "defaultMessage": "Email address successfully registered"
   },
   {
+    "id": "signup.registering-input",
+    "defaultMessage": "Email address"
+  },
+  {
     "id": "signup.registering-address-used",
     "defaultMessage": "The email address you entered is already in use"
   },


### PR DESCRIPTION
#### Description: Makes the full footer (with language option) render on register page as described in issue #282.    

**Summary:**
- To display language in footer: 
    - Removed rendering conditional: `this.props.is_configured` from `<Footer/>` component 
    - Also removed from `<Footer/>` container 
- To fix that button was not disabled from start in Swedish translation: 
    - changed the condition to disable the button from `props.invalid` to `!props.valid_email`  
--- 

###### Register, before (Eng only as language option removed): 
<img width="300" alt="Screenshot 2020-05-07 at 12 49 03" src="https://user-images.githubusercontent.com/30963614/81286356-398d2400-9061-11ea-89dd-a75779c3a4d9.png">

###### Register, after (Eng and Swe)
<img width="300" alt="Screenshot 2020-05-07 at 12 45 49" src="https://user-images.githubusercontent.com/30963614/81286258-0cd90c80-9061-11ea-8b29-64494e973ae7.png"> <img width="300" alt="Screenshot 2020-05-07 at 12 45 42" src="https://user-images.githubusercontent.com/30963614/81286261-0ea2d000-9061-11ea-8b6d-17562d6dbdeb.png">


 


#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

