### PR TITLE
Sets the `<html lang="">` to match translation language

### DIFF
--- a/src/components/Footer.js
+++ b/src/components/Footer.js
@@ -9,6 +9,8 @@ class Footer extends Component {
     const langs = Object.getOwnPropertyNames(this.props.languages);
     langElems = langs.map((lang, index) => {
       if (lang === this.props.language) {
+        // sets the < html lang=""> to the interface language
+        document.documentElement.lang = this.props.language;
         return (
           <p key="0" className="non-selected" key={index}>
             <span key="0">{this.props.languages[lang]}</span>


### PR DESCRIPTION
#### Description: the <html lang=""> should match the language on the page (as described in issue #286) 

**Summary:** 
- code added to translation link in  `<Footer />` to set the lang attribute to match `this.props.language` 
- checked in Safari, chrome and Firefox

---- 
html before and after: 
<img width="300" alt="Screenshot 2020-05-08 at 14 47 07" src="https://user-images.githubusercontent.com/30963614/81407506-d0c6aa00-913b-11ea-9adb-90eb2906cf26.png"> <img width="300" alt="Screenshot 2020-05-08 at 14 47 16" src="https://user-images.githubusercontent.com/30963614/81407507-d2906d80-913b-11ea-85c4-c88ef2173e13.png">



#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

