### PR TITLE
VETTING: Refactor of <VerifyIdentity> to be able to better follow how vetting buttons render

### DIFF
--- a/src/components/VerifyIdentity.js
+++ b/src/components/VerifyIdentity.js
@@ -9,78 +9,107 @@ import "../login/styles/index.scss";
 
 class VerifyIdentity extends Component {
   render() {
-    let vettingButtons = "";
-    let connectNin = "";
-    let headerText = "";
-    let recoverIdentityTip = "";
-    let ninExplanation = this.props.translate(
-      "verify-identity.unverified_page-description"
-    );
-    let numberedHeading = this.props.translate(
-      "verify-identity.add-nin_heading"
-    );
-    let buttonHelpTextArray = [
-      this.props.translate("letter.initialize_proofing_help_text"),
-      this.props.translate("lmp.initialize_proofing_help_text"),
-      this.props.translate("eidas.initialize_proofing_help_text"),
-    ];
-    if (this.props.is_configured) {
-      const vettingBtns = vettingRegistry(!this.props.valid_nin);
-      const verifyOptions = this.props.proofing_methods.filter(
-        (option) => option !== "oidc"
-      );
-      vettingButtons = verifyOptions.map((key, index) => {
-        let helpText = buttonHelpTextArray[index];
-        return (
-          <div key={index}>
-            {vettingBtns[key]}
-            <p key={index} className="proofing-btn-help">
-              {helpText}
-            </p>
-          </div>
-        );
-      });
-    }
+    // page text depend on nin status (verified or not)
+    let pageHeading = "";
+    let pageText = "";
 
-    if (!this.props.verifiedNinStatus) {
-      headerText = this.props.translate(
+    // nin is not verified (add nin)
+    let AddNumber = (props) => {
+      pageHeading = this.props.translate(
         "verify-identity.unverified_main_title"
       );
-      connectNin = [
-        <div key="1" className="intro">
-          <h3 key="0">
-            {this.props.translate("verify-identity.connect-nin_heading")}
-          </h3>
-          <p>
-            {this.props.translate("verify-identity.connect-nin_description")}
-          </p>
-          <div key="1" id="nins-btn-grid">
-            {vettingButtons}
-          </div>
-        </div>,
-      ];
-    } else if (this.props.verifiedNinStatus) {
-      headerText = this.props.translate("verify-identity.verified_main_title");
-      connectNin = "";
-      numberedHeading = "";
-      ninExplanation = this.props.translate(
+      pageText = this.props.translate(
+        "verify-identity.unverified_page-description"
+      );
+      return (
+        <div key="0" className="intro">
+          <h4>{pageHeading}</h4>
+          <p>{pageText}</p>
+          <h3>{this.props.translate("verify-identity.add-nin_heading")}</h3>
+        </div>
+      );
+    };
+
+    let NumberAdded = (props) => {
+      // nin is verified (nin added)
+      pageHeading = this.props.translate("verify-identity.verified_main_title");
+      pageText = this.props.translate(
         "verify-identity.verified_page-description"
       );
       recoverIdentityTip = this.props.translate(
         "verify-identity.verified_pw_reset_extra_security"
       );
-    }
+      return (
+        <div key="0" className="intro">
+          <h4>{pageHeading}</h4>
+          <p>{pageText}</p>
+        </div>
+      );
+    };
 
+    // top half of page: add nin/nin added
+    let VerifyIdentity_Step1 = (props) => {
+      if (this.props.verifiedNinStatus) {
+        return <NumberAdded {...this.props} />;
+      } else {
+        return <AddNumber {...this.props} />;
+      }
+    };
+
+    // rendering of vetting buttons from options in an object in another file
+    let VettingButtons = (props) => {
+      // this is the help text under the first 3 vetting buttons
+      let helpTextArray = [
+        this.props.translate("letter.initialize_proofing_help_text"),
+        this.props.translate("lmp.initialize_proofing_help_text"),
+        this.props.translate("eidas.initialize_proofing_help_text"),
+      ];
+
+      // this is an object listing all the vetting components in another file (src/vetting-registry.js)
+      const vettingOptionsObject = vettingRegistry(!this.props.valid_nin);
+      // extract the keys from the vettingOptionsObject
+      const vettingOptionsKeys = Object.keys(vettingOptionsObject);
+
+      // this is where each button is rendered based on the vettingOptionsList object
+      return vettingOptionsKeys.map((key, i) => {
+        let helpText = helpTextArray[i];
+        return (
+          <div key={i}>
+            {vettingOptionsObject[key]}
+            <p key={i} className="proofing-btn-help">
+              {helpText}
+            </p>
+          </div>
+        );
+      });
+    };
+
+    // bottom half of page: vetting on added nin
+    let VerifyIdentity_Step2 = (props) => {
+      if (this.props.is_configured && !this.props.verifiedNinStatus) {
+        return (
+          <div key="1" className="intro">
+            <h3>
+              {this.props.translate("verify-identity.connect-nin_heading")}
+            </h3>
+            <p>
+              {this.props.translate("verify-identity.connect-nin_description")}
+            </p>
+            <div key="1" id="nins-btn-grid">
+              <VettingButtons {...this.props} />
+            </div>
+          </div>
+        );
+      } else {
+        return <div />;
+      }
+    };
+  
     return (
       <Fragment>
-        <div key="0" className="intro">
-          <h4>{headerText}</h4>
-          <p>{ninExplanation}</p>
-          <h3>{numberedHeading}</h3>
-          <AddNin {...this.props} />
-          <p className="help-text">{recoverIdentityTip}</p>
-        </div>
-        {connectNin}
+        <VerifyIdentity_Step1 {...this.props} />
+        <AddNin {...this.props} />
+        <VerifyIdentity_Step2 {...this.props} />
       </Fragment>
     );
   }

--- a/src/components/VerifyIdentity.js
+++ b/src/components/VerifyIdentity.js
@@ -15,28 +15,28 @@ class VerifyIdentity extends Component {
 
     // nin is not verified (add nin)
     let AddNumber = (props) => {
-      pageHeading = this.props.translate(
+      pageHeading = props.translate(
         "verify-identity.unverified_main_title"
       );
-      pageText = this.props.translate(
+      pageText = props.translate(
         "verify-identity.unverified_page-description"
       );
       return (
         <div key="0" className="intro">
           <h4>{pageHeading}</h4>
           <p>{pageText}</p>
-          <h3>{this.props.translate("verify-identity.add-nin_heading")}</h3>
+          <h3>{props.translate("verify-identity.add-nin_heading")}</h3>
         </div>
       );
     };
 
     let NumberAdded = (props) => {
       // nin is verified (nin added)
-      pageHeading = this.props.translate("verify-identity.verified_main_title");
-      pageText = this.props.translate(
+      pageHeading = props.translate("verify-identity.verified_main_title");
+      pageText = props.translate(
         "verify-identity.verified_page-description"
       );
-      recoverIdentityTip = this.props.translate(
+      recoverIdentityTip = props.translate(
         "verify-identity.verified_pw_reset_extra_security"
       );
       return (

--- a/src/components/VerifyIdentity.js
+++ b/src/components/VerifyIdentity.js
@@ -107,9 +107,9 @@ class VerifyIdentity extends Component {
   
     return (
       <Fragment>
-        <VerifyIdentity_Step1 {...this.props} />
+        <VerifyIdentity_Step1 />
         <AddNin {...this.props} />
-        <VerifyIdentity_Step2 {...this.props} />
+        <VerifyIdentity_Step2 />
       </Fragment>
     );
   }

--- a/src/components/VerifyIdentity.js
+++ b/src/components/VerifyIdentity.js
@@ -57,7 +57,7 @@ class VerifyIdentity extends Component {
     };
 
     // rendering of vetting buttons from options in an object in another file
-    let VettingButtons = (props) => {
+    let VettingButtons = () => {
       // this is the help text under the first 3 vetting buttons
       let helpTextArray = [
         this.props.translate("letter.initialize_proofing_help_text"),
@@ -96,7 +96,7 @@ class VerifyIdentity extends Component {
               {this.props.translate("verify-identity.connect-nin_description")}
             </p>
             <div key="1" id="nins-btn-grid">
-              <VettingButtons {...this.props} />
+              <VettingButtons />
             </div>
           </div>
         );

--- a/src/components/VerifyIdentity.js
+++ b/src/components/VerifyIdentity.js
@@ -48,7 +48,7 @@ class VerifyIdentity extends Component {
     };
 
     // top half of page: add nin/nin added
-    let VerifyIdentity_Step1 = (props) => {
+    let VerifyIdentity_Step1 = () => {
       if (this.props.verifiedNinStatus) {
         return <NumberAdded {...this.props} />;
       } else {
@@ -85,7 +85,7 @@ class VerifyIdentity extends Component {
     };
 
     // bottom half of page: vetting on added nin
-    let VerifyIdentity_Step2 = (props) => {
+    let VerifyIdentity_Step2 = () => {
       if (this.props.is_configured && !this.props.verifiedNinStatus) {
         return (
           <div key="1" className="intro">


### PR DESCRIPTION
#### Description:
A quick refactor of `<VerifyIdentity/>` to be able to follow more clearly how the vetting buttons are rendered and in particular see how `<OpenidConnect/>` works.

**Summary:**
- This is by no means a perfect job just a quick restructure of a component that was an even greater mess to begin with
- component now restructured into separate functions:

```
<VerifyIdentity_Step1 />
   <Number added> (if nin is verified) 
   <AddNumber> (if nin is not verified) 
<AddNin/> (the nin input/display of added nin - which has its own complicated render logic that I am not going to touch now)
<VerifyIdentity_Step2 />
  <VettingButtons>
```

Note, as this is not a full path for group management, I will keep it separate from master and request that it is merged into a group management path branch

Next steps:
- will be to look closer at `<OpenidConnect/>` and its `<CookieChecker/>` child
- the `<CookieChecker/>` could be suitable for the hidden group management path

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

