### PR TITLE
GROUP MGMT: Draft logic for <Groups/> parent 

### DIFF
--- a/src/components/Settings.js
+++ b/src/components/Settings.js
@@ -39,6 +39,7 @@ class Settings extends Component {
           path="/profile/settings/personaldata"
           component={MobileContainer}
         />
+        <Route path="/profile/settings/personaldata" component={Groups} />
         <Route
           path="/profile/settings/personaldata"
           component={ChangePasswordDisplay}
@@ -47,7 +48,6 @@ class Settings extends Component {
           path="/profile/settings/personaldata"
           component={DeleteAccount}
         />
-        <Route path="/profile/settings/personaldata" component={Groups} />
         <Route
           path="/profile/settings/advanced-settings"
           component={SecurityContainer}

--- a/src/login/components/App/DashboardApp/Settings/Groups/Groups.js
+++ b/src/login/components/App/DashboardApp/Settings/Groups/Groups.js
@@ -12,13 +12,13 @@ class Groups extends Component {
 
     if (showComponent) {
 
-      // just mock handling data here to render something from the api
-      let mockData = [];
-      let mockArray = Object.keys(this.props.data);
-      mockData = mockArray.map((thing, i) => {
-        console.log("these are thing:", thing);
-        return <p key={i}>{thing}</p>;
-      });
+      // // just mock handling data here to render something from the api
+      // let mockData = [];
+      // let mockArray = Object.keys(this.props.data);
+      // mockData = mockArray.map((thing, i) => {
+      //   console.log("these are thing:", thing);
+      //   return <p key={i}>{thing}</p>;
+      // });
 
       
       return (
@@ -29,7 +29,7 @@ class Groups extends Component {
               Create groups with other eduID users to allow them access to
               third-party services using eduID for login.
             </p>
-            {mockData}
+            {/* {mockData} */}
             <div>This will be the DataPanel component</div>
             {/* <DataTable data={this.props.data} /> */}
           </div>

--- a/src/login/components/App/DashboardApp/Settings/Groups/Groups.js
+++ b/src/login/components/App/DashboardApp/Settings/Groups/Groups.js
@@ -22,7 +22,7 @@ class Groups extends Component {
 
       
       return (
-        <div className="namesview-form-container">
+        <article className="namesview-form-container">
           <div className="intro">
             <h4>Groups</h4>
             <p>
@@ -32,7 +32,7 @@ class Groups extends Component {
             {mockData}
             {/* <DataTable data={this.props.data} /> */}
           </div>
-        </div>
+        </article>
       );
     }
     return <div />;

--- a/src/login/components/App/DashboardApp/Settings/Groups/Groups.js
+++ b/src/login/components/App/DashboardApp/Settings/Groups/Groups.js
@@ -14,7 +14,7 @@ class Groups extends Component {
   constructor(props) {
     super(props);
     // will start as true and permanently be set to false when wizard is completed
-    this.state = { wizardCreateGroup: true };
+    this.state = { wizardCreateGroup: true};
   }
 
   render() {
@@ -22,10 +22,10 @@ class Groups extends Component {
     const cookiePattern = "";
     const showComponent = checkForCookie(cookieName, cookiePattern);
 
-    const RenderWizard = () => {
+    const RenderWizard = (props) => {
       return (
         <div className={"wizard"}>
-          {this.state.wizardCreateGroup && <p>Create you first group wizard</p>}
+          {props.show && <p>Create you first group wizard</p>}
         </div>
       );
     };
@@ -33,7 +33,7 @@ class Groups extends Component {
     const RenderCreateButton = (props) => {
       return (
         <a href="#">
-          {!this.state.wizardCreateGroup && (
+          {!props.show && (
             <button className={"create-group"}>Create button</button>
           )}
         </a>
@@ -54,7 +54,7 @@ class Groups extends Component {
           <div className="intro">
             <div>
               <h4>Groups</h4>
-              <RenderCreateButton />
+              <RenderCreateButton show={this.state.wizardCreateGroup} />
             </div>
             <p>
               Create groups with other eduID users to allow them access to
@@ -63,7 +63,7 @@ class Groups extends Component {
             {/* {mockData} */}
             <div>
               <p>This will be the DataPanel component</p>
-              <RenderWizard />
+              <RenderWizard show={this.state.wizardCreateGroup} />
             </div>
             {/* <DataTable data={this.props.data} /> */}
           </div>

--- a/src/login/components/App/DashboardApp/Settings/Groups/Groups.js
+++ b/src/login/components/App/DashboardApp/Settings/Groups/Groups.js
@@ -22,6 +22,14 @@ class Groups extends Component {
     const cookiePattern = "";
     const showComponent = checkForCookie(cookieName, cookiePattern);
 
+    const RenderWizard = () => {
+      return (
+        <div className={"wizard"}>
+          {this.state.wizardCreateGroup && <p>Create you first group wizard</p>}
+        </div>
+      );
+    };
+
     if (showComponent) {
       // // just mock handling data here to render something from the api
       // let mockData = [];
@@ -40,7 +48,9 @@ class Groups extends Component {
               third-party services using eduID for login.
             </p>
             {/* {mockData} */}
-            <div>This will be the DataPanel component</div>
+            <div>
+              <p>This will be the DataPanel component</p> <RenderWizard />
+            </div>
             {/* <DataTable data={this.props.data} /> */}
           </div>
         </article>

--- a/src/login/components/App/DashboardApp/Settings/Groups/Groups.js
+++ b/src/login/components/App/DashboardApp/Settings/Groups/Groups.js
@@ -2,7 +2,6 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import InjectIntl from "../../../../../translation/InjectIntl_HOC_factory";
 import checkForCookie from "../../../../../app_utils/checkForCookie";
-import DataTable from "../../../../DataTable/DataTable";
 
 class Groups extends Component {
   // this component should:
@@ -41,14 +40,6 @@ class Groups extends Component {
     };
 
     if (showComponent) {
-      // // just mock handling data here to render something from the api
-      // let mockData = [];
-      // let mockArray = Object.keys(this.props.data);
-      // mockData = mockArray.map((thing, i) => {
-      //   console.log("these are thing:", thing);
-      //   return <p key={i}>{thing}</p>;
-      // });
-
       return (
         <article>
           <div className="intro">
@@ -60,12 +51,10 @@ class Groups extends Component {
               Create groups with other eduID users to allow them access to
               third-party services using eduID for login.
             </p>
-            {/* {mockData} */}
             <div>
               <p>This will be the DataPanel component</p>
               <RenderWizard show={this.state.wizardCreateGroup} />
             </div>
-            {/* <DataTable data={this.props.data} /> */}
           </div>
         </article>
       );

--- a/src/login/components/App/DashboardApp/Settings/Groups/Groups.js
+++ b/src/login/components/App/DashboardApp/Settings/Groups/Groups.js
@@ -30,6 +30,7 @@ class Groups extends Component {
               third-party services using eduID for login.
             </p>
             {mockData}
+            <div>This will be the DataPanel component</div>
             {/* <DataTable data={this.props.data} /> */}
           </div>
         </article>

--- a/src/login/components/App/DashboardApp/Settings/Groups/Groups.js
+++ b/src/login/components/App/DashboardApp/Settings/Groups/Groups.js
@@ -5,13 +5,18 @@ import checkForCookie from "../../../../../app_utils/checkForCookie";
 import DataTable from "../../../../DataTable/DataTable";
 
 class Groups extends Component {
+  // this component should:
+  // 1. take in text to fill .intro h4 and .intro p (hardcoded at the moment)
+  // 2. be able to handle logic of create group button:
+  // - if wizard: hide button
+  // - if no wizard: show button
+
   render() {
     const cookieName = "show-groups";
     const cookiePattern = "";
     const showComponent = checkForCookie(cookieName, cookiePattern);
 
     if (showComponent) {
-
       // // just mock handling data here to render something from the api
       // let mockData = [];
       // let mockArray = Object.keys(this.props.data);
@@ -20,7 +25,6 @@ class Groups extends Component {
       //   return <p key={i}>{thing}</p>;
       // });
 
-      
       return (
         <article>
           <div className="intro">

--- a/src/login/components/App/DashboardApp/Settings/Groups/Groups.js
+++ b/src/login/components/App/DashboardApp/Settings/Groups/Groups.js
@@ -30,6 +30,16 @@ class Groups extends Component {
       );
     };
 
+    const RenderCreateButton = (props) => {
+      return (
+        <a href="#">
+          {!this.state.wizardCreateGroup && (
+            <button className={"create-group"}>Create button</button>
+          )}
+        </a>
+      );
+    };
+
     if (showComponent) {
       // // just mock handling data here to render something from the api
       // let mockData = [];
@@ -42,14 +52,18 @@ class Groups extends Component {
       return (
         <article>
           <div className="intro">
-            <h4>Groups</h4>
+            <div>
+              <h4>Groups</h4>
+              <RenderCreateButton />
+            </div>
             <p>
               Create groups with other eduID users to allow them access to
               third-party services using eduID for login.
             </p>
             {/* {mockData} */}
             <div>
-              <p>This will be the DataPanel component</p> <RenderWizard />
+              <p>This will be the DataPanel component</p>
+              <RenderWizard />
             </div>
             {/* <DataTable data={this.props.data} /> */}
           </div>

--- a/src/login/components/App/DashboardApp/Settings/Groups/Groups.js
+++ b/src/login/components/App/DashboardApp/Settings/Groups/Groups.js
@@ -11,6 +11,12 @@ class Groups extends Component {
   // - if wizard: hide button
   // - if no wizard: show button
 
+  constructor(props) {
+    super(props);
+    // will start as true and permanently be set to false when wizard is completed
+    this.state = { wizardCreateGroup: true };
+  }
+
   render() {
     const cookieName = "show-groups";
     const cookiePattern = "";

--- a/src/login/components/App/DashboardApp/Settings/Groups/Groups.js
+++ b/src/login/components/App/DashboardApp/Settings/Groups/Groups.js
@@ -22,7 +22,7 @@ class Groups extends Component {
 
       
       return (
-        <article className="namesview-form-container">
+        <article>
           <div className="intro">
             <h4>Groups</h4>
             <p>

--- a/src/login/styles/_base.scss
+++ b/src/login/styles/_base.scss
@@ -35,6 +35,11 @@ body {
   background-color: #f4f4f4;
 }
 
+// same styling as .phoneview-form-container, #delete-account-container,#change-password-container in Email.js = replaced thes ewith with <article>
+article {
+  margin-top: 2rem;
+}
+
 .vertical-content-margin {
   padding: 0;
   width: 58%;


### PR DESCRIPTION
#### Description:
Further evolves the logic for the parent `<Groups/>` in preparation for taking on further children.

**Summary:** 
1. Refine component structure 
- The first `<div>` has been changed into an `<article>` and a proposal to make all the different components in settings the same has meed added as an issue (#418 ) 
- Styling to make section consistent with others has been added to `article {}` in `_base.scss`
2. Instructions added as comment for complete transparency of intention (lines 7-11 of file):
```
 // this component should:
  // 1. take in text to fill .intro h4 and .intro p (hardcoded at the moment)
  // 2. be able to handle logic of create group button:
  // - if wizard: hide button
  // - if no wizard: show button
``` 
3. As described in above instructions wizard render logic has been added to control both display of wizard but also display of create group button 
-   Logic: state to show wizard will start as `true` and permanently be set to `false` when wizard is completed
      - `this.state = { wizardCreateGroup: true};` = show wizard
      - `this.state = { wizardCreateGroup: false};` = show create group button 
- Render functions added depending on above state:
   -  RenderWizard (renders text: "Create you first group wizard", final versions set to render fully interactive wizard)
   -  RenderCreateButton (renders text: "CreateButton", final version set to say "create groups")
4. The idea is that the future `<Wizard/>` component will be responsible for triggering the change in state

---
###### `<Groups/>` with `this.state.wizardCreateGroup` manually set to `true`
<img width="500" alt="Screenshot 2020-08-31 at 15 50 40" src="https://user-images.githubusercontent.com/30963614/91727828-819cfd00-eba2-11ea-81b5-a8c8c795c4b4.png">

###### `<Groups/>` with `this.state.wizardCreateGroup` manually set to `false`
<img width="500" alt="Screenshot 2020-08-31 at 15 50 23" src="https://user-images.githubusercontent.com/30963614/91727777-734ee100-eba2-11ea-8cb0-0603e820585d.png">

---

#### For reviewer:
**WHAT?**
- [x] Check that text line: "Create you first group wizard" renders initially (`state.wizardCreateGroup` hardcoded to be `true`)
- [x] Check that button:  "CreateButton"  renders when `state.wizardCreateGroup` is **manually** changed to `false`
- [x] Check that text line: "This will be the DataPanel component" (mock child component renders in both states)

**HOW?**
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

