### PR TITLE
SWEDISH TRANSLATION: Adjust Swedish text in vetting buttons and help text

### DIFF
--- a/i18n/src/login/translation/defaultMessages/userProfile.json
+++ b/i18n/src/login/translation/defaultMessages/userProfile.json
@@ -85,15 +85,15 @@
   },
   {
     "id": "verify-identity.vetting_post_tagline",
-    "defaultMessage": "For those registered at their current address"
+    "defaultMessage": "For you registered at your current address"
   },
   {
     "id": "verify-identity.vetting_phone_tagline",
-    "defaultMessage": "For those with a phone registered in their name"
+    "defaultMessage": "For you with a phone registered in your name"
   },
   {
     "id": "verify-identity.vetting_freja_tagline",
-    "defaultMessage": "For those able to create a Freja eID by visiting one of the authorised agents"
+    "defaultMessage": "For you able to create a Freja eID by visiting one of the authorised agents"
   },
   {
     "id": "verify-identity.connect-nin_heading",

--- a/i18n/src/login/translation/defaultMessages/userProfile.json
+++ b/i18n/src/login/translation/defaultMessages/userProfile.json
@@ -89,7 +89,7 @@
   },
   {
     "id": "verify-identity.vetting_phone_tagline",
-    "defaultMessage": "For you with a phone registered in your name"
+    "defaultMessage": "For you with a phone number registered in your name"
   },
   {
     "id": "verify-identity.vetting_freja_tagline",

--- a/src/login/translation/defaultMessages/userProfile.js
+++ b/src/login/translation/defaultMessages/userProfile.js
@@ -153,7 +153,7 @@ export const userProfile = {
   "verify-identity.vetting_phone_tagline": (
     <FormattedMessage
       id="verify-identity.vetting_phone_tagline"
-      defaultMessage={`For you with a phone registered in your name`}
+      defaultMessage={`For you with a phone number registered in your name`}
     />
   ),
 

--- a/src/login/translation/defaultMessages/userProfile.js
+++ b/src/login/translation/defaultMessages/userProfile.js
@@ -146,21 +146,21 @@ export const userProfile = {
   "verify-identity.vetting_post_tagline": (
     <FormattedMessage
       id="verify-identity.vetting_post_tagline"
-      defaultMessage={`For those registered at their current address`}
+      defaultMessage={`For you registered at your current address`}
     />
   ),
 
   "verify-identity.vetting_phone_tagline": (
     <FormattedMessage
       id="verify-identity.vetting_phone_tagline"
-      defaultMessage={`For those with a phone registered in their name`}
+      defaultMessage={`For you with a phone registered in your name`}
     />
   ),
 
   "verify-identity.vetting_freja_tagline": (
     <FormattedMessage
       id="verify-identity.vetting_freja_tagline"
-      defaultMessage={`For those able to create a Freja eID by visiting one of the authorised agents`}
+      defaultMessage={`For you able to create a Freja eID by visiting one of the authorised agents`}
     />
   ),
 

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -391,7 +391,7 @@
   "verify-identity.verified_main_title": "Your eduID is ready to use",
   "verify-identity.verified_page-description": "The below id number is now connected to this eduID. Use your eduID to log in to sevices related to higher education.",
   "verify-identity.verified_pw_reset_extra_security": "Add a phone number or a security key to your eduID to keep your identity at password reset.",
-  "verify-identity.vetting_freja_tagline": "For those able to create a Freja eID by visiting one of the authorised agents",
-  "verify-identity.vetting_phone_tagline": "For those with a phone registered in their name",
-  "verify-identity.vetting_post_tagline": "For those registered at their current address"
+  "verify-identity.vetting_freja_tagline": "For you able to create a Freja eID by visiting one of the authorised agents",
+  "verify-identity.vetting_phone_tagline": "For you with a phone registered in your name",
+  "verify-identity.vetting_post_tagline": "For you registered at your current address"
 }

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -392,6 +392,6 @@
   "verify-identity.verified_page-description": "The below id number is now connected to this eduID. Use your eduID to log in to sevices related to higher education.",
   "verify-identity.verified_pw_reset_extra_security": "Add a phone number or a security key to your eduID to keep your identity at password reset.",
   "verify-identity.vetting_freja_tagline": "For you able to create a Freja eID by visiting one of the authorised agents",
-  "verify-identity.vetting_phone_tagline": "For you with a phone registered in your name",
+  "verify-identity.vetting_phone_tagline": "For you with a phone number registered in your name",
   "verify-identity.vetting_post_tagline": "For you registered at your current address"
 }

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -392,6 +392,6 @@
   "verify-identity.verified_page-description": "Personummret nedan är nu kopplat till detta eduID. Använd ditt eduID för att logga in till  olika tjänster inom högskolan.",
   "verify-identity.verified_pw_reset_extra_security": "Lägg till ett telefonnummer eller en säkerhetsnyckel för att behålla din identitet om du återställer ditt lösenord.",
   "verify-identity.vetting_freja_tagline": "För dig som har eller kan skapa Freja eID genom att besöka ett ombud i Sverige",
-  "verify-identity.vetting_phone_tagline": "För dig som har ett telefonabonnemang i sitt eget namn",
-  "verify-identity.vetting_post_tagline": "För dig som har tillgång till sin folkbokföringsaddress"
+  "verify-identity.vetting_phone_tagline": "För dig som har ett telefonabonnemang i ditt eget namn",
+  "verify-identity.vetting_post_tagline": "För dig som har tillgång till din folkbokföringsaddress"
 }

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -391,7 +391,7 @@
   "verify-identity.verified_main_title": "Ditt eduID är redo att användas",
   "verify-identity.verified_page-description": "Personummret nedan är nu kopplat till detta eduID. Använd ditt eduID för att logga in till  olika tjänster inom högskolan.",
   "verify-identity.verified_pw_reset_extra_security": "Lägg till ett telefonnummer eller en säkerhetsnyckel för att behålla din identitet om du återställer ditt lösenord.",
