### PR TITLE
MODAL: Import generic confirm modal for email(register)

### DIFF
--- a/src/components/Email.js
+++ b/src/components/Email.js
@@ -81,7 +81,9 @@ class Email extends Component {
         </p>
       </div>,
       <div key="1">
-        <GenericConfirmModal />
+        <GenericConfirmModal 
+          modalId="register-modal"
+        />
       </div>,
       //   <Modal isOpen={this.props.acceptingTOU} id="register-modal">
       //     <ModalHeader>{this.props.translate("tou.header")}</ModalHeader>

--- a/src/components/Email.js
+++ b/src/components/Email.js
@@ -88,6 +88,8 @@ class Email extends Component {
           closeModal={this.props.handleReject}
           acceptModal={this.props.handleAccept}
           mainText={this.props.tou}
+          acceptButtonText={this.props.translate("tou.accept")}
+          closeButtonText={this.props.translate("tou.cancel")}
         />
       </div>,
       //   <Modal isOpen={this.props.acceptingTOU} id="register-modal">

--- a/src/components/Email.js
+++ b/src/components/Email.js
@@ -90,6 +90,8 @@ class Email extends Component {
           mainText={this.props.tou}
           acceptButtonText={this.props.translate("tou.accept")}
           closeButtonText={this.props.translate("tou.cancel")}
+          acceptButtonId={"accept-tou-button"}
+          closeButtonId={"reject-tou-button"}
         />
       </div>,
       //   <Modal isOpen={this.props.acceptingTOU} id="register-modal">

--- a/src/components/Email.js
+++ b/src/components/Email.js
@@ -12,7 +12,7 @@ import {
 } from "reactstrap";
 
 import EduIDButton from "components/EduIDButton";
-// import "style/Email.scss";
+import GenericConfirmModal from "components/GenericConfirmModal";
 
 /* FORM */
 
@@ -81,27 +81,29 @@ class Email extends Component {
         </p>
       </div>,
       <div key="1">
-        <Modal isOpen={this.props.acceptingTOU} id="register-modal">
-          <ModalHeader>{this.props.translate("tou.header")}</ModalHeader>
-          <ModalBody dangerouslySetInnerHTML={{ __html: this.props.tou }} />
-          <ModalFooter>
-            <EduIDButton
-              id="accept-tou-button"
-              className="modal-button ok-button"
-              onClick={this.props.handleAccept}
-            >
-              {this.props.translate("tou.accept")}
-            </EduIDButton>
-            <EduIDButton
-              className="modal-button cancel-button"
-              id="reject-tou-button"
-              onClick={this.props.handleReject}
-            >
-              {this.props.translate("tou.cancel")}
-            </EduIDButton>
-          </ModalFooter>
-        </Modal>
+        <GenericConfirmModal />
       </div>,
+      //   <Modal isOpen={this.props.acceptingTOU} id="register-modal">
+      //     <ModalHeader>{this.props.translate("tou.header")}</ModalHeader>
+      //     <ModalBody dangerouslySetInnerHTML={{ __html: this.props.tou }} />
+      //     <ModalFooter>
+      //       <EduIDButton
+      //         id="accept-tou-button"
+      //         className="modal-button ok-button"
+      //         onClick={this.props.handleAccept}
+      //       >
+      //         {this.props.translate("tou.accept")}
+      //       </EduIDButton>
+      //       <EduIDButton
+      //         className="modal-button cancel-button"
+      //         id="reject-tou-button"
+      //         onClick={this.props.handleReject}
+      //       >
+      //         {this.props.translate("tou.cancel")}
+      //       </EduIDButton>
+      //     </ModalFooter>
+      //   </Modal>
+     
     ];
   }
 }

--- a/src/components/Email.js
+++ b/src/components/Email.js
@@ -84,6 +84,9 @@ class Email extends Component {
         <GenericConfirmModal 
           modalId="register-modal"
           title={this.props.translate("tou.header")}
+          showModal={this.props.acceptingTOU}
+          closeModal={this.props.handleReject}
+          acceptModal={this.props.handleAccept}
         />
       </div>,
       //   <Modal isOpen={this.props.acceptingTOU} id="register-modal">

--- a/src/components/Email.js
+++ b/src/components/Email.js
@@ -87,6 +87,7 @@ class Email extends Component {
           showModal={this.props.acceptingTOU}
           closeModal={this.props.handleReject}
           acceptModal={this.props.handleAccept}
+          mainText={this.props.tou}
         />
       </div>,
       //   <Modal isOpen={this.props.acceptingTOU} id="register-modal">

--- a/src/components/Email.js
+++ b/src/components/Email.js
@@ -4,13 +4,6 @@ import { connect } from "react-redux";
 import CustomInput from "../login/components/Inputs/CustomInput";
 import { Field, reduxForm } from "redux-form";
 import Form from "reactstrap/lib/Form";
-import {
-  Modal,
-  ModalHeader,
-  ModalBody,
-  ModalFooter,
-} from "reactstrap";
-
 import EduIDButton from "components/EduIDButton";
 import GenericConfirmModal from "components/GenericConfirmModal";
 
@@ -93,28 +86,7 @@ class Email extends Component {
           acceptButtonId={"accept-tou-button"}
           closeButtonId={"reject-tou-button"}
         />
-      </div>,
-      //   <Modal isOpen={this.props.acceptingTOU} id="register-modal">
-      //     <ModalHeader>{this.props.translate("tou.header")}</ModalHeader>
-      //     <ModalBody dangerouslySetInnerHTML={{ __html: this.props.tou }} />
-      //     <ModalFooter>
-      //       <EduIDButton
-      //         id="accept-tou-button"
-      //         className="modal-button ok-button"
-      //         onClick={this.props.handleAccept}
-      //       >
-      //         {this.props.translate("tou.accept")}
-      //       </EduIDButton>
-      //       <EduIDButton
-      //         className="modal-button cancel-button"
-      //         id="reject-tou-button"
-      //         onClick={this.props.handleReject}
-      //       >
-      //         {this.props.translate("tou.cancel")}
-      //       </EduIDButton>
-      //     </ModalFooter>
-      //   </Modal>
-     
+      </div>
     ];
   }
 }

--- a/src/components/Email.js
+++ b/src/components/Email.js
@@ -83,6 +83,7 @@ class Email extends Component {
       <div key="1">
         <GenericConfirmModal 
           modalId="register-modal"
+          title={this.props.translate("tou.header")}
         />
       </div>,
       //   <Modal isOpen={this.props.acceptingTOU} id="register-modal">

--- a/src/components/GenericConfirmModal.js
+++ b/src/components/GenericConfirmModal.js
@@ -1,11 +1,9 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-
 import Modal from "reactstrap/lib/Modal";
 import ModalHeader from "reactstrap/lib/ModalHeader";
 import ModalBody from "reactstrap/lib/ModalBody";
 import ModalFooter from "reactstrap/lib/ModalFooter";
-
 import i18n from "../login/translation/InjectIntl_HOC_factory";
 import EduIDButton from "components/EduIDButton";
 
@@ -82,7 +80,6 @@ GenericConfirmModal.propTypes = {
   closeModal: PropTypes.func,
   acceptModal: PropTypes.func,
   showModal: PropTypes.bool,
-  //is_fetching: PropTypes.bool,
   confirming: PropTypes.bool
 };
 

--- a/src/components/GenericConfirmModal.js
+++ b/src/components/GenericConfirmModal.js
@@ -35,6 +35,7 @@ class GenericConfirmModal extends Component {
           }
           <ModalFooter>
             <EduIDButton
+              id={this.props.acceptButtonId}
               className="modal-button ok-button"
               onClick={this.props.acceptModal}
             >
@@ -44,6 +45,7 @@ class GenericConfirmModal extends Component {
               }
             </EduIDButton>
             <EduIDButton
+              id={this.props.closeButtonId}
               className="modal-button cancel-button"
               onClick={this.props.closeModal}
             >

--- a/src/components/GenericConfirmModal.js
+++ b/src/components/GenericConfirmModal.js
@@ -21,12 +21,18 @@ class GenericConfirmModal extends Component {
       >
         <Modal isOpen={this.props.showModal}>
           <ModalHeader>{this.props.title}</ModalHeader>
-
-          <ModalBody>
-            <div>
-              <p>{this.props.mainText}</p>
-            </div>
-          </ModalBody>
+          {
+            this.props.modalId === "register-modal" ?
+            <ModalBody 
+              dangerouslySetInnerHTML={{ __html: this.props.mainText }} 
+            />
+            : 
+            <ModalBody>
+              <div>
+                <p>{this.props.mainText}</p>
+              </div>
+            </ModalBody>
+          }
           <ModalFooter>
             <EduIDButton
               className="modal-button ok-button"

--- a/src/components/GenericConfirmModal.js
+++ b/src/components/GenericConfirmModal.js
@@ -11,47 +11,61 @@ import EduIDButton from "components/EduIDButton";
 
 class GenericConfirmModal extends Component {
   render() {
+    const { 
+      modalId, 
+      showModal, 
+      title, 
+      mainText, 
+      acceptButtonId, 
+      acceptModal, 
+      closeModal,
+      acceptButtonText, 
+      closeButtonId, 
+      closeButtonText, 
+      translate 
+    } = this.props;
+
     return (
       <div
-        id={this.props.modalId}
+        id={modalId}
         tabIndex="-1"
         role="dialog"
         aria-hidden="true"
         data-backdrop="true"
       >
-        <Modal isOpen={this.props.showModal} className={this.props.modalId}>
-          <ModalHeader>{this.props.title}</ModalHeader>
+        <Modal isOpen={showModal} className={modalId}>
+          <ModalHeader>{title}</ModalHeader>
           {
-            this.props.modalId === "register-modal" ?
+            modalId === "register-modal" ?
             <ModalBody 
-              dangerouslySetInnerHTML={{ __html: this.props.mainText }} 
+              dangerouslySetInnerHTML={{ __html: mainText }} 
             />
             : 
             <ModalBody>
               <div>
-                <p>{this.props.mainText}</p>
+                <p>{mainText}</p>
               </div>
             </ModalBody>
           }
           <ModalFooter>
             <EduIDButton
-              id={this.props.acceptButtonId}
+              id={acceptButtonId}
               className="modal-button ok-button"
-              onClick={this.props.acceptModal}
+              onClick={acceptModal}
             >
               {
-                this.props.acceptButtonText ? this.props.acceptButtonText 
-                : this.props.translate("cm.accept")
+                acceptButtonText ? acceptButtonText 
+                : translate("cm.accept")
               }
             </EduIDButton>
             <EduIDButton
-              id={this.props.closeButtonId}
+              id={closeButtonId}
               className="modal-button cancel-button"
-              onClick={this.props.closeModal}
+              onClick={closeModal}
             >
               {
-                this.props.closeButtonText ? this.props.closeButtonText 
-                : this.props.translate("cm.cancel")
+                closeButtonText ? closeButtonText 
+                : translate("cm.cancel")
               }
             </EduIDButton>
           </ModalFooter>

--- a/src/components/GenericConfirmModal.js
+++ b/src/components/GenericConfirmModal.js
@@ -38,13 +38,19 @@ class GenericConfirmModal extends Component {
               className="modal-button ok-button"
               onClick={this.props.acceptModal}
             >
-              {this.props.translate("cm.accept")}
+              {
+                this.props.acceptButtonText ? this.props.acceptButtonText 
+                : this.props.translate("cm.accept")
+              }
             </EduIDButton>
             <EduIDButton
               className="modal-button cancel-button"
               onClick={this.props.closeModal}
             >
-              {this.props.translate("cm.cancel")}
+              {
+                this.props.closeButtonText ? this.props.closeButtonText 
+                : this.props.translate("cm.cancel")
+              }
             </EduIDButton>
           </ModalFooter>
         </Modal>

--- a/src/components/GenericConfirmModal.js
+++ b/src/components/GenericConfirmModal.js
@@ -19,7 +19,7 @@ class GenericConfirmModal extends Component {
         aria-hidden="true"
         data-backdrop="true"
       >
-        <Modal isOpen={this.props.showModal}>
+        <Modal isOpen={this.props.showModal} className={this.props.modalId}>
           <ModalHeader>{this.props.title}</ModalHeader>
           {
             this.props.modalId === "register-modal" ?

--- a/src/login/styles/_modals.scss
+++ b/src/login/styles/_modals.scss
@@ -58,7 +58,7 @@ h5.modal-title {
 }
 
 // temporary styling for register tou
-#register-modal {
+.register-modal{
   & .modal-header {
     padding: 1rem 2rem;
   }

--- a/src/login/styles/_modals.scss
+++ b/src/login/styles/_modals.scss
@@ -63,7 +63,7 @@ h5.modal-title {
     padding: 1rem 2rem;
   }
   & .modal-body {
-    padding: 1rem 2rem 0 2rem;
+    padding: 1rem 2rem 1rem 2rem;
     & p {
       font-size: 1rem;
       padding-bottom: 0;


### PR DESCRIPTION
#### Description:
for reusability I have remove modal code in `Email.js` and added a Import` GenericConfromModal`
- this needed to send specific props for rendering different text and translation in button. `Email.js row 84`
```
   acceptButtonText={this.props.translate("tou.accept")}
   closeButtonText={this.props.translate("tou.cancel")}
   acceptButtonId={"accept-tou-button"}
   closeButtonId={"reject-tou-button"}
```

- props.mainText(props.tou) have a html tags `<ul/><li/>`so needed have a logic to check modal-id to display different modal-body
```
            modalId === "register-modal" ?
            <ModalBody 
              dangerouslySetInnerHTML={{ __html: mainText }} 
            />
            : 
            <ModalBody>
              <div>
                <p>{mainText}</p>
              </div>
            </ModalBody>
```

- to display  button text in Emails.js (eng)"Accept" (Swe)"Godkänd" / (eng)"Cancel" (Swe)"Avbryt"  


    `acceptButtonText ? acceptButtonText  : translate("cm.accept")`

    ` closeButtonText ? closeButtonText  : translate("cm.cancel")`

- Added className in Modal and Adjust `#register-modal` to `register-modal`
   - to keep general structure in GenericConfrimModal component  `modalId` need to be  inside `div` and have a list styling for modal-body, it needs modalId for className
` <div  id={modalId} .... />`.  ` <Modal isOpen={showModal} className={modalId}>`

- Adjust` padding-bottom:0` to `1rem` for modal-body 
- defined all props and removed` this.props`  **ps. please come with feedback on the change**


----
- Browser: Chrome
- Before
<img width="1438" alt="Screenshot 2020-09-07 at 11 18 53" src="https://user-images.githubusercontent.com/44289056/92371631-21570f80-f0fc-11ea-8a73-2c08ba04cc89.png">

- After
<img width="1437" alt="Screenshot 2020-09-07 at 11 19 24" src="https://user-images.githubusercontent.com/44289056/92371647-26b45a00-f0fc-11ea-8c05-50a9868f6f3c.png">



----


#### For reviewer:
what?
- [x] Check modal button text in register (Accept/Godkänd)
- [x] Check if other component that using gernericConfirmModal is still working? vetting button(via post, via phone, changePassword)

how?
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

