### PR TITLE
Change nin_display.profile.main_title text lowcase to capitalise 

### DIFF
--- a/i18n/src/login/translation/defaultMessages/userProfile.json
+++ b/i18n/src/login/translation/defaultMessages/userProfile.json
@@ -373,7 +373,7 @@
   },
   {
     "id": "nin_display.profile.main_title",
-    "defaultMessage": "id number"
+    "defaultMessage": "Id number"
   },
   {
     "id": "nin_display.profile.no_nin",

--- a/src/login/translation/defaultMessages/userProfile.js
+++ b/src/login/translation/defaultMessages/userProfile.js
@@ -665,7 +665,7 @@ export const userData = {
   "nin_display.profile.main_title": (
     <FormattedMessage
       id="nin_display.profile.main_title"
-      defaultMessage={`id number`}
+      defaultMessage={`Id number`}
     />
   ),
 

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -191,7 +191,7 @@
   "mobile.mobile": "mobile",
   "mobile.resend_success": "New code sent to {email}",
   "nin needs to be formatted as 18|19|20yymmddxxxx": "National identity number needs to be in the form of yyyymmddxxxx",
-  "nin_display.profile.main_title": "id number",
+  "nin_display.profile.main_title": "Id number",
   "nin_display.profile.no_nin": "add id number",
   "nin_display.verify-identity_unverified_main_title": "1. Your added id number",
   "nin_display.verify-identity_verified_main_title": "National id number",

--- a/src/login/translation/src/login/translation/defaultMessages/userProfile.json
+++ b/src/login/translation/src/login/translation/defaultMessages/userProfile.json
@@ -381,7 +381,7 @@
   },
   {
     "id": "nin_display.profile.main_title",
-    "defaultMessage": "id number"
+    "defaultMessage": "Id number"
   },
   {
     "id": "nin_display.profile.no_nin",


### PR DESCRIPTION
#### Description:
Issue https://github.com/SUNET/eduid-front/issues/391
translation`nin_display.profile.main_title` is not capitalised
- change `nin_display.profile.main_title` (Engilsh) text ` id number` to `Id number `

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

