### PR TITLE
Avoid race condition on initialization wrt the saml request in the se…

### DIFF
--- a/src/dashboard-root-saga.js
+++ b/src/dashboard-root-saga.js
@@ -63,8 +63,8 @@ function* rootSaga() {
     takeLatest(configActions.GET_JSCONFIG_CONFIG, requestConfig),
     takeLatest(configActions.GET_JSCONFIG_CONFIG_SUCCESS, configSaga),
     takeLatest(configActions.GET_INITIAL_USERDATA, requestAllPersonalData),
-    takeLatest(configActions.GET_INITIAL_USERDATA, requestCredentials),
-    takeLatest(configActions.GET_INITIAL_USERDATA, requestSuggestedPassword),
+    takeLatest(pdataActions.GET_USERDATA_SUCCESS, requestCredentials),
+    takeLatest(pdataActions.GET_USERDATA_SUCCESS, requestSuggestedPassword),
     ...groupsSagas,
     takeLatest(pdataActions.POST_USERDATA, savePersonalData),
     takeLatest(

--- a/src/login/redux/sagas/rootSaga/groupsSagas.js
+++ b/src/login/redux/sagas/rootSaga/groupsSagas.js
@@ -9,7 +9,6 @@ import { createGroupSaga } from "../groups/createGroupSaga";
 // connecting actions (redux) with sagas (fetch)
 const groupsSagas = [
   // takeLatest(configActions.GET_INITIAL_USERDATA, groupsSaga),
-  takeLatest(configActions.GET_INITIAL_USERDATA, allDataSaga),
   takeLatest(createGroupActions.CREATE_GROUP, createGroupSaga),
 ];
 


### PR DESCRIPTION
…ssion

#### Description:
We have 3 initial simultaneous GET requests that need to be authenticated, retrieving user data, credentials, and suggested password. This creates a race condition in the authn service with the end result of overwriting the proper saml request id in the  session. So this PR ensures that the requests are not simultaneous, avoiding the race condition.

To test this, check that when the app is loaded unauthenticated, and thus the user is redirected to the IdP, the network tab in the developer's tools shows a request to the `/services/personal-data/all-user-data`, but not to the `/services/security/credentials`, to the `/services/security/suggested-password`, or to the `/services/group-management/all-data` endpoints.

Once the user is identified by the IdP, and the app loads authenticated, the network tab should show requests for all 4 endpoints.

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