-  "verify-identity.vetting_freja_tagline": "För de som har eller kan skapa Freja eID genom att besöka ett ombud i Sverige",
-  "verify-identity.vetting_phone_tagline": "För de som har ett telefonabonnemang i sitt eget namn",
-  "verify-identity.vetting_post_tagline": "För de som har tillgång till sin folkbokföringsaddress"
+  "verify-identity.vetting_freja_tagline": "För dig som har eller kan skapa Freja eID genom att besöka ett ombud i Sverige",
+  "verify-identity.vetting_phone_tagline": "För dig som har ett telefonabonnemang i sitt eget namn",
+  "verify-identity.vetting_post_tagline": "För dig som har tillgång till sin folkbokföringsaddress"
 }

--- a/src/login/translation/src/i18n-messages.json
+++ b/src/login/translation/src/i18n-messages.json
@@ -445,7 +445,7 @@
   },
   {
     "id": "verify-identity.vetting_phone_tagline",
-    "defaultMessage": "For you with a phone registered in your name"
+    "defaultMessage": "For you with a phone number registered in your name"
   },
   {
     "id": "verify-identity.vetting_freja_tagline",

--- a/src/login/translation/src/i18n-messages.json
+++ b/src/login/translation/src/i18n-messages.json
@@ -441,15 +441,15 @@
   },
   {
     "id": "verify-identity.vetting_post_tagline",
-    "defaultMessage": "For those registered at their current address"
+    "defaultMessage": "For you registered at your current address"
   },
   {
     "id": "verify-identity.vetting_phone_tagline",
-    "defaultMessage": "For those with a phone registered in their name"
+    "defaultMessage": "For you with a phone registered in your name"
   },
   {
     "id": "verify-identity.vetting_freja_tagline",
-    "defaultMessage": "For those able to create a Freja eID by visiting one of the authorised agents"
+    "defaultMessage": "For you able to create a Freja eID by visiting one of the authorised agents"
   },
   {
     "id": "verify-identity.connect_nin_title",

--- a/src/login/translation/src/login/translation/defaultMessages/userProfile.json
+++ b/src/login/translation/src/login/translation/defaultMessages/userProfile.json
@@ -97,7 +97,7 @@
   },
   {
     "id": "verify-identity.vetting_phone_tagline",
-    "defaultMessage": "For you with a phone registered in your name"
+    "defaultMessage": "For you with a phone number registered in your name"
   },
   {
     "id": "verify-identity.vetting_freja_tagline",

--- a/src/login/translation/src/login/translation/defaultMessages/userProfile.json
+++ b/src/login/translation/src/login/translation/defaultMessages/userProfile.json
@@ -93,15 +93,15 @@
   },
   {
     "id": "verify-identity.vetting_post_tagline",
-    "defaultMessage": "For those registered at their current address"
+    "defaultMessage": "For you registered at your current address"
   },
   {
     "id": "verify-identity.vetting_phone_tagline",
-    "defaultMessage": "For those with a phone registered in their name"
+    "defaultMessage": "For you with a phone registered in your name"
   },
   {
     "id": "verify-identity.vetting_freja_tagline",
-    "defaultMessage": "For those able to create a Freja eID by visiting one of the authorised agents"
+    "defaultMessage": "For you able to create a Freja eID by visiting one of the authorised agents"
   },
   {
     "id": "verify-identity.connect-nin_heading",


### PR DESCRIPTION
#### Description:
I update  a skipped suggestion in issue https://github.com/SUNET/eduid-front/issues/354
#### Summary:

- Vetting buttons in English 
"For those registered at their current address" -> "For you registered at your current address"
"For those with a phone registered in their name"->"For you with a phone registered in your name"
"For those able to create a Freja eID by visiting one of the authorised agents"-> "For you able to create a Freja eID by visiting one of the authorised agents"

- Vetting buttons in Swedish 
"För de som har eller kan skapa Freja eID genom att besöka ett ombud i Sverige"->"För dig som har eller kan skapa Freja eID genom att besöka ett ombud i Sverige"
"För de som har ett telefonabonnemang i sitt eget namn"->"För dig som har ett telefonabonnemang i ditt eget namn"
"För de som har tillgång till sin folkbokföringsaddress"->"För dig som har tillgång till din folkbokföringsaddress"
#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

