### PR TITLE
INPUT: implement custom input for confirm modal form

### DIFF
--- a/i18n/src/login/translation/messageIndex.json
+++ b/i18n/src/login/translation/messageIndex.json
@@ -14,6 +14,11 @@
     "defaultMessage": "Phone confirmation code"
   },
   {
+    "id": "security.confirm_security_placeholder",
+    "description": "Placeholder for security key text input",
+    "defaultMessage": "Security key"
+  },
+  {
     "id": "chpass.help-text-newpass",
     "description": "help text for custom password",
     "defaultMessage": "<label>Tip: Choose a strong password</label>\n            <ul id=\"password-custom-help\">\n\t            <li>Use upper- and lowercase characters, but not at the beginning or end</li>\n\t            <li>Add digits somewhere, but not at the beginning or end</li>\n                <li>Add special characters, such as &#64; &#36; &#92; &#43; &#95; &#37;</li>\n\t            <li>Spaces are ignored</li>\n            </ul>"

--- a/i18n/src/login/translation/messageIndex.json
+++ b/i18n/src/login/translation/messageIndex.json
@@ -16,7 +16,7 @@
   {
     "id": "security.confirm_security_placeholder",
     "description": "Placeholder for security key text input",
-    "defaultMessage": "Security key"
+    "defaultMessage": "Describe your security key"
   },
   {
     "id": "chpass.help-text-newpass",

--- a/src/components/ConfirmModal.js
+++ b/src/components/ConfirmModal.js
@@ -18,11 +18,11 @@ class ConfirmModal extends Component {
     let resendMarkup = "";
     if (this.props.with_resend_link) {
       resendMarkup = (
-        <div>
+        <>
           <a href="#" onClick={this.props.handleResend} className="resend-code">
             {this.props.resendText}
           </a>
-        </div>
+        </>
       );
     }
 

--- a/src/components/ConfirmModal.js
+++ b/src/components/ConfirmModal.js
@@ -1,15 +1,10 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import { connect } from "react-redux";
-import { Field, reduxForm } from "redux-form";
-
-import Button from "reactstrap/lib/Button";
 import Modal from "reactstrap/lib/Modal";
 import ModalHeader from "reactstrap/lib/ModalHeader";
 import ModalBody from "reactstrap/lib/ModalBody";
 import ModalFooter from "reactstrap/lib/ModalFooter";
 import ConfirmModalForm from "./ConfirmModalForm";
-
 import i18n from "../login/translation/InjectIntl_HOC_factory";
 import EduIDButton from "components/EduIDButton";
 

--- a/src/components/ConfirmModalForm.js
+++ b/src/components/ConfirmModalForm.js
@@ -1,25 +1,12 @@
 import React, { Component } from "react";
-import PropTypes from "prop-types";
 import { connect } from "react-redux";
 import { Field, reduxForm } from "redux-form";
-import { ButtonGroup, Form } from "reactstrap";
-import Button from "reactstrap/lib/Button";
-import Modal from "reactstrap/lib/Modal";
-import ModalHeader from "reactstrap/lib/ModalHeader";
-import ModalBody from "reactstrap/lib/ModalBody";
-import ModalFooter from "reactstrap/lib/ModalFooter";
-
+import { Form } from "reactstrap";
 import i18n from "../login/translation/InjectIntl_HOC_factory";
 import CustomInput from "../login/components/Inputs/CustomInput";
-import EduIDButton from "components/EduIDButton";
-import NotificationsContainer from "containers/Notifications";
 
 const validate = (values, props) => {
-  console.log("validate - values", values);
-  console.log("valiadate - props.inputName", props.inputName);
-  console.log("valiadate - this.props.inputName", props.inputName);
   let inputName = props.inputName;
-  console.log("valiadate - inputName", inputName);
   const errors = {};
   const code = values[inputName];
   if (!code) {

--- a/src/components/ConfirmModalForm.js
+++ b/src/components/ConfirmModalForm.js
@@ -10,7 +10,7 @@ import ModalBody from "reactstrap/lib/ModalBody";
 import ModalFooter from "reactstrap/lib/ModalFooter";
 
 import i18n from "../login/translation/InjectIntl_HOC_factory";
-import TextInput from "components/EduIDTextInput";
+import CustomInput from "../login/components/Inputs/CustomInput";
 import EduIDButton from "components/EduIDButton";
 import NotificationsContainer from "containers/Notifications";
 
@@ -35,7 +35,7 @@ class ConfirmModalForm extends Component {
         <Form id={this.props.inputName + "-form"} role="form">
           <div id="confirmation-code-area">
             <Field
-              component={TextInput}
+              component={CustomInput}
               componentClass="input"
               type="text"
               label={this.props.resendLabel}

--- a/src/components/Security.js
+++ b/src/components/Security.js
@@ -169,10 +169,10 @@ class Security extends Component {
           modalId="describeWebauthnTokenDialog"
           id="describeWebauthnTokenDialogControl"
           title={this.props.translate("security.webauthn-describe-title")}
-          resendLabel=""
+          resendLabel={this.props.translate("security.webauthn_credential_type")}
           resendHelp=""
           resendText=""
-          placeholder=""
+          placeholder={this.props.translate("security.placeholder")}
           with_resend_link={false}
           showModal={Boolean(this.props.webauthn_asking_description)}
           closeModal={this.props.handleStopAskingWebauthnDescription}

--- a/src/components/Security.js
+++ b/src/components/Security.js
@@ -170,8 +170,6 @@ class Security extends Component {
           id="describeWebauthnTokenDialogControl"
           title={this.props.translate("security.webauthn-describe-title")}
           resendLabel={this.props.translate("security.webauthn_credential_type")}
-          resendHelp=""
-          resendText=""
           placeholder={this.props.translate("security.placeholder")}
           with_resend_link={false}
           showModal={Boolean(this.props.webauthn_asking_description)}

--- a/src/login/styles/_inputs.scss
+++ b/src/login/styles/_inputs.scss
@@ -110,6 +110,7 @@ input:focus {
   border: none;
   border-bottom: 2px solid $orange-highlight;
   background-image: none;
+  padding-right: 8px;
 }
 
 .form-control.is-invalid:focus {

--- a/src/login/styles/_modals.scss
+++ b/src/login/styles/_modals.scss
@@ -163,14 +163,11 @@ p.modal-text {
       & button.btn.settings-button {
         margin: 0 0 1rem 0;
       }
-      & #modal-form form {
-        margin-top: 0;
-        & .form-control,
-        & input {
+      & .form-control,
+      & input {
+        font-size: 1.25rem;
+        &::placeholder {
           font-size: 1.25rem;
-          &::placeholder {
-            font-size: 1.25rem;
-          }
         }
       }
       & p {

--- a/src/login/styles/_modals.scss
+++ b/src/login/styles/_modals.scss
@@ -47,6 +47,10 @@ h5.modal-title {
   margin: auto;
 }
 
+.resend-code {
+  margin-top: 2rem;
+}
+
 // temporary styling for register tou
 #register-modal {
   & .modal-header {

--- a/src/login/styles/_modals.scss
+++ b/src/login/styles/_modals.scss
@@ -6,7 +6,14 @@
   justify-content: center;
   width: calc(100% - 2rem);
   margin: 0 1rem;
+  &  #modal-form{
+    & form{
+      margin-top: 0;
+    }
+  }
 }
+
+
 
 h5.modal-title {
   font-family: "Akkurat";

--- a/src/login/styles/_modals.scss
+++ b/src/login/styles/_modals.scss
@@ -184,6 +184,7 @@ p.modal-text {
   }
 
   .resend-code {
+    margin-top: 1rem;
     font-size: 0.9rem;
   }
 

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -187,7 +187,7 @@
   "mfa.two-factor-authn": "Two-factor authentication",
   "mobile.button_add": "Add",
   "mobile.confirm_mobile_placeholder": "Phone confirmation code",
-  "security.confirm_security_placeholder": "Security key",
+  "security.confirm_security_placeholder": "Describe your security key",
   "mobile.confirm_title": "Enter the code sent to {phone} here",
   "mobile.mobile": "mobile",
   "mobile.resend_success": "New code sent to {email}",

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -187,6 +187,7 @@
   "mfa.two-factor-authn": "Two-factor authentication",
   "mobile.button_add": "Add",
   "mobile.confirm_mobile_placeholder": "Phone confirmation code",
+  "security.confirm_security_placeholder": "Security key",
   "mobile.confirm_title": "Enter the code sent to {phone} here",
   "mobile.mobile": "mobile",
   "mobile.resend_success": "New code sent to {email}",

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -187,7 +187,7 @@
   "mfa.two-factor-authn": "Tvåfaktorsautentisering",
   "mobile.button_add": "Lägg till",
   "mobile.confirm_mobile_placeholder": "Bekräftelsekod",
-  "security.confirm_security_placeholder": "Beskrivning av säkerhetsnyckel",
+  "security.confirm_security_placeholder": "Beskriv din säkerhetsnyckel",
   "mobile.confirm_title": "Skriv in koden som skickats till {phone} här",
   "mobile.mobile": "Telefon",
   "mobile.resend_success": "Ny bekräftelsekod skickad till {email}",

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -187,7 +187,7 @@
   "mfa.two-factor-authn": "Tvåfaktorsautentisering",
   "mobile.button_add": "Lägg till",
   "mobile.confirm_mobile_placeholder": "Bekräftelsekod",
-  "security.confirm_security_placeholder": "Säkerhetsnyckel",
+  "security.confirm_security_placeholder": "Beskrivning av säkerhetsnyckel",
   "mobile.confirm_title": "Skriv in koden som skickats till {phone} här",
   "mobile.mobile": "Telefon",
   "mobile.resend_success": "Ny bekräftelsekod skickad till {email}",

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -187,6 +187,7 @@
   "mfa.two-factor-authn": "Tvåfaktorsautentisering",
   "mobile.button_add": "Lägg till",
   "mobile.confirm_mobile_placeholder": "Bekräftelsekod",
+  "security.confirm_security_placeholder": "Säkerhetsnyckel",
   "mobile.confirm_title": "Skriv in koden som skickats till {phone} här",
   "mobile.mobile": "Telefon",
   "mobile.resend_success": "Ny bekräftelsekod skickad till {email}",

--- a/src/login/translation/messageIndex.js
+++ b/src/login/translation/messageIndex.js
@@ -47,7 +47,7 @@ export const unformattedMessages = defineMessages({
   },
   "security.placeholder": {
     id: "security.confirm_security_placeholder",
-    defaultMessage: `Security key`,
+    defaultMessage: `Describe your security key`,
     description: "Placeholder for security key text input"
   },
   "register.toLogin": {

--- a/src/login/translation/messageIndex.js
+++ b/src/login/translation/messageIndex.js
@@ -45,7 +45,11 @@ export const unformattedMessages = defineMessages({
     defaultMessage: `Phone confirmation code`,
     description: "Placeholder for phone text input"
   },
-
+  "security.placeholder": {
+    id: "security.confirm_security_placeholder",
+    defaultMessage: `Security key`,
+    description: "Placeholder for security key text input"
+  },
   "register.toLogin": {
     id: "register.toLogin",
     defaultMessage: `If you already have eduID you can log in`,

--- a/src/login/translation/src/i18n-messages.json
+++ b/src/login/translation/src/i18n-messages.json
@@ -1440,7 +1440,7 @@
   {
     "id": "security.confirm_security_placeholder",
     "description": "Placeholder for security key text input",
-    "defaultMessage": "Security key"
+    "defaultMessage": "Describe your security key"
   },
   {
     "id": "chpass.help-text-newpass",

--- a/src/login/translation/src/i18n-messages.json
+++ b/src/login/translation/src/i18n-messages.json
@@ -1438,6 +1438,11 @@
     "defaultMessage": "Phone confirmation code"
   },
   {
+    "id": "security.confirm_security_placeholder",
+    "description": "Placeholder for security key text input",
+    "defaultMessage": "Security key"
+  },
+  {
     "id": "chpass.help-text-newpass",
     "description": "help text for custom password",
     "defaultMessage": "<label>Tip: Choose a strong password</label>\n            <ul id=\"password-custom-help\">\n\t            <li>Use upper- and lowercase characters, but not at the beginning or end</li>\n\t            <li>Add digits somewhere, but not at the beginning or end</li>\n                <li>Add special characters, such as &#64; &#36; &#92; &#43; &#95; &#37;</li>\n\t            <li>Spaces are ignored</li>\n            </ul>"

--- a/src/login/translation/src/login/translation/messageIndex.json
+++ b/src/login/translation/src/login/translation/messageIndex.json
@@ -14,6 +14,11 @@
     "defaultMessage": "Phone confirmation code"
   },
   {
+    "id": "security.confirm_security_placeholder",
+    "description": "Placeholder for security key text input",
+    "defaultMessage": "Security key"
+  },
+  {
     "id": "register.toLogin",
     "description": "Placeholder for phone text input",
     "defaultMessage": "If you already have eduID you can log in"

--- a/src/login/translation/src/login/translation/messageIndex.json
+++ b/src/login/translation/src/login/translation/messageIndex.json
@@ -16,7 +16,7 @@
   {
     "id": "security.confirm_security_placeholder",
     "description": "Placeholder for security key text input",
-    "defaultMessage": "Security key"
+    "defaultMessage": "Describe your security key"
   },
   {
     "id": "register.toLogin",


### PR DESCRIPTION
#### Description:
Replace new customInput for modal form

#### Summary:
- Replace customInput
- Adjust styling according to figma https://www.figma.com/file/1uzAOgj9zgIpL6n7C0z24o/eduID%3A-website-anatomy?node-id=394%3A813
- Add placeholder(translate) for security key 
- Adjust padding-right for .form-control.is-invalid to avoid covering place holder text

----

- before and after (email confirm code) @1200px
![Screenshot 2020-08-27 at 11 54 33](https://user-images.githubusercontent.com/44289056/91427139-c00e8100-e85d-11ea-87cf-6834d9197301.png)
- before and after (mobile confirm code) @1200px
![Screenshot 2020-08-27 at 11 54 39](https://user-images.githubusercontent.com/44289056/91427144-c13fae00-e85d-11ea-8e2b-f3d2c102652a.png)
- before and after (security code) @1200px
![Screenshot 2020-08-27 at 11 54 46](https://user-images.githubusercontent.com/44289056/91427146-c270db00-e85d-11ea-8efb-07389ffcf2d4.png)
- before and after (email confirm code) @320px
![Screenshot 2020-08-27 at 12 06 16](https://user-images.githubusercontent.com/44289056/91427181-ce5c9d00-e85d-11ea-9210-6b58d0ca0a06.png)
- before and after (mobile confirm code) @320px
![Screenshot 2020-08-27 at 12 06 21](https://user-images.githubusercontent.com/44289056/91427185-cf8dca00-e85d-11ea-8d3d-100ea70fc612.png)
- before and after (security code) @320px
![Screenshot 2020-08-27 at 12 06 09](https://user-images.githubusercontent.com/44289056/91427188-d0bef700-e85d-11ea-94a6-19f2b929ea05.png)
----





#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

