### PR TITLE
SIGNUP: Updates naming of structural css in line with anatomy outlined in Figma

### DIFF
--- a/plugins/eduid_action.tou/component.js
+++ b/plugins/eduid_action.tou/component.js
@@ -18,9 +18,9 @@ class Main extends Component {
   render() {
     return (
       <ActionWrapperContainer>
-        <h3 key="0" className="tou-title">
+        <p key="0" className="heading">
           {this.props.translate("tou.header")}
-        </h3>
+        </p>
         <div
           // className="card-body"
           id="eduid-tou"

--- a/plugins/eduid_action.tou/style.scss
+++ b/plugins/eduid_action.tou/style.scss
@@ -1,25 +1,12 @@
-.tou-title,
-#eduid-tou {
-  width: 58.3333333333%;
-  margin: 0 auto;
-}
-
-.tou-title {
-  margin-top: 30px;
-  font-weight: 700;
-}
-
 #eduid-tou li {
   font-size: 20px;
   line-height: 24px;
   margin-top: 24px;
-  padding-right: 20px;
 }
 
 #eduid-tou p {
   margin-top: 4rem;
   margin-bottom: 1rem;
-  padding-right: 20px;
 }
 
 #tou-buttons {
@@ -36,22 +23,16 @@
 }
 
 @media (max-width: 823px) {
-  .tou-title,
   #eduid-tou {
-    // padding: 3rem 0 2rem;
     width: 75%;
   }
 }
 
 @media (max-width: 768px) {
-  .tou-title,
   #eduid-tou {
-    // padding: 3rem 20px 2rem 0;
     width: calc(100% - 40px);
   }
-  .tou-title {
-    margin-top: 15px;
-  }
+
   #eduid-tou p {
     margin-top: 2rem;
   }
@@ -62,20 +43,4 @@
   }
 }
 
-@media (max-width: 414px) {
-  .tou-title {
-    margin-top: 30px;
-  }
-  #eduid-tou ul {
-    padding-left: 20px;
-  }
-  #eduid-tou li {
-    font-size: 20px;
-    line-height: 24px;
-    margin-top: 24px;
-  }
-  #eduid-tou p {
-    font-size: 20px;
-    line-height: 24px;
-  }
-}
+@media (max-width: 414px) { }

--- a/src/components/ActionWrapper.js
+++ b/src/components/ActionWrapper.js
@@ -40,27 +40,19 @@ class ActionWrapper extends Component {
     return [
       <SplashContainer key="0" />,
       <Router key="1" history={history}>
-        <div className="dashboard-wrapper">
-          <HeaderContainer {...this.props} />
-          <div id="dashboard-text">
-            <div id="banner">
-              <h1 className="banner-tagline">
-                {this.props.translate("banner.tagline")}
-              </h1>
-            </div>
-
-            <div id="content">
-              <NotificationsContainer />
-              <Route
-                exact
-                path={`${BASE_PATH}`}
-                component={() => <Redirect to={this.props.redirect} />}
-              />
-              {this.props.children}
-            </div>
+        <HeaderContainer {...this.props} />
+        <section id="panel">
+          <NotificationsContainer />
+          <div key="0" id="content" className="vertical-content-margin">
+            <Route
+              exact
+              path={`${BASE_PATH}`}
+              component={() => <Redirect to={this.props.redirect} />}
+            />
+            {this.props.children}
           </div>
-          <FooterContainer {...this.props} />
-        </div>
+        </section>
+        <FooterContainer {...this.props} />
       </Router>,
     ];
   }

