### PR TITLE
Rename GenericConfirmModal to NotificationModal

### DIFF
--- a/src/components/ChangePasswordDisplay.js
+++ b/src/components/ChangePasswordDisplay.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import EduIDButton from "components/EduIDButton";
-import GenericConfirmModal from "components/GenericConfirmModal";
+import NotificationModal from "components/NotificationModal";
 
 import "../login/styles/index.scss";
 
@@ -24,7 +24,7 @@ class ChangePasswordDisplay extends Component {
             </EduIDButton>
           </div>
         </div>
-        <GenericConfirmModal
+        <NotificationModal
           modalId="securityConfirmDialog"
           title={this.props.translate("settings.confirm_title_chpass")}
           mainText={this.props.translate("settings.change_info")}

--- a/src/components/Email.js
+++ b/src/components/Email.js
@@ -5,7 +5,7 @@ import CustomInput from "../login/components/Inputs/CustomInput";
 import { Field, reduxForm } from "redux-form";
 import Form from "reactstrap/lib/Form";
 import EduIDButton from "components/EduIDButton";
-import GenericConfirmModal from "components/GenericConfirmModal";
+import NotificationModal from "components/NotificationModal";
 import { validate } from "../login/app_utils/validation/validateEmail";
 
 /* FORM */
@@ -62,7 +62,7 @@ class Email extends Component {
         </p>
       </div>,
       <div key="1">
-        <GenericConfirmModal 
+        <NotificationModal 
           modalId="register-modal"
           title={this.props.translate("tou.header")}
           showModal={this.props.acceptingTOU}

--- a/src/components/LetterProofing.js
+++ b/src/components/LetterProofing.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 
 import ConfirmModal from "components/ConfirmModal";
-import GenericConfirmModal from "components/GenericConfirmModal";
+import NotificationModal from "components/NotificationModal";
 
 class LetterProofingButton extends Component {
   render() {
@@ -21,7 +21,7 @@ class LetterProofingButton extends Component {
             </div>
           </button>
         </div>
-        <GenericConfirmModal
+        <NotificationModal
           modalId="letterGenericConfirmDialog"
           title={this.props.translate("letter.modal_confirm_title")}
           mainText={this.props.translate("letter.modal_confirm_info")}

--- a/src/components/LookupMobileProofing.js
+++ b/src/components/LookupMobileProofing.js
@@ -1,6 +1,6 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
-import GenericConfirmModal from "components/GenericConfirmModal";
+import NotificationModal from "components/NotificationModal";
 
 class LookupMobileProofing extends Component {
   render() {
@@ -15,7 +15,7 @@ class LookupMobileProofing extends Component {
 
     if (phoneNumbers.length) {
       modalPrompt = [
-        <GenericConfirmModal
+        <NotificationModal
           key="0"
           modalId="mobileGenericConfirmDialog"
           title={this.props.translate("lmp.modal_reminder_to_confirm_title")}
@@ -27,7 +27,7 @@ class LookupMobileProofing extends Component {
       ];
       if (primaryNumber) {
         modalPrompt = [
-          <GenericConfirmModal
+          <NotificationModal
             key="0"
             modalId="mobileGenericConfirmDialog"
             title={this.props.translate("lmp.modal_confirm_title")}
@@ -40,7 +40,7 @@ class LookupMobileProofing extends Component {
       }
     } else {
       modalPrompt = [
-        <GenericConfirmModal
+        <NotificationModal
           key="0"
           modalId="mobileGenericConfirmDialog"
           title={this.props.translate("lmp.modal_add_number_title")}

--- a/src/components/NotificationModal.js
+++ b/src/components/NotificationModal.js
@@ -7,7 +7,7 @@ import ModalFooter from "reactstrap/lib/ModalFooter";
 import i18n from "../login/translation/InjectIntl_HOC_factory";
 import EduIDButton from "components/EduIDButton";
 
-class GenericConfirmModal extends Component {
+class NotificationModal extends Component {
   render() {
     const { 
       modalId, 
@@ -73,7 +73,7 @@ class GenericConfirmModal extends Component {
   }
 }
 
-GenericConfirmModal.propTypes = {
+NotificationModal.propTypes = {
   modalId: PropTypes.string,
   title: PropTypes.any,
   mainText: PropTypes.any,
@@ -83,4 +83,4 @@ GenericConfirmModal.propTypes = {
   confirming: PropTypes.bool
 };
 
-export default i18n(GenericConfirmModal);
+export default i18n(NotificationModal);

--- a/src/components/Security.js
+++ b/src/components/Security.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import EduIDButton from "components/EduIDButton";
-import GenericConfirmModal from "components/GenericConfirmModal";
+import NotificationModal from "components/NotificationModal";
 import ConfirmModal from "components/ConfirmModal";
 
 import "../login/styles/index.scss";
@@ -156,7 +156,7 @@ class Security extends Component {
           </div>
         </div>
 
-        <GenericConfirmModal
+        <NotificationModal
           modalId="securityConfirmDialog"
           title={this.props.translate("security.confirm_title_chpass")}
           mainText={this.props.translate("security.change_info")}

--- a/src/tests/ChangePasswordDisplay-test.js
+++ b/src/tests/ChangePasswordDisplay-test.js
@@ -5,7 +5,7 @@ import { put, select, call } from "redux-saga/effects";
 import { shallow, mount } from "enzyme";
 import fetchMock from "fetch-mock";
 import { addLocaleData, IntlProvider } from "react-intl";
-import GenericConfirmModal from "components/GenericConfirmModal";
+import NotificationModal from "components/NotificationModal";
 import ChangePasswordDisplay from "containers/ChangePasswordDisplay";
 import * as actions from "actions/Security";
 import securityReducer from "reducers/Security";
@@ -73,7 +73,7 @@ describe("ChangePasswordDisplay component", () => {
 
   it("has a modal", () => {
     const { wrapper } = setupComponent();
-    const modal = wrapper.find(GenericConfirmModal);
+    const modal = wrapper.find(NotificationModal);
     expect(modal.exists()).toEqual(true);
   });
 });
@@ -110,7 +110,7 @@ describe("ChangePasswordDisplay component, when confirming_change is (false)", (
   // leave confirming_change as false
   it("does not render a modal", () => {
     const { wrapper } = setupComponent();
-    const modal = wrapper.find(GenericConfirmModal);
+    const modal = wrapper.find(NotificationModal);
     expect(modal.props().showModal).toEqual(false);
   });
 
@@ -154,12 +154,12 @@ describe("ChangePasswordDisplay component, when confirming_change is (true)", ()
   state.security.confirming_change = true;
   it("renders a modal", () => {
     const { wrapper } = setupComponent();
-    const modal = wrapper.find(GenericConfirmModal);
+    const modal = wrapper.find(NotificationModal);
     expect(modal.props().showModal).toEqual(true);
   });
   it("Renders ACCEPT and CANCEL EduIDButtons in modal", () => {
     const { wrapper } = setupComponent();
-    const modal = wrapper.find(GenericConfirmModal);
+    const modal = wrapper.find(NotificationModal);
     const button = modal.find("EduIDButton");
     expect(button.length).toEqual(2);
   });

--- a/src/tests/Security-test.js
+++ b/src/tests/Security-test.js
@@ -957,7 +957,7 @@ describe("Security Component", () => {
       buttonChange = wrapper.find("EduIDButton#security-change-button"),
       buttonWEBAUTHN = wrapper.find("EduIDButton#security-webauthn-button"),
       buttonDelete = wrapper.find("EduIDButton#delete-button"),
-      modalChange = wrapper.find("GenericConfirmModal"),
+      modalChange = wrapper.find("NotificationModal"),
       modalWEBAUTHNDescription = wrapper.find("ConfirmModal"),
       modalDelete = wrapper.find("DeleteModal");
   });


### PR DESCRIPTION
#### Description:
we decided to rename some of files 
 - **GenericConfrimModal->NotificationModal**
 - Email-> AddEmail
 - Emails->AddPhoneNumbers
 - Mobile->AddPhoneNumbers

**this PR renamed only GenericConfrimModal- > NotificationModal**

#### Summary:
GenericConfrimModa.js in container, action, reducer, component, test renamed to NotificationModal.js

- please check, modal is working 
- [ ] Email, Vetting button(Letter, Phone, FrejaEid)

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

