### PR TITLE
Adds wrap to header text and email in dashboard

### DIFF
--- a/src/login/styles/_Header.scss
+++ b/src/login/styles/_Header.scss
@@ -19,6 +19,7 @@ header {
 .tagline {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   margin: 4rem 0 3rem 0;
   & span {
     margin-right: 0.375rem;


### PR DESCRIPTION
#### Description: Fix for header in dashboard (as described in issue #298 )

**Summary:**
- Adds `flex-wrap: wrap` to the two elements so they stack as soon as they don't fit on one line

---
###### Dashboard header (before and after): 
<img width="300" alt="Screenshot 2020-05-15 at 11 14 11" src="https://user-images.githubusercontent.com/30963614/82036340-15ed5d80-96a1-11ea-8444-b4fca7024b13.png"> <img width="300" alt="Screenshot 2020-05-15 at 11 35 45" src="https://user-images.githubusercontent.com/30963614/82036337-14239a00-96a1-11ea-8651-590555b4d41f.png">


#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

