### PR TITLE
INPUT: Add placeholder in given_name, surname fields

### DIFF
--- a/src/components/PersonalData.js
+++ b/src/components/PersonalData.js
@@ -35,6 +35,7 @@ let PdataForm = (props) => {
           type="text"
           name="given_name"
           label={props.translate("pd.given_name")}
+          placeholder={props.translate("pd.given_name")}
         />
         <Field
           component={TextInput}
@@ -42,6 +43,7 @@ let PdataForm = (props) => {
           type="text"
           name="surname"
           label={props.translate("pd.surname")}
+          placeholder={props.translate("pd.surname")}
         />
         <Field
           component={TextInput}


### PR DESCRIPTION
#### Description:

- first name (given_name) and last name(surname) are missing place holders.
- added `placeholder={props.translate("pd.given_name")} placeholder={props.translate("pd.surname")}`

**before and after**
![Screenshot 2020-07-14 at 11 02 16](https://user-images.githubusercontent.com/44289056/87406785-83ded400-c5c1-11ea-9531-81485fe5b7ec.png)



#### For reviewer:
- [x] Read the above description
- [x] Reviewed the code changes
- [x] Navigate to the branch (pulled the latest version)
- [x] Run the code and been able to execute the expected function
- [x] Check any styling on both desktop and mobile sizes

