### PR TITLE
REGISTER: Fix for header (incorrectly displaying user email)

### DIFF
--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -17,7 +17,11 @@ class Header extends Component {
         </a>
       );
     } else if (url.includes("profile")) {
-      tagline = this.props.translate("dashboard.tagline");
+      tagline = (
+        <Fragment>
+          {this.props.translate("dashboard.tagline")} {this.props.email}
+        </Fragment>
+      );
       button = (
         <div id="eduid-button">
           <button id="logout" className="btn" onClick={this.props.handleLogout}>
@@ -38,9 +42,7 @@ class Header extends Component {
           {button}
         </header>
         <div className="vertical-content-margin">
-          <h1 className="tagline">
-            {tagline} {this.props.email}
-          </h1>
+          <h1 className="tagline">{tagline}</h1>
         </div>
       </section>
     );

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,4 +1,4 @@
-import React, { Component } from "react";
+import React, { Component, Fragment } from "react";
 import PropTypes from "prop-types";
 import "../login/styles/index.scss";
 


### PR DESCRIPTION
#### Description: 
user email showing in Header outside of dashboard (as described in issue #292 )

**Summary:** 
- moved email variable to conditional to only show in dashboard (url includes "profile")

---
###### Register > captcha (before and after)
<img width="300" alt="Screenshot 2020-05-12 at 15 50 44" src="https://user-images.githubusercontent.com/30963614/81700264-ba388f80-9468-11ea-96ba-d4d819aeaf43.png"> <img width="300" alt="Screenshot 2020-05-12 at 15 48 43" src="https://user-images.githubusercontent.com/30963614/81700233-b1e05480-9468-11ea-9bbd-97640f9d00f5.png">


#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

