### PR TITLE
Fixes misalignment affecting inputs and the register email form

### DIFF
--- a/src/login/styles/_SignupMain.scss
+++ b/src/login/styles/_SignupMain.scss
@@ -2,7 +2,7 @@
 #register-form {
   display: flex;
   flex-direction: row;
-  align-items: center;
+  align-items: baseline;
   margin-top: 0;
   &.form-group {
     margin-bottom: 0;

--- a/src/login/styles/_anti-bootstrap.scss
+++ b/src/login/styles/_anti-bootstrap.scss
@@ -22,7 +22,7 @@ input {
   border-bottom: solid 2px #161616;
 
   width: 100%;
-  padding: 0.25rem 0.5rem;
+  padding: 1.35rem 0.5rem;
   height: 2.25rem;
 }
 
@@ -37,7 +37,7 @@ select {
   border: none;
   outline: 0;
   width: 100%;
-  padding: 0.25rem 0.5rem;
+  padding: 1.35rem 0.5rem;
   height: 2.25rem;
   &.form-control.is-valid:focus {
     border: none;

--- a/src/login/styles/_anti-bootstrap.scss
+++ b/src/login/styles/_anti-bootstrap.scss
@@ -22,7 +22,7 @@ input {
   border-bottom: solid 2px #161616;
 
   width: 100%;
-  padding: 1.35rem 0.5rem;
+  padding: 1.25rem 0.5rem;
   height: 2.25rem;
 }
 
@@ -37,7 +37,7 @@ select {
   border: none;
   outline: 0;
   width: 100%;
-  padding: 1.35rem 0.5rem;
+  padding: 1.25rem 0.5rem;
   height: 2.25rem;
   &.form-control.is-valid:focus {
     border: none;


### PR DESCRIPTION
#### Description: 
Addresses misalignment (described in issue #289 ) of: 
- input and button height
- button position when error message is displayed under input (only seen at Registration > add email input, as all other inputs have persistent descriptive text) 

**Summary:** 
- Added padding to top and bottom of inputs from `0.25rem` to `1.25rem` (creating a total of `3rem` = button height)
- Made items in `#register-from` align along baseline to no longer be affected by the appearance of error message

---
###### Height of input and button same (Settings > Add email inputs) before and after:
<img width="300" alt="Screenshot 2020-05-14 at 13 56 15" src="https://user-images.githubusercontent.com/30963614/81934640-92bfff00-95ef-11ea-8f1c-66a049469b11.png"><img width="300" alt="Screenshot 2020-05-14 at 13 56 44" src="https://user-images.githubusercontent.com/30963614/81934646-93f12c00-95ef-11ea-91ab-071b0b8339e0.png">

###### Position of button with input error message (Register > Email) before and after:
<img width="300" alt="Screenshot 2020-05-14 at 14 17 01" src="https://user-images.githubusercontent.com/30963614/81934521-5f7d7000-95ef-11ea-9400-6281b56e0232.png"> <img width="300" alt="Screenshot 2020-05-14 at 14 17 55" src="https://user-images.githubusercontent.com/30963614/81934507-58eef880-95ef-11ea-83ca-b695879f0e74.png">

---

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

