### PR TITLE
VETTING BUTTONS: Fix positioning of vetting buttons

### DIFF
--- a/src/components/VerifyIdentity.js
+++ b/src/components/VerifyIdentity.js
@@ -64,7 +64,7 @@ class VerifyIdentity extends Component {
       // extract the keys from the vettingOptionsObject
       const vettingOptionsKeys = Object.keys(vettingOptionsObject);
       vettingButtons = [
-        <div id="nins-btn-grid"> 
+        <div key="1" id="nins-btn-grid"> 
           {vettingOptionsKeys.map((key, index) => {
             let helpText = buttonHelpTextArray[index];
             return (

--- a/src/components/VerifyIdentity.js
+++ b/src/components/VerifyIdentity.js
@@ -64,18 +64,20 @@ class VerifyIdentity extends Component {
       // extract the keys from the vettingOptionsObject
       const vettingOptionsKeys = Object.keys(vettingOptionsObject);
       vettingButtons = [
-        vettingOptionsKeys.map((key, index) => {
-          let helpText = buttonHelpTextArray[index];
-          return (
-            <div key={index}>
-              {vettingOptionsObject[key]}
-              <p key={index} className="proofing-btn-help">
-                {helpText}
-              </p>
-            </div>
-          );
-        }),
-      ];
+        <div id="nins-btn-grid"> 
+          {vettingOptionsKeys.map((key, index) => {
+            let helpText = buttonHelpTextArray[index];
+            return (
+              <div key={index}>
+                {vettingOptionsObject[key]}
+                <p key={index} className="proofing-btn-help">
+                  {helpText}
+                </p>
+              </div>
+            )
+          })}
+        </div>
+      ]
     }
 
     // bottom half of page: vetting on added nin
@@ -89,7 +91,6 @@ class VerifyIdentity extends Component {
             <p>
               {this.props.translate("verify-identity.connect-nin_description")}
             </p>
-            <div key="1" id="nins-btn-grid"></div>
           </div>
         );
       } else {


### PR DESCRIPTION
#### Description:
Issue https://github.com/SUNET/eduid-front/issues/380
the positioning of the vetting buttons in desktop mode changed
but now returned to previous position 

- replace  `<div key="1" id="nins-btn-grid" />` outside of vetting buttons

before
![Screenshot 2020-07-29 at 14 18 05](https://user-images.githubusercontent.com/44289056/88799179-5e97bb80-d1a6-11ea-8317-da925557ce7e.png)

after
![Screenshot 2020-07-29 at 14 15 05](https://user-images.githubusercontent.com/44289056/88798924-f9dc6100-d1a5-11ea-9190-e4bb9cc4ca71.png)

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