--- a/src/components/Email.js
+++ b/src/components/Email.js
@@ -67,24 +67,19 @@ class Email extends Component {
   render() {
     return [
       <div key="0" id="content" className="vertical-content-margin">
-        <div className="text-content">
-          <p className="sub-heading">
-            {this.props.translate("register.sub-heading")}
-          </p>
-          <p>{this.props.translate("register.paragraph")}</p>
-        </div>
-        <div className="text-content">
-          <label>{this.props.translate("signup.registering-input")}</label>
-          <EmailForm {...this.props} />
-        </div>
-        <div className="text-content">
-          <p className="text-link-container">
-            <span>{this.props.translate("register.toLogin")}</span>
-            <a className="text-link" href={this.props.dashboard_url}>
-              <span>{this.props.translate("text.link")}</span>
-            </a>
-          </p>
-        </div>
+        <p className="sub-heading">
+          {this.props.translate("register.sub-heading")}
+        </p>
+        <p>{this.props.translate("register.paragraph")}</p>
+
+        <label>{this.props.translate("signup.registering-input")}</label>
+        <EmailForm {...this.props} />
+        <p className="text-link-container">
+          <span>{this.props.translate("register.toLogin")}</span>
+          <a className="text-link" href={this.props.dashboard_url}>
+            <span>{this.props.translate("text.link")}</span>
+          </a>
+        </p>
       </div>,
       <div key="1">
         <Modal isOpen={this.props.acceptingTOU} id="register-modal">

--- a/src/components/Email.js
+++ b/src/components/Email.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import TextInput from "components/EduIDTextInput";
+import Input from "../login/components/Inputs/Input";
 import { Field, reduxForm } from "redux-form";
 import {
   FormFeedback,
@@ -35,7 +35,7 @@ let EmailForm = (props) => (
       name="email"
       componentClass="input"
       id="email-input"
-      component={TextInput}
+      component={Input}
       translate={props.translate}
       placeholder="example@email.com"
     />

--- a/src/components/Email.js
+++ b/src/components/Email.js
@@ -67,7 +67,7 @@ class Email extends Component {
   render() {
     return [
       <div key="0" id="content" className="vertical-content-margin">
-        <p className="sub-heading">
+        <p className="heading">
           {this.props.translate("register.sub-heading")}
         </p>
         <p>{this.props.translate("register.paragraph")}</p>

--- a/src/components/Email.js
+++ b/src/components/Email.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import { connect } from "react-redux";
-import Input from "../login/components/Inputs/Input";
+import TextInput from "components/EduIDTextInput";
 import { Field, reduxForm } from "redux-form";
 import {
   FormFeedback,
@@ -35,7 +35,7 @@ let EmailForm = (props) => (
       name="email"
       componentClass="input"
       id="email-input"
-      component={Input}
+      component={TextInput}
       translate={props.translate}
       placeholder="example@email.com"
     />

--- a/src/login/styles/_typography.scss
+++ b/src/login/styles/_typography.scss
@@ -75,16 +75,6 @@ p.steps {
   }
 }
 
-
-#content{
-  .sub-heading {
-    margin-top: 0rem;
-    font-size: 1.25rem;
-    line-height: 1.5;
-    font-family: "ProximaNova-Bold";
-  }
-}
-
 span.heading,
 p.heading {
   font-family: "ProximaNova-Bold";

--- a/src/login/styles/_typography.scss
+++ b/src/login/styles/_typography.scss
@@ -83,9 +83,6 @@ p.steps {
     line-height: 1.5;
     font-family: "ProximaNova-Bold";
   }
-  .text-content {
-    margin-bottom: 2rem;
-  }
 }
 
 span.heading,


### PR DESCRIPTION
#### Description:
.css ids and classes names of structural elements in SignupMain.js updated in line with example anatomy created in Figma

#### Summary:
- Remove `.text-content`
- Change className .`sub-headin`g to `.heading`
- Remove `#content .heading` styling
- Import Input from LoginApp to have same styling as Login

_Before_
![Screenshot 2020-06-15 at 11 47 11](https://user-images.githubusercontent.com/44289056/84644948-3149c380-af00-11ea-869c-3483ef211317.png)
![Screenshot 2020-06-15 at 12 07 47](https://user-images.githubusercontent.com/44289056/84645423-d82e5f80-af00-11ea-94cd-cf0775411483.png)




_After_
![Screenshot 2020-06-15 at 12 02 31](https://user-images.githubusercontent.com/44289056/84644965-36a70e00-af00-11ea-81d4-b1690dc93656.png)
![Screenshot 2020-06-15 at 12 34 12](https://user-images.githubusercontent.com/44289056/84648003-956e8680-af04-11ea-9bff-8c8a925b194b.png)


#### For reviewer:
- [x] Read the above description
- [x] Reviewed the code changes
- [x] Navigate to the branch (pulled the latest version)
- [x] Run the code and been able to execute the expected function
- [x] Check any styling on both desktop and mobile sizes

