### PR TITLE
Fix for broken register link on small screens

### DIFF
--- a/src/login/styles/_SignupMain.scss
+++ b/src/login/styles/_SignupMain.scss
@@ -25,7 +25,10 @@ h3 {
   }
 }
 .text-link-container {
-  display: flex;
+  display: block;
+  & span {
+    margin-right: 0.375rem;
+  }
 }
 
 .registered-email {

--- a/src/login/styles/_links.scss
+++ b/src/login/styles/_links.scss
@@ -11,11 +11,11 @@ a {
   }
   &.text-link {
     font-family: "ProximaNova-Regular";
-    text-decoration: none;
-    margin-left: 0.375rem;
-    border-bottom: solid #ff4500 1px;
+    text-decoration: underline;
+    line-height:1.4;
     &:hover {
-      border-bottom: solid transparent 1px;
+      text-decoration: none;
+      // border-bottom: solid transparent 1px;
       color: #ff4500;
     }
   }


### PR DESCRIPTION
#### Description: Text link on register page is broken when line wraps on smaller screens (as described in #299 )

**Summary:** 
- made container holding both elements (text and link) `display: block`

---
###### Register email input
<img width="300" alt="Screenshot 2020-05-15 at 11 37 10" src="https://user-images.githubusercontent.com/30963614/82038287-9d3bd080-96a3-11ea-8830-8811d0def6d1.png"> <img width="300" alt="Screenshot 2020-05-15 at 11 57 15" src="https://user-images.githubusercontent.com/30963614/82038291-9e6cfd80-96a3-11ea-8d37-b5385a50b338.png">



#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

