### PR TITLE
CONFIRM IDENTITY: Uncaught ReferenceError on Identity tab

### DIFF
--- a/src/components/VerifyIdentity.js
+++ b/src/components/VerifyIdentity.js
@@ -18,6 +18,9 @@ class VerifyIdentity extends Component {
       this.props.translate("lmp.initialize_proofing_help_text"),
       this.props.translate("eidas.initialize_proofing_help_text"),
     ];
+    let recoverIdentityTip = this.props.translate(
+      "verify-identity.verified_pw_reset_extra_security"
+    );
 
     // nin is not verified (add nin)
     let AddNumber = (props) => {
@@ -36,13 +39,10 @@ class VerifyIdentity extends Component {
       // nin is verified (nin added)
       pageHeading = props.translate("verify-identity.verified_main_title");
       pageText = props.translate("verify-identity.verified_page-description");
-      recoverIdentityTip = props.translate(
-        "verify-identity.verified_pw_reset_extra_security"
-      );
       return (
         <div key="0" className="intro">
           <h4>{pageHeading}</h4>
-          <p>{pageText}</p>
+          <p>{pageText}</p>    
         </div>
       );
     };
@@ -50,7 +50,9 @@ class VerifyIdentity extends Component {
     // top half of page: add nin/nin added
     let VerifyIdentity_Step1 = () => {
       if (this.props.verifiedNinStatus) {
-        return <NumberAdded {...this.props} />;
+        return (
+          <NumberAdded {...this.props} />
+        ) 
       } else {
         return <AddNumber {...this.props} />;
       }
@@ -102,6 +104,9 @@ class VerifyIdentity extends Component {
       <Fragment>
         <VerifyIdentity_Step1 />
         <AddNin {...this.props} />
+        { this.props.verifiedNinStatus && 
+          <p className="help-text">{recoverIdentityTip}</p>
+        }
         <VerifyIdentity_Step2 />
         {vettingButtons}
       </Fragment>

--- a/src/components/VerifyIdentity.js
+++ b/src/components/VerifyIdentity.js
@@ -60,7 +60,7 @@ class VerifyIdentity extends Component {
 
     // this is where the buttons are generated
     // this needs to be outside of <VerifyIdentity_Step2> for the second modal to render
-    if (this.props.is_configured) {
+    if (this.props.is_configured && !this.props.verifiedNinStatus) {
       //this is an object listing all the vetting components in another file (src/vetting-registry.js)
       const vettingOptionsObject = vettingRegistry(!this.props.valid_nin);
       // extract the keys from the vettingOptionsObject


### PR DESCRIPTION
#### Description:
issue https://github.com/SUNET/eduid-front/issues/389

#### Summary:
- when `verifiedNinStatus` is true, display `recoverIdentityTip`
- `!this.props.verifiedNinStatus` to show vetting buttons when user have not verified 

----
<img width="1427" alt="Screenshot 2020-08-07 at 12 54 10" src="https://user-images.githubusercontent.com/44289056/89639038-2894be80-d8ad-11ea-8bce-27b1cb2ea58e.png">

<img width="595" alt="Screenshot 2020-08-07 at 12 53 42" src="https://user-images.githubusercontent.com/44289056/89639021-1fa3ed00-d8ad-11ea-9f72-ce2da384a549.png">

----

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

