### PR TITLE
LOGIN: Updates naming of structural css in line with anatomy outlined in Figma

### DIFF
--- a/src/login/styles/_Notifications.scss
+++ b/src/login/styles/_Notifications.scss
@@ -6,7 +6,7 @@
   color: transparent;
   background-color: transparent;
   height: 3rem;
-  margin-bottom: 1rem;
+  margin-bottom: 0.75rem;
   width: 100%;
 }
 

--- a/src/login/styles/_Notifications.scss
+++ b/src/login/styles/_Notifications.scss
@@ -6,6 +6,7 @@
   color: transparent;
   background-color: transparent;
   height: 3rem;
+  margin-bottom: 1rem;
   width: 100%;
 }
 

--- a/src/login/styles/_Notifications.scss
+++ b/src/login/styles/_Notifications.scss
@@ -43,9 +43,6 @@
 }
 
 @media (max-width: 823px) {
-  .notifications-area {
-    height: 49px;
-  }
   .alert.alert-dismissible {
     padding: 0.5rem 1rem;
     & span {

--- a/src/login/styles/_base.scss
+++ b/src/login/styles/_base.scss
@@ -42,7 +42,7 @@ body {
   // max-width: 43.5rem;
   // this margin covers the notifications (check in the new login app why it is like this - plan for dashboard to have notifications under nav)
   // margin: -2.25rem auto 0 auto;
-  margin: 1rem auto;
+  margin: 0 auto;
   // this is added to prevent margin collapse (look for other solution if causing problems)
   display: flex;
   flex-direction: column;

--- a/src/sagas/common.js
+++ b/src/sagas/common.js
@@ -70,7 +70,7 @@ export function saveData(getData, formName, startAction, fetcher, failAction) {
     try {
       const state = yield select(state => state);
       const data = getData(state);
-      yield put(startAction(data));
+      yield put(startAction({...data}));
       yield put(startSubmit(formName));
       yield put(startAsyncValidation(formName));
       const resp = yield call(fetcher, state.config, data);


### PR DESCRIPTION
#### Description:
.css ids and classes names of structural elements in `App.js` (equivalent to "Main" component of other apps) updated in line with example anatomy created in Figma

**Summary:**
- removes top and bottom margins from `.vertical-content-margin` (as name implies it should only add a vertical margin, across the page)
- adds in `margin-bottom` to `<Notifications/>` to create space between text and alert
- removes styling for `<Notifications/>` at 823px and smaller 
   - the rule increased the height of notifications by 1px at small screens: `height: 49px` at small screens vs `height: 3rem` (48px) at any other size   

> **Not intended colours below!** 
Colouring only added for clarity (yellow: `<Notifications/>`, black border:`.vertical-content-margin`

###### Login app: Login form - margin changes (before and after)
<img width="300" alt="Screenshot 2020-06-12 at 14 30 18" src="https://user-images.githubusercontent.com/30963614/84505617-56e78a80-acbe-11ea-9cf6-8c8569a2b479.png"> <img width="300" alt="Screenshot 2020-06-12 at 14 51 34" src="https://user-images.githubusercontent.com/30963614/84505710-83030b80-acbe-11ea-97f1-46d3259047cc.png">
###### Login app: Reset password - margin changes (before and after)
<img width="300" alt="Screenshot 2020-06-12 at 14 32 24" src="https://user-images.githubusercontent.com/30963614/84506141-33710f80-acbf-11ea-9041-af2ceb208740.png"> <img width="300" alt="Screenshot 2020-06-12 at 14 46 02" src="https://user-images.githubusercontent.com/30963614/84506129-2bb16b00-acbf-11ea-9e57-7c28bc9cc9c7.png">

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

