### PR TITLE
VALIDATION: adjust help text for phone form and add validation for max length source

### DIFF
--- a/i18n/src/login/translation/defaultMessages/userProfile.json
+++ b/i18n/src/login/translation/defaultMessages/userProfile.json
@@ -425,7 +425,7 @@
   },
   {
     "id": "phone_format",
-    "defaultMessage": "Invalid telephone number. It must be a valid Swedish number, or written\n                            using international notation, starting with '+' and followed by 10-20 digits."
+    "defaultMessage": "Invalid telephone number. It must be a valid Swedish number, or written\n                            using international notation, starting with '+' and followed by 6-20 digits."
   },
   {
     "id": "still-valid-code",

--- a/i18n/src/login/translation/defaultMessages/userProfile.json
+++ b/i18n/src/login/translation/defaultMessages/userProfile.json
@@ -441,7 +441,7 @@
   },
   {
     "id": "phones.input_help_text",
-    "defaultMessage": "Phone number starting with 0 or +"
+    "defaultMessage": "Phone number starting with 0 or +46"
   },
   {
     "id": "phones.main_title",

--- a/i18n/src/login/translation/defaultMessages/userProfile.json
+++ b/i18n/src/login/translation/defaultMessages/userProfile.json
@@ -513,7 +513,7 @@
   },
   {
     "id": "phone.e164_format",
-    "defaultMessage": "Invalid telephone number. It must be a valid Swedish number, or written\n                            using international notation, starting with '+' and followed by 10-20 digits."
+    "defaultMessage": "Invalid telephone number. It must be a valid Swedish number, or written\n                            using international notation, starting with '+' and followed by 6-20 digits."
   },
   {
     "id": "phone.swedish_mobile_format",

--- a/src/components/Mobile.js
+++ b/src/components/Mobile.js
@@ -25,6 +25,7 @@ const validate = (values, props) => {
   if (phone.startsWith("0")) {
     phone = "+" + props.default_country_code + phone.substr(1);
   }
+  //Reason for 20 digit max length due to https://en.wikipedia.org/wiki/E.164 
   const pattern = /^\+[1-9]\d{6,20}$/;
   if (!pattern.test(phone)) {
     return { number: "phone.phone_format" };

--- a/src/login/translation/defaultMessages/userProfile.js
+++ b/src/login/translation/defaultMessages/userProfile.js
@@ -787,7 +787,7 @@ export const userData = {
   "phones.input_help_text": (
     <FormattedMessage
       id="phones.input_help_text"
-      defaultMessage={"Phone number starting with 0 or +"}
+      defaultMessage={"Phone number starting with 0 or +46"}
     />
   ),
 

--- a/src/login/translation/defaultMessages/userProfile.js
+++ b/src/login/translation/defaultMessages/userProfile.js
@@ -758,7 +758,7 @@ export const userData = {
     <FormattedMessage
       id="phone_format"
       defaultMessage={`Invalid telephone number. It must be a valid Swedish number, or written
-                            using international notation, starting with '+' and followed by 10-20 digits.`}
+                            using international notation, starting with '+' and followed by 6-20 digits.`}
     />
   ),
 

--- a/src/login/translation/defaultMessages/userProfile.js
+++ b/src/login/translation/defaultMessages/userProfile.js
@@ -914,7 +914,7 @@ export const userData = {
     <FormattedMessage
       id="phone.e164_format"
       defaultMessage={`Invalid telephone number. It must be a valid Swedish number, or written
-                            using international notation, starting with '+' and followed by 10-20 digits.`}
+                            using international notation, starting with '+' and followed by 6-20 digits.`}
     />
   ),
 

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -257,7 +257,7 @@
   "phone.e164_format": "Invalid telephone number. It must be a valid Swedish number, or written\n                            using international notation, starting with '+' and followed by 10-20 digits.",
   "phone.swedish_mobile_format": "Invalid telephone number. It must be a valid Swedish number, or written\n                            using international notation, starting with '+' and followed by 10-20 digits.",
   "phone_duplicated": "Added number is duplicated",
-  "phone_format": "Invalid telephone number. It must be a valid Swedish number, or written\n                            using international notation, starting with '+' and followed by 10-20 digits.",
+  "phone_format": "Invalid telephone number. It must be a valid Swedish number, or written\n                            using international notation, starting with '+' and followed by 6-20 digits.",
   "phones.add_new": "A new phone number will receive a confirmation code for you to use by clicking Confirm in the list of phone numbers.",
   "phones.button_add_more": "+ add more",
   "phones.cannot_remove_primary": "You cannot remove your primary phone number",

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -254,7 +254,7 @@
   "pd.surname": "Last name",
   "pdata.field_required": "This field is required",
   "pfilled.completion": "Completion",
-  "phone.e164_format": "Invalid telephone number. It must be a valid Swedish number, or written\n                            using international notation, starting with '+' and followed by 10-20 digits.",
+  "phone.e164_format": "Invalid telephone number. It must be a valid Swedish number, or written\n                            using international notation, starting with '+' and followed by 6-20 digits.",
   "phone.swedish_mobile_format": "Invalid telephone number. It must be a valid Swedish number, or written\n                            using international notation, starting with '+' and followed by 10-20 digits.",
   "phone_duplicated": "Added number is duplicated",
   "phone_format": "Invalid telephone number. It must be a valid Swedish number, or written\n                            using international notation, starting with '+' and followed by 6-20 digits.",

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -268,7 +268,7 @@
   "phones.code_invalid_or_expired": "The confirmation code is invalid or it has expired, please try again or request a new code",
   "phones.duplicated": "That phone number is already in use, please choose another",
   "phones.get-success": "Successfully retrieved phone numbers",
-  "phones.input_help_text": "Phone number starting with 0 or +",
+  "phones.input_help_text": "Phone number starting with 0 or +46",
   "phones.input_placeholder": "phone number",
   "phones.invalid_phone": "Invalid phone number",
   "phones.long_description": "You can connect one or more mobile phone numbers to\n           your eduID, but one has to be set as the primary one.",

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -258,7 +258,7 @@
   "phone.e164_format": "Ogiltigt telefonnummer. Skriv ett svensk nummer eller ett internationellt nummer som börjar med '+' följt av 10-20 siffror.",
   "phone.swedish_mobile_format": "Ogiltigt telefonnummer. Skriv ett svensk nummer eller ett internationellt nummer som börjar med '+' följt av 10-20 siffror.",
   "phone_duplicated": "Telefonnummret är redan tillagt",
-  "phone_format": "Ogiltigt telefonnummer. Skriv ett svensk nummer eller ett internationellt nummer som börjar med '+' följt av 10-20 siffror.",
+  "phone_format": "Ogiltigt telefonnummer. Skriv ett svensk nummer eller ett internationellt nummer som börjar med '+' följt av 6-20 siffror.",
   "phones.add_new": "Ett nytt telefonnummer kommer att ta emot en verifieringskod som kan användas genom att klicka Bekräfta i listan med nummer.",
   "phones.button_add_more": "+ lägg till fler",
   "phones.cannot_remove_primary": "Du kan inte ta bort ditt primära telefonnummer",

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -255,7 +255,7 @@
   "pd.surname": "Efternamn",
   "pdata.field_required": "Obligatoriskt",
   "pfilled.completion": "Profilstatus",
-  "phone.e164_format": "Ogiltigt telefonnummer. Skriv ett svensk nummer eller ett internationellt nummer som börjar med '+' följt av 10-20 siffror.",
+  "phone.e164_format": "Ogiltigt telefonnummer. Skriv ett svensk nummer eller ett internationellt nummer som börjar med '+' följt av 6-20 siffror.",
   "phone.swedish_mobile_format": "Ogiltigt telefonnummer. Skriv ett svensk nummer eller ett internationellt nummer som börjar med '+' följt av 10-20 siffror.",
   "phone_duplicated": "Telefonnummret är redan tillagt",
   "phone_format": "Ogiltigt telefonnummer. Skriv ett svensk nummer eller ett internationellt nummer som börjar med '+' följt av 6-20 siffror.",

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -269,7 +269,7 @@
   "phones.code_invalid_or_expired": "Den bekräftelsekod du angett stämmer inte. Var god försök igen",
   "phones.duplicated": "Telefonnumret du angett används redan. Försök med ett annat.",
   "phones.get-success": "Telefonnummer laddades",
-  "phones.input_help_text": "Telefonnummer som börjar med 0 eller +",
+  "phones.input_help_text": "Telefonnummer som börjar med 0 eller +46",
   "phones.input_placeholder": "Telefonnummer",
   "phones.invalid_phone": "Ogiltigt telefonnummer",
   "phones.long_description": "Du kan koppla ett eller flera av dina mobiltelefonnummer till ditt eduID-konto och därefter välja vilket av dem som ska vara primär.",

--- a/src/login/translation/src/i18n-messages.json
+++ b/src/login/translation/src/i18n-messages.json
@@ -1245,7 +1245,7 @@
   },
   {
     "id": "phone.e164_format",
-    "defaultMessage": "Invalid telephone number. It must be a valid Swedish number, or written\n                            using international notation, starting with '+' and followed by 10-20 digits."
+    "defaultMessage": "Invalid telephone number. It must be a valid Swedish number, or written\n                            using international notation, starting with '+' and followed by 6-20 digits."
   },
   {
     "id": "phone.swedish_mobile_format",

--- a/src/login/translation/src/i18n-messages.json
+++ b/src/login/translation/src/i18n-messages.json
@@ -1173,7 +1173,7 @@
   },
   {
     "id": "phones.input_help_text",
-    "defaultMessage": "Phone number starting with 0 or +"
+    "defaultMessage": "Phone number starting with 0 or +46"
   },
   {
     "id": "phones.main_title",

--- a/src/login/translation/src/i18n-messages.json
+++ b/src/login/translation/src/i18n-messages.json
@@ -409,7 +409,7 @@
   },
   {
     "id": "phone_format",
-    "defaultMessage": "Invalid telephone number. It must be a valid Swedish number, or written\n                            using international notation, starting with '+' and followed by 10-20 digits."
+    "defaultMessage": "Invalid telephone number. It must be a valid Swedish number, or written\n                            using international notation, starting with '+' and followed by 6-20 digits."
   },
   {
     "id": "still-valid-code",

--- a/src/login/translation/src/login/translation/defaultMessages/userProfile.json
+++ b/src/login/translation/src/login/translation/defaultMessages/userProfile.json
@@ -521,7 +521,7 @@
   },
   {
     "id": "phone.e164_format",
-    "defaultMessage": "Invalid telephone number. It must be a valid Swedish number, or written\n                            using international notation, starting with '+' and followed by 10-20 digits."
+    "defaultMessage": "Invalid telephone number. It must be a valid Swedish number, or written\n                            using international notation, starting with '+' and followed by 6-20 digits."
   },
   {
     "id": "phone.swedish_mobile_format",

--- a/src/login/translation/src/login/translation/defaultMessages/userProfile.json
+++ b/src/login/translation/src/login/translation/defaultMessages/userProfile.json
@@ -449,7 +449,7 @@
   },
   {
     "id": "phones.input_help_text",
-    "defaultMessage": "Phone number starting with 0 or +"
+    "defaultMessage": "Phone number starting with 0 or +46"
   },
   {
     "id": "phones.main_title",

--- a/src/login/translation/src/login/translation/defaultMessages/userProfile.json
+++ b/src/login/translation/src/login/translation/defaultMessages/userProfile.json
@@ -433,7 +433,7 @@
   },
   {
     "id": "phone_format",
-    "defaultMessage": "Invalid telephone number. It must be a valid Swedish number, or written\n                            using international notation, starting with '+' and followed by 10-20 digits."
+    "defaultMessage": "Invalid telephone number. It must be a valid Swedish number, or written\n                            using international notation, starting with '+' and followed by 6-20 digits."
   },
   {
     "id": "still-valid-code",


### PR DESCRIPTION
#### Description:
At this time only Swedish Mobile phone numbers are supported for confirmation, so I have adjust help text from "0 or +" to "0 or +46",
and I have added a comment explaining the reason for max mobile telephone length and linked the source "https://en.wikipedia.org/wiki/E.164"
we have not confirmed the International minimum length of a mobile phone number yet.

----
- Browswer : Chrome
 
![Screenshot 2020-08-19 at 09 42 07](https://user-images.githubusercontent.com/44289056/90606548-4395f580-e200-11ea-9bbd-2b4328743504.png)
----


#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

