### PR TITLE
Fixes styling for Freja eID modal 

### DIFF
--- a/src/components/Eidas.js
+++ b/src/components/Eidas.js
@@ -25,28 +25,14 @@ class Eidas extends Component {
           <label>{this.props.translate("eidas.freja_instructions_tip1")}</label>
           <li>{this.props.translate("eidas.freja_instructions_step5")}</li>
         </ol>
+        <a
+          // className="btn-link"
+          href="https://frejaeid.com/skaffa-freja-eid/"
+          target="_blank"
+        >
+          {this.props.translate("eidas.freja_instructions_install_link")}
+        </a>
       </div>
-    );
-
-    let have_freja, install_freja;
-
-    have_freja = (
-      <EduIDButton
-        className="btn-link"
-        href={this.props.eidas_sp_freja_idp_url}
-      >
-        {this.props.translate("eidas.freja_eid_ready")}
-      </EduIDButton>
-    );
-
-    install_freja = (
-      <EduIDButton
-        className="btn-link"
-        href="https://frejaeid.com/skaffa-freja-eid/"
-        target="_blank"
-      >
-        {this.props.translate("eidas.freja_instructions_install_link")}
-      </EduIDButton>
     );
 
     return (
@@ -74,15 +60,15 @@ class Eidas extends Component {
               {this.props.translate("eidas.modal_title")}
             </ModalHeader>
 
-            <ModalBody>
-              {freja_instructions}
-              <div id="freja-links">
-                {have_freja}
-                {install_freja}
-              </div>
-            </ModalBody>
+            <ModalBody>{freja_instructions}</ModalBody>
 
             <ModalFooter>
+              <EduIDButton
+                className="modal-button ok-button"
+                href={this.props.eidas_sp_freja_idp_url}
+              >
+                {this.props.translate("eidas.freja_eid_ready")}
+              </EduIDButton>
               <EduIDButton
                 className="modal-button cancel-button"
                 id="eidas-hide-modal"
@@ -102,7 +88,7 @@ Eidas.propTypes = {
   handleShowModal: PropTypes.func,
   handleHideModal: PropTypes.func,
   showModal: PropTypes.bool,
-  eidas_sp_freja_idp_url: PropTypes.string
+  eidas_sp_freja_idp_url: PropTypes.string,
 };
 
 export default Eidas;

--- a/src/login/styles/_buttons.scss
+++ b/src/login/styles/_buttons.scss
@@ -106,6 +106,10 @@ button.btn.modal-button {
   border: solid 1px transparent;
   background-color: transparent;
   margin: 0.5rem 1rem;
+  &:hover {
+    background: transparent;
+    transform: scale(1);
+  }
 }
 
 /* color for OK and ACCEPT buttons in modals */

--- a/src/login/styles/_buttons.scss
+++ b/src/login/styles/_buttons.scss
@@ -157,6 +157,7 @@ button.btn.icon-button {
 
 /* styles for links that are also buttons */
 // -----  ----  //
+a.btn-link,
 button.btn-link {
   background-color: transparent;
   color: $orange-highlight;

--- a/src/login/styles/_buttons.scss
+++ b/src/login/styles/_buttons.scss
@@ -8,7 +8,7 @@
   margin-top: 0;
   margin-bottom: 0;
 }
-
+a.btn,
 button,
 button.btn {
   font-family: "Akkurat";
@@ -95,8 +95,12 @@ button.close:hover {
   transform: scale(1.2);
 }
 
-/* MODALS */
+//  {
+//   font-family: "ProximaNova-Regular";
+// }
 
+/* MODALS */
+a.btn.modal-button,
 button.btn.modal-button {
   box-shadow: none;
   border: solid 1px transparent;
@@ -106,6 +110,7 @@ button.btn.modal-button {
 
 /* color for OK and ACCEPT buttons in modals */
 // ----- buttons with actions in modals ----  //
+a.ok-button,
 button.ok-button {
   color: $orange-highlight;
   &:hover,

--- a/src/login/styles/_links.scss
+++ b/src/login/styles/_links.scss
@@ -6,7 +6,8 @@ a {
   text-decoration: none;
   transition: all 0.2s ease;
   &:hover {
-    text-decoration: none;
+    text-decoration: underline;
+    color: #ff4500;
   }
   &.text-link {
     font-family: "ProximaNova-Regular";

--- a/src/login/styles/_links.scss
+++ b/src/login/styles/_links.scss
@@ -6,7 +6,7 @@ a {
   text-decoration: none;
   transition: all 0.2s ease;
   &:hover {
-    text-decoration: underline;
+    text-decoration: none;
     color: #ff4500;
   }
   &.text-link {

--- a/src/login/styles/_modals.scss
+++ b/src/login/styles/_modals.scss
@@ -34,7 +34,7 @@ h5.modal-title {
   & .modal-footer {
     & a {
       display: flex;
-      align-items:center;
+      align-items: center;
     }
   }
 }
@@ -89,15 +89,17 @@ ol {
         line-height: 1.4;
       }
     }
-    & a {
-      font-size: 1rem;
-      &:hover {
-        color: #ff4500;
-      }
-    }
     & label {
       color: #7c7c7c;
       margin: 1rem 0;
+    }
+  }
+  & a {
+    font-size: 1rem;
+    text-decoration: underline;
+    &:hover {
+      color: #ff4500;
+      text-decoration: none;
     }
   }
 }

--- a/src/login/styles/_modals.scss
+++ b/src/login/styles/_modals.scss
@@ -31,6 +31,12 @@ h5.modal-title {
       margin: 0 0 1rem 0;
     }
   }
+  & .modal-footer {
+    & a {
+      display: flex;
+      align-items:center;
+    }
+  }
 }
 
 .modal-dialog {

--- a/src/login/styles/_modals.scss
+++ b/src/login/styles/_modals.scss
@@ -23,7 +23,7 @@ h5.modal-title {
   }
   & .modal-body {
     background-color: #f4f4f4;
-    padding: 2rem 2rem 0 2rem;
+    padding: 2rem;
     display: flex;
     flex-direction: column;
     color: #7c7c7c;
@@ -68,33 +68,32 @@ h5.modal-title {
   }
 }
 
-#freja-instructions,
-#freja-instructions label {
-  color: #7c7c7c;
-}
-#freja-instructions ol {
-  padding-left: 30px;
-  line-height: 1.2;
-  font-size: 1.25rem;
+ol {
+  list-style-type: decimal;
 }
 
-#freja-instructions li {
-  padding-left: 5px;
-  margin: 15px 0;
-}
-
-#freja-links {
-  margin: 50px 0 20px;
-  display: flex;
-  justify-content: space-around;
-}
-
-#freja-links a {
-  border: none;
-  color: #ff4500;
-  line-height: 1.2;
-  font-weight: 700;
-  font-size: 1rem;
+#freja-instructions {
+  & ol {
+    line-height: 1;
+    font-size: 1.25rem;
+    margin: 0 0 2rem 2rem;
+    & li {
+      margin-bottom: 1rem;
+      & span {
+        line-height: 1.4;
+      }
+    }
+    & a {
+      font-size: 1rem;
+      &:hover {
+        color: #ff4500;
+      }
+    }
+    & label {
+      color: #7c7c7c;
+      margin: 1rem 0;
+    }
+  }
 }
 
 #delete-account-modal {
@@ -120,10 +119,7 @@ h5.modal-title {
 }
 
 p.modal-text {
-  // display: flex;
-  // flex-direction: column;
   margin-top: 0;
-  // margin-bottom: 30px;
 }
 
 @media (max-width: 823px) {
@@ -192,9 +188,6 @@ p.modal-text {
 }
 
 @media (min-width: 576px) {
-  // .container {
-  //   max-width: 100%;
-  // }
   .modal-dialog {
     max-width: 100%;
   }


### PR DESCRIPTION
#### Description: Styling for Freja eID modal is broken.

**Summary:** 
- Styled text in line with other modals:
    - added numbers to list 
- moved "use Freja eID" link to the bottom of modal
    - styled link as a button (adds styles for `a.btn` as the button really is a link)
    
###### Freja eID modal (before and after)
<img width="300" alt="Screenshot 2020-05-13 at 10 42 23" src="https://user-images.githubusercontent.com/30963614/81791468-0df9b600-9507-11ea-838a-1fa65e97be4b.png"> <img width="300" alt="Screenshot 2020-05-13 at 10 58 31" src="https://user-images.githubusercontent.com/30963614/81792708-b4928680-9508-11ea-9ab5-b75611e2a12a.png">


#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

