### PR TITLE
BUTTON: Misalign button in firefox

### DIFF
--- a/src/login/styles/_Emails.scss
+++ b/src/login/styles/_Emails.scss
@@ -13,7 +13,7 @@
 #emailsview-form,
 #phonesview-form {
   flex-direction: row;
-  align-items: baseline;
+  //align-items: baseline;
   & button {
     margin-left: 1rem;
   }

--- a/src/login/styles/_SignupMain.scss
+++ b/src/login/styles/_SignupMain.scss
@@ -2,7 +2,7 @@
 #register-form {
   display: flex;
   flex-direction: row;
-  align-items: baseline;
+  //align-items: baseline;
   margin-top: 0;
   &.form-group {
     margin-bottom: 0;

--- a/src/login/styles/_buttons.scss
+++ b/src/login/styles/_buttons.scss
@@ -95,6 +95,11 @@ button.close:hover {
   transform: scale(1.2);
 }
 
+button.btn#email-button,
+#mobile-button {
+  margin-top: 0;
+}
+
 //  {
 //   font-family: "ProximaNova-Regular";
 // }


### PR DESCRIPTION
#### Description:
misalign button in firefox browser 
issue https://github.com/SUNET/eduid-front/issues/387

#### Summary:
- Comment out` align-items: baseline;`` #emailsview-form`,` #phonesview-form`, `#register-form`
- Add `margin-top: 0` in `#email-button `and `#mobile-button`

#### Browser: Firefox
#### Desktop
------
**Before and After(Register)**
![Screenshot 2020-08-03 at 10 20 03](https://user-images.githubusercontent.com/44289056/89162329-34fadd80-d574-11ea-81de-c4ba8907f0ee.png)

**Before and After(Settings)**
![Screenshot 2020-08-03 at 10 20 12](https://user-images.githubusercontent.com/44289056/89162320-33c9b080-d574-11ea-8abf-e34c2eac8cc4.png)


#### For reviewer:
- [x] Read the above description
- [x] Reviewed the code changes
- [x] Navigate to the branch (pulled the latest version)
- [x] Run the code and been able to execute the expected function
- [x] Check any styling on both desktop and mobile sizes

