### PR TITLE
SELECT LANGUAGE: Add translation language options

### DIFF
--- a/i18n/src/login/translation/messageIndex.json
+++ b/i18n/src/login/translation/messageIndex.json
@@ -4,6 +4,14 @@
     "defaultMessage": "Choose language"
   },
   {
+    "id": "pd.language-english",
+    "defaultMessage": "English"
+  },
+  {
+    "id": "pd.language-swedish",
+    "defaultMessage": "Swedish"
+  },
+  {
     "id": "emails.confirm_email_placeholder",
     "description": "Placeholder for email text input",
     "defaultMessage": "Email confirmation code"

--- a/src/components/EduIDTextInput.js
+++ b/src/components/EduIDTextInput.js
@@ -8,6 +8,7 @@ import Input from "reactstrap/lib/Input";
 import Label from "reactstrap/lib/Label";
 import i18n from "../login/translation/InjectIntl_HOC_factory";
 
+
 const textInput = props => {
   const {
     input,
@@ -60,7 +61,10 @@ const textInput = props => {
             value={option[0]}
             checked={option[0]===input.value}
           />
-          <span key={index}>{option[1]}</span>
+          <span key={index}>{option[1] === "English" ? 
+            props.translate("pd.language-english") 
+            : props.translate("pd.language-swedish")}
+          </span>
           </label>
         </Fragment>
       );

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -242,6 +242,8 @@
   "out_of_sync": "User data is out of sync. Reload page to re-sync.",
   "pd.all-data-success": "Successfully retrieved personal information",
   "pd.choose-language": "Choose language",
+  "pd.language-english": "English",
+  "pd.language-swedish": "Swedish",
   "pd.display_name": "Display Name",
   "pd.display_name_input_help_text": "Some services will show this instead of your first and last name.",
   "pd.display_name_inputplaceholder": "First and last name",

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -242,6 +242,8 @@
   "out_of_sync": "Användardata ur synk. Var god ladda om sidan.",
   "pd.all-data-success": "Kontodata laddat",
   "pd.choose-language": "Välj språk",
+  "pd.language-english": "Engelska",
+  "pd.language-swedish": "Svenska",
   "pd.display_name": "Visningsnamn",
   "pd.display_name_input_help_text": "Vissa tjänster visar detta i stället för förnamn och efternamn.",
   "pd.display_name_inputplaceholder": "Förnamn Efternamn",

--- a/src/login/translation/messageIndex.js
+++ b/src/login/translation/messageIndex.js
@@ -35,6 +35,14 @@ export const unformattedMessages = defineMessages({
     id: "pd.choose-language",
     defaultMessage: `Choose language`
   },
+  "pd.language-english": {
+    id: "pd.language-english",
+    defaultMessage: `English`
+  },
+  "pd.language-swedish": {
+    id: "pd.language-swedish",
+    defaultMessage: `Swedish`
+  },
   "emails.placeholder": {
     id: "emails.confirm_email_placeholder",
     defaultMessage: `Email confirmation code`,

--- a/src/login/translation/src/login/translation/messageIndex.json
+++ b/src/login/translation/src/login/translation/messageIndex.json
@@ -4,6 +4,14 @@
     "defaultMessage": "Choose language"
   },
   {
+    "id": "pd.language-english",
+    "defaultMessage": "English"
+  },
+  {
+    "id": "pd.language-swedish",
+    "defaultMessage": "Swedish"
+  },
+  {
     "id": "emails.confirm_email_placeholder",
     "description": "Placeholder for email text input",
     "defaultMessage": "Email confirmation code"


### PR DESCRIPTION
#### Description:
we had mixed language options in select language.
I added a translation of language options.

- in English version, option will be **English** and **Swedish**.
- in Swedish version, options will be **Engelska** and **Svenska**.

**Previous version**

<img width="918" alt="Screenshot 2020-07-21 at 13 12 17" src="https://user-images.githubusercontent.com/44289056/88048568-d71dcd00-cb53-11ea-8b8a-5e172c9b70da.png">

**Current version (in English)**
<img width="912" alt="Screenshot 2020-07-21 at 13 08 34" src="https://user-images.githubusercontent.com/44289056/88048490-b786a480-cb53-11ea-8808-3002c6bb5e2d.png">
**Current version (in Swedish)**
<img width="981" alt="Screenshot 2020-07-21 at 13 08 15" src="https://user-images.githubusercontent.com/44289056/88048494-b9506800-cb53-11ea-9f25-38dd537e0167.png">



#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

