### PR TITLE
SIGNUP MAIN: Updates naming of structural css in line with anatomy outlined in Figma 

### DIFF
--- a/src/components/AccountCreated.js
+++ b/src/components/AccountCreated.js
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 class AccountCreated extends Component {
   render() {
     return (
-      <div id="register-container" className="vertical-content-margin">
+      <div id="content" className="vertical-content-margin">
         <h3 className="register-header">
           {this.props.translate("created.account-created")}
         </h3>

--- a/src/components/Captcha.js
+++ b/src/components/Captcha.js
@@ -14,7 +14,7 @@ class Captcha extends Component {
     }
 
     return [
-      <div key="0" id="register-container" className="vertical-content-margin">
+      <div key="0" id="content" className="vertical-content-margin">
         <h3 className="register-header">
           {this.props.translate("captcha.verify-human")}
         </h3>

--- a/src/components/CodeVerified.js
+++ b/src/components/CodeVerified.js
@@ -6,7 +6,7 @@ class CodeVerified extends Component {
   render() {
     return (
       <form key="2" method="GET" action={this.props.dashboard_url} className="vertical-content-margin">
-        <div key="0" id="register-container">
+        <div key="0" id="content">
           <div>
             <h3 className="register-header">
               {this.props.translate("finish.registration-complete")}

--- a/src/components/Email.js
+++ b/src/components/Email.js
@@ -66,7 +66,7 @@ EmailForm = connect((state) => ({
 class Email extends Component {
   render() {
     return [
-      <div key="0" id="register-container" className="vertical-content-margin">
+      <div key="0" id="content" className="vertical-content-margin">
         <div className="text-content">
           <p className="sub-heading">
             {this.props.translate("register.sub-heading")}

--- a/src/components/EmailInUse.js
+++ b/src/components/EmailInUse.js
@@ -5,7 +5,7 @@ import EduIDButton from "./EduIDButton";
 class EmailInUse extends Component {
   render() {
     return (
-      <div id="register-container" className="vertical-content-margin">
+      <div id="content" className="vertical-content-margin">
         <div>
           <h3 className="register-header">
             {this.props.translate("used.email-in-use")({

--- a/src/components/ResendCode.js
+++ b/src/components/ResendCode.js
@@ -5,7 +5,7 @@ import EduIDButton from "components/EduIDButton";
 class ResendCode extends Component {
   render() {
     return (
-      <div id="register-container" className="vertical-content-margin">
+      <div id="content" className="vertical-content-margin">
         <h3 className="register-header">
           {this.props.translate("resend.link-sent")}
         </h3>

--- a/src/components/SignupMain.js
+++ b/src/components/SignupMain.js
@@ -76,7 +76,6 @@ class SignupMain extends Component {
       <SplashContainer key="0" />,
       <Router key="1" history={history}>
         <HeaderContainer {...this.props} />
-        <div id="dashboard-text">
           <section id="panel">
             <NotificationsContainer />
             <Route
@@ -106,7 +105,6 @@ class SignupMain extends Component {
               component={EmailInUseContainer}
             />
           </section>
-        </div>
         <FooterContainer {...this.props} />
       </Router>,
     ];

--- a/src/components/SignupMain.js
+++ b/src/components/SignupMain.js
@@ -75,41 +75,39 @@ class SignupMain extends Component {
     return [
       <SplashContainer key="0" />,
       <Router key="1" history={history}>
-        <div className="dashboard-wrapper">
-          <HeaderContainer {...this.props} />
-          <div id="dashboard-text">
-            <div id="content">
-              <NotificationsContainer />
-              <Route
-                exact
-                path={`${BASE_PATH}`}
-                component={() => <Redirect to={redirect} />}
-              />
-              <Route path={`${BASE_PATH}/email`} component={EmailContainer} />
-              <Route
-                path={`${BASE_PATH}/trycaptcha`}
-                component={CaptchaContainer}
-              />
-              <Route
-                path={`${BASE_PATH}/new`}
-                component={AccountCreatedContainer}
-              />
-              <Route
-                path={`${BASE_PATH}/code-verified`}
-                component={CodeVerifiedContainer}
-              />
-              <Route
-                path={`${BASE_PATH}/resend-code`}
-                component={ResendCodeContainer}
-              />
-              <Route
-                path={`${BASE_PATH}/address-used`}
-                component={EmailInUseContainer}
-              />
-            </div>
+        <HeaderContainer {...this.props} />
+        <div id="dashboard-text">
+          <div id="content">
+            <NotificationsContainer />
+            <Route
+              exact
+              path={`${BASE_PATH}`}
+              component={() => <Redirect to={redirect} />}
+            />
+            <Route path={`${BASE_PATH}/email`} component={EmailContainer} />
+            <Route
+              path={`${BASE_PATH}/trycaptcha`}
+              component={CaptchaContainer}
+            />
+            <Route
+              path={`${BASE_PATH}/new`}
+              component={AccountCreatedContainer}
+            />
+            <Route
+              path={`${BASE_PATH}/code-verified`}
+              component={CodeVerifiedContainer}
+            />
+            <Route
+              path={`${BASE_PATH}/resend-code`}
+              component={ResendCodeContainer}
+            />
+            <Route
+              path={`${BASE_PATH}/address-used`}
+              component={EmailInUseContainer}
+            />
           </div>
-          <FooterContainer {...this.props} />
         </div>
+        <FooterContainer {...this.props} />
       </Router>,
     ];
   }

--- a/src/components/SignupMain.js
+++ b/src/components/SignupMain.js
@@ -77,7 +77,7 @@ class SignupMain extends Component {
       <Router key="1" history={history}>
         <HeaderContainer {...this.props} />
         <div id="dashboard-text">
-          <div id="content">
+          <section id="panel">
             <NotificationsContainer />
             <Route
               exact
@@ -105,7 +105,7 @@ class SignupMain extends Component {
               path={`${BASE_PATH}/address-used`}
               component={EmailInUseContainer}
             />
-          </div>
+          </section>
         </div>
         <FooterContainer {...this.props} />
       </Router>,

--- a/src/login/styles/_typography.scss
+++ b/src/login/styles/_typography.scss
@@ -83,7 +83,7 @@ p.steps {
   font-weight: 700;
 }
 
-#register-container {
+#content{
   .sub-heading {
     margin-top: 0rem;
     font-size: 1.25rem;

--- a/src/login/styles/_typography.scss
+++ b/src/login/styles/_typography.scss
@@ -20,7 +20,6 @@ h2 {
 h3 {
   font-size: 24px;
   line-height: 34px;
-  // margin-top: 56px;
 }
 
 h4 {
@@ -46,14 +45,13 @@ p {
 }
 
 p.verified {
-  color: #161616;
+  color: $black;
 }
 
 // these styles are the same as input values and placeholder
 p.data {
   font-size: 1.5rem;
   font-weight: 500;
-  // padding: 0.25rem 0.5rem;
 }
 
 p.no-data.data {
@@ -89,7 +87,6 @@ p.steps {
     font-size: 1.25rem;
     line-height: 1.5;
     font-family: "ProximaNova-Bold";
-    // font-weight: 700;
   }
   .text-content {
     margin-bottom: 2rem;


### PR DESCRIPTION
#### Description:
.css ids and classes names of structural elements in `SignupMain.js` (equivalent to "Main" component of other apps) updated in line with example anatomy created in Figma

- remove `div .dashboard-wrapper`
- replace `#register-container` to `#content` 
  @src/components/AccountCreated.js 
  @src/components/Captcha.js 
  @src/components/CodeVerified.js 
  @src/components/Email.js 
  @src/components/EmailInUse.js
  @src/components/ResendCode.js 
  @src/components/ResendCode.js
  @src/components/SignupMain.js 
  @src/login/styles/_typography.scss 



_Before_
<img width="540" alt="Screenshot 2020-06-12 at 15 23 40" src="https://user-images.githubusercontent.com/44289056/84507209-c0689880-acc0-11ea-8460-7d6b7bdae3cb.png">

_After_
<img width="521" alt="Screenshot 2020-06-12 at 15 22 33" src="https://user-images.githubusercontent.com/44289056/84507069-8f886380-acc0-11ea-983e-76278c44b438.png">

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

