### PR TITLE
MODAL: Corrected spelling error for modal title by vetting phone

### DIFF
--- a/i18n/src/login/translation/defaultMessages/userProfile.json
+++ b/i18n/src/login/translation/defaultMessages/userProfile.json
@@ -185,7 +185,7 @@
   },
   {
     "id": "lmp.modal_reminder_to_confirm_title",
-    "defaultMessage": "Your number also needs to be confrimed"
+    "defaultMessage": "Your number also needs to be confirmed"
   },
   {
     "id": "lmp.modal_reminder_to_confirm_info",

--- a/src/components/LookupMobileProofing.js
+++ b/src/components/LookupMobileProofing.js
@@ -23,6 +23,7 @@ class LookupMobileProofing extends Component {
           showModal={this.props.showModal}
           closeModal={this.props.handleCloseModal}
           acceptModal={this.props.handleCloseModal}
+          acceptButtonText={this.props.translate("cm.ok")}
         />,
       ];
       if (primaryNumber) {

--- a/src/login/translation/defaultMessages/userProfile.js
+++ b/src/login/translation/defaultMessages/userProfile.js
@@ -330,7 +330,7 @@ export const userVetting = {
   "lmp.modal_reminder_to_confirm_title": (
     <FormattedMessage
       id="lmp.modal_reminder_to_confirm_title"
-      defaultMessage={`Your number also needs to be confrimed`}
+      defaultMessage={`Your number also needs to be confirmed`}
     />
   ),
 

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -169,7 +169,7 @@
   "lmp.modal_add_number_title": "Add your mobile number to continue",
   "lmp.modal_confirm_title": "Check if your phone number is connected to your id number.",
   "lmp.modal_reminder_to_confirm_info": "Go to Settings to confirm your number. You can only use this option with a confirmed number.",
-  "lmp.modal_reminder_to_confirm_title": "Your number also needs to be confrimed",
+  "lmp.modal_reminder_to_confirm_title": "Your number also needs to be confirmed",
   "lmp.verification_success": "Your national id number has been successfully verified",
   "mail_duplicated": "Added email is duplicated",
   "main.confirmed": "Confirmed",

--- a/src/login/translation/src/i18n-messages.json
+++ b/src/login/translation/src/i18n-messages.json
@@ -597,7 +597,7 @@
   },
   {
     "id": "lmp.modal_reminder_to_confirm_title",
-    "defaultMessage": "Your number also needs to be confrimed"
+    "defaultMessage": "Your number also needs to be confirmed"
   },
   {
     "id": "lmp.modal_reminder_to_confirm_info",

--- a/src/login/translation/src/login/translation/defaultMessages/userProfile.json
+++ b/src/login/translation/src/login/translation/defaultMessages/userProfile.json
@@ -193,7 +193,7 @@
   },
   {
     "id": "lmp.modal_reminder_to_confirm_title",
-    "defaultMessage": "Your number also needs to be confrimed"
+    "defaultMessage": "Your number also needs to be confirmed"
   },
   {
     "id": "lmp.modal_reminder_to_confirm_info",


### PR DESCRIPTION
#### Description:
I have corrected spelling error in ` lmp.modal_reminder_to_confirm_title`
I have changed `Your number also needs to be confrimed `to `Your number also needs to be confirmed`

---
- Before/After

![Screenshot 2020-09-23 at 10 56 34](https://user-images.githubusercontent.com/44289056/93990509-785f1480-fd8b-11ea-971c-58810b783625.png)
---



#### For reviewer:
- [x] Read the above description
- [x] Reviewed the code changes
- [x] Navigate to the branch (pulled the latest version)
- [x] Run the code and been able to execute the expected function
- [x] Check any styling on both desktop and mobile sizes

