### PR TITLE
access config keys using lowercase names

### DIFF
--- a/src/containers/ChangePassword.js
+++ b/src/containers/ChangePassword.js
@@ -28,7 +28,7 @@ const mapStateToProps = (state, props) => {
       state.form.chpass.values[comp.pwFieldCustomName]) ||
     "";
   let score = 0,
-    configEntropy = state.config.PASSWORD_ENTROPY,
+    configEntropy = state.config.password_entropy,
     minEntropy = configEntropy / 5,
     stepEntropy = minEntropy,
     entropy = 0;

--- a/src/containers/Eidas.js
+++ b/src/containers/Eidas.js
@@ -5,8 +5,8 @@ import { eduidRMAllNotify } from "actions/Notifications";
 import i18n from "../login/translation/InjectIntl_HOC_factory";
 
 const mapStateToProps = (state, props) => {
-  let eidas_sp_url = state.config.EIDAS_URL;
-  let freja_idp_url = state.config.TOKEN_VERIFY_IDP;
+  let eidas_sp_url = state.config.eidas_url;
+  let freja_idp_url = state.config.token_verify_idp;
   let verify_path = "verify-nin";
   if (!eidas_sp_url.endsWith("/")) {
     eidas_sp_url = eidas_sp_url.concat("/");

--- a/src/containers/Footer.js
+++ b/src/containers/Footer.js
@@ -7,15 +7,15 @@ import i18n from "../login/translation/InjectIntl_HOC_factory";
 
 const mapStateToProps = (state, props) => {
   const languages = {};
-  if (state.config.AVAILABLE_LANGUAGES !== undefined) {
-    state.config.AVAILABLE_LANGUAGES.forEach(l => {
+  if (state.config.available_languages !== undefined) {
+    state.config.available_languages.forEach(l => {
       languages[l[0]] = l[1];
     });
   }
   return {
     language: state.intl.locale,
     languages: languages,
-    reload_to: state.config.DASHBOARD_URL,
+    reload_to: state.config.dashboard_url,
     faq_link: state.config.static_faq_url
   };
 };

--- a/src/containers/Mobile.js
+++ b/src/containers/Mobile.js
@@ -21,7 +21,7 @@ const mapStateToProps = (state, props) => {
     phone: state.phones.phone,
     confirming: state.phones.confirming,
     resending: state.phones.resending,
-    default_country_code: state.config.DEFAULT_COUNTRY_CODE
+    default_country_code: state.config.default_country_code
   };
 };
 

--- a/src/containers/Nins.js
+++ b/src/containers/Nins.js
@@ -16,7 +16,7 @@ const mapStateToProps = (state, props) => {
     verifyingLetter: state.letter_proofing.verifyingLetter,
     nins: state.nins.nins,
     is_configured: state.config.is_configured,
-    proofing_methods: state.config.PROOFING_METHODS,
+    proofing_methods: state.config.proofing_methods,
     valid_nin: isValid("nins")(state),
     nin: state.nins.nin,
     message: state.nins.message,

--- a/src/containers/OpenidConnectFreja.js
+++ b/src/containers/OpenidConnectFreja.js
@@ -16,7 +16,7 @@ const mapStateToProps = (state, props) => {
     showModal: state.openid_freja_data.showModal,
     error: state.openid_freja_data.error,
     // Used until we deploy the nin component
-    proofing_methods: state.config.PROOFING_METHODS
+    proofing_methods: state.config.proofing_methods
   };
 };
 

--- a/src/containers/PersonalData.js
+++ b/src/containers/PersonalData.js
@@ -5,8 +5,8 @@ import i18n from "../login/translation/InjectIntl_HOC_factory";
 
 const mapStateToProps = (state, props) => {
   let langs = [];
-  if (state.config.AVAILABLE_LANGUAGES !== undefined) {
-    langs = [...state.config.AVAILABLE_LANGUAGES];
+  if (state.config.available_languages !== undefined) {
+    langs = [...state.config.available_languages];
     // langs.unshift(["", props.translate("pd.choose-language")]);
   }
   return {

--- a/src/containers/VerifyIdentity.js
+++ b/src/containers/VerifyIdentity.js
@@ -12,7 +12,7 @@ const mapStateToProps = (state, props) => {
     verifiedNinStatus: verifiedNinStatus,
     is_configured: state.config.is_configured,
     letter_verification: state.letter_proofing.confirmingLetter,
-    proofing_methods: state.config.PROOFING_METHODS,
+    proofing_methods: state.config.proofing_methods,
     message: state.nins.message
   };
 };

--- a/src/login/app_init/init_reducer.js
+++ b/src/login/app_init/init_reducer.js
@@ -3,8 +3,8 @@ import * as actions from "./init_actions";
 const initData = {
   csrf_token: "",
   error: false,
-  DEBUG: true,
-  AVAILABLE_LANGUAGES: [],
+  debug: true,
+  available_languages: [],
   extra_security: {}
 };
 

--- a/src/login/components/Footer/Footer_container.js
+++ b/src/login/components/Footer/Footer_container.js
@@ -16,7 +16,7 @@ const mapStateToProps = (state, props) => {
     is_configured: state.config.is_configured,
     language: state.intl.locale,
     languages: languages,
-    reload_to: state.config.DASHBOARD_URL,
+    reload_to: state.config.dashboard_url,
     faq_link: state.config.static_faq_url
   };
 };

--- a/src/login/components/Header/Header_sagas.js
+++ b/src/login/components/Header/Header_sagas.js
@@ -5,7 +5,7 @@ import { postLogoutFail, POST_AUTHN_LOGOUT_SUCCESS } from "./Header_actions";
 export function* requestLogout() {
   try {
     const state = yield select(state => state),
-      url = state.config.TOKEN_SERVICE_URL + "logout";
+      url = state.config.token_service_url + "logout";
     if (navigator.userAgent.indexOf("Trident/7") > -1) {
       window.location = url;
     } else {

--- a/src/reducers/ActionMain.js
+++ b/src/reducers/ActionMain.js
@@ -6,7 +6,7 @@ const configData = {
   is_app_loaded: false,
   redirect: "/",
   //is_fetching: false,
-  available_languages: {}
+  available_languages: []
 };
 
 let actionMainReducer = (state = configData, action) => {

--- a/src/reducers/DashboardConfig.js
+++ b/src/reducers/DashboardConfig.js
@@ -17,8 +17,8 @@ const configData = {
   is_configured: false,
   //is_fetching: false,
   is_app_loaded: false,
-  AVAILABLE_LANGUAGES: [],
-  DEBUG: true
+  available_languages: [],
+  debug: true
 };
 
 //const fetchingActions = [

--- a/src/reducers/SignupMain.js
+++ b/src/reducers/SignupMain.js
@@ -15,7 +15,7 @@ const configData = {
   is_app_loaded: false,
   //is_fetching: false,
   debug: true,
-  available_languages: {},
+  available_languages: [],
   eidas_url: "",
   mfa_authn_idp: ""
 };

--- a/src/reducers/SignupMain.js
+++ b/src/reducers/SignupMain.js
@@ -14,7 +14,7 @@ const configData = {
   tou: "",
   is_app_loaded: false,
   //is_fetching: false,
-  DEBUG: true,
+  debug: true,
   available_languages: {},
   eidas_url: "",
   mfa_authn_idp: ""

--- a/src/sagas/AccountLinking.js
+++ b/src/sagas/AccountLinking.js
@@ -24,7 +24,7 @@ export function* requestOrcid() {
 export function* requestConnectOrcid(win) {
   try {
     const config = yield select(state => state.config);
-    let url = config.ORCID_URL + "authorize";
+    let url = config.orcid_url + "authorize";
 
     if (win !== undefined && win.location !== undefined) {
       win.location.href = url;
@@ -38,7 +38,7 @@ export function* requestConnectOrcid(win) {
 
 export function fetchOrcid(config) {
   return window
-    .fetch(config.ORCID_URL, {
+    .fetch(config.orcid_url, {
       ...getRequest
     })
     .then(checkStatus)
@@ -61,7 +61,7 @@ export function* requestRemoveOrcid() {
 
 export function removeOrcid(config, data) {
   return window
-    .fetch(config.ORCID_URL + "remove", {
+    .fetch(config.orcid_url + "remove", {
       ...postRequest,
       body: JSON.stringify(data)
     })

--- a/src/sagas/ChangePassword.js
+++ b/src/sagas/ChangePassword.js
@@ -25,7 +25,7 @@ export function* requestSuggestedPassword() {
 
 export function fetchSuggestedPassword(config) {
   return window
-    .fetch(config.SECURITY_URL + "suggested-password", {
+    .fetch(config.security_url + "suggested-password", {
       ...getRequest
     })
     .then(checkStatus)
@@ -64,7 +64,7 @@ export function* postPasswordChange() {
 
 export function postPassword(config, data) {
   return window
-    .fetch(config.SECURITY_URL + "change-password", {
+    .fetch(config.security_url + "change-password", {
       ...postRequest,
       body: JSON.stringify(data)
     })

--- a/src/sagas/Emails.js
+++ b/src/sagas/Emails.js
@@ -18,7 +18,7 @@ const getData = state => ({
 
 export function sendEmail(config, data) {
   return window
-    .fetch(config.EMAILS_URL + "new", {
+    .fetch(config.emails_url + "new", {
       ...postRequest,
       body: JSON.stringify(data)
     })
@@ -51,7 +51,7 @@ export function* requestResendEmailCode() {
 
 export function requestResend(config, data) {
   return window
-    .fetch(config.EMAILS_URL + "resend-code", {
+    .fetch(config.emails_url + "resend-code", {
       ...postRequest,
       body: JSON.stringify(data)
     })
@@ -77,7 +77,7 @@ export function* requestVerifyEmail() {
 
 export function requestVerify(config, data) {
   return window
-    .fetch(config.EMAILS_URL + "verify", {
+    .fetch(config.emails_url + "verify", {
       ...postRequest,
       body: JSON.stringify(data)
     })
@@ -102,7 +102,7 @@ export function* requestRemoveEmail() {
 
 export function requestRemove(config, data) {
   return window
-    .fetch(config.EMAILS_URL + "remove", {
+    .fetch(config.emails_url + "remove", {
       ...postRequest,
       body: JSON.stringify(data)
     })
@@ -127,7 +127,7 @@ export function* requestMakePrimaryEmail() {
 
 export function requestMakePrimary(config, data) {
   return window
-    .fetch(config.EMAILS_URL + "primary", {
+    .fetch(config.emails_url + "primary", {
       ...postRequest,
       body: JSON.stringify(data)
     })

--- a/src/sagas/Header.js
+++ b/src/sagas/Header.js
@@ -11,7 +11,7 @@ import { postLogoutFail, POST_AUTHN_LOGOUT_SUCCESS } from "actions/Header";
 export function* requestLogout() {
   try {
     const state = yield select(state => state),
-      url = state.config.TOKEN_SERVICE_URL + "logout";
+      url = state.config.token_service_url + "logout";
     if (navigator.userAgent.indexOf("Trident/7") > -1) {
       window.location = url;
     } else {

--- a/src/sagas/LetterProofing.js
+++ b/src/sagas/LetterProofing.js
@@ -25,7 +25,7 @@ export function* sendGetLetterProofing() {
 
 export function fetchGetLetterProofing(config, nin) {
   return window
-    .fetch(config.LETTER_PROOFING_URL + "proofing?nin=" + nin, {
+    .fetch(config.letter_proofing_url + "proofing?nin=" + nin, {
       ...getRequest
     })
     .then(checkStatus)
@@ -50,7 +50,7 @@ export function* sendLetterProofing() {
 
 export function fetchLetterProofing(config, data) {
   return window
-    .fetch(config.LETTER_PROOFING_URL + "proofing", {
+    .fetch(config.letter_proofing_url + "proofing", {
       ...postRequest,
       body: JSON.stringify(data)
     })
@@ -76,7 +76,7 @@ export function* sendLetterCode() {
 
 export function fetchLetterCode(config, data) {
   return window
-    .fetch(config.LETTER_PROOFING_URL + "verify-code", {
+    .fetch(config.letter_proofing_url + "verify-code", {
       ...postRequest,
       body: JSON.stringify(data)
     })

--- a/src/sagas/LookupMobileProofing.js
+++ b/src/sagas/LookupMobileProofing.js
@@ -44,7 +44,7 @@ import * as ninActions from "actions/Nins";
 export function fetchLookupMobileProof(config, data) {
   console.log("this is config in fetchLookupMobileProof", config);
   console.log("this is data in fetchLookupMobileProof", data);
-  const url = config.LOOKUP_MOBILE_PROOFING_URL;
+  const url = config.lookup_mobile_proofing_url;
   return window
     .fetch(url, {
       ...postRequest,

--- a/src/sagas/Mobile.js
+++ b/src/sagas/Mobile.js
@@ -18,7 +18,7 @@ const getData = state => ({
 
 export function sendMobile(config, data) {
   return window
-    .fetch(config.MOBILE_URL + "new", {
+    .fetch(config.mobile_url + "new", {
       ...postRequest,
       body: JSON.stringify(data)
     })
@@ -51,7 +51,7 @@ export function* requestResendMobileCode() {
 
 export function requestResend(config, data) {
   return window
-    .fetch(config.MOBILE_URL + "resend-code", {
+    .fetch(config.mobile_url + "resend-code", {
       ...postRequest,
       body: JSON.stringify(data)
     })
@@ -77,7 +77,7 @@ export function* requestVerifyMobile() {
 
 export function requestVerify(config, data) {
   return window
-    .fetch(config.MOBILE_URL + "verify", {
+    .fetch(config.mobile_url + "verify", {
       ...postRequest,
       body: JSON.stringify(data)
     })
@@ -102,7 +102,7 @@ export function* requestRemoveMobile() {
 
 export function requestRemove(config, data) {
   return window
-    .fetch(config.MOBILE_URL + "remove", {
+    .fetch(config.mobile_url + "remove", {
       ...postRequest,
       body: JSON.stringify(data)
     })
@@ -127,7 +127,7 @@ export function* requestMakePrimaryMobile() {
 
 export function requestMakePrimary(config, data) {
   return window
-    .fetch(config.MOBILE_URL + "primary", {
+    .fetch(config.mobile_url + "primary", {
       ...postRequest,
       body: JSON.stringify(data)
     })

--- a/src/sagas/Nins.js
+++ b/src/sagas/Nins.js
@@ -23,7 +23,7 @@ export function* requestNins() {
 
 export function fetchNins(config) {
   return window
-    .fetch(config.PERSONAL_DATA_URL + "nins", {
+    .fetch(config.personal_data_url + "nins", {
       ...getRequest
     })
     .then(checkStatus)
@@ -79,7 +79,7 @@ export function* requestRemoveNin() {
 
 export function requestRemove(config, data) {
   return window
-    .fetch(config.SECURITY_URL + "remove-nin", {
+    .fetch(config.security_url + "remove-nin", {
       ...postRequest,
       body: JSON.stringify(data)
     })

--- a/src/sagas/OpenidConnect.js
+++ b/src/sagas/OpenidConnect.js
@@ -39,7 +39,7 @@ export function* checkNINAndShowSelegModal() {
 
 export function* requestOpenidQRcode() {
   const state = yield select(state => state),
-    openid_url = state.config.OIDC_PROOFING_URL,
+    openid_url = state.config.oidc_proofing_url,
     data = {
       csrf_token: state.config.csrf_token,
       nin: state.openid_data.nin

--- a/src/sagas/OpenidConnectFreja.js
+++ b/src/sagas/OpenidConnectFreja.js
@@ -44,7 +44,7 @@ export function* closeFrejaModal() {
 export function* initializeOpenidFrejaData() {
   try {
     const state = yield select(state => state),
-      openid_freja_url = state.config.OIDC_PROOFING_FREJA_URL,
+      openid_freja_url = state.config.oidc_proofing_freja_url,
       data = {
         nin: state.openid_freja_data.nin,
         csrf_token: state.config.csrf_token
@@ -72,7 +72,7 @@ export function* initializeOpenidFrejaData() {
 export function* requestOpenidFrejaData() {
   try {
     const openid_freja_url = yield select(
-      state => state.config.OIDC_PROOFING_FREJA_URL
+      state => state.config.oidc_proofing_freja_url
     );
     console.log("Checking for existing opaque data");
     const oidcFrejaData = yield call(fetchFrejaData, openid_freja_url);

--- a/src/sagas/PersonalData.js
+++ b/src/sagas/PersonalData.js
@@ -95,7 +95,7 @@ export function* requestAllPersonalData() {
 
 export function fetchAllPersonalData(config) {
   return window
-    .fetch(config.PERSONAL_DATA_URL + "all-user-data", {
+    .fetch(config.personal_data_url + "all-user-data", {
       ...getRequest
     })
     .then(checkStatus)
@@ -113,7 +113,7 @@ const getData = state => {
 
 export function sendPersonalData(config, data) {
   return window
-    .fetch(config.PERSONAL_DATA_URL + "user", {
+    .fetch(config.personal_data_url + "user", {
       ...postRequest,
       body: JSON.stringify(data)
     })

--- a/src/sagas/Security.js
+++ b/src/sagas/Security.js
@@ -39,7 +39,7 @@ export function* requestCredentials() {
 
 export function fetchCredentials(config) {
   return window
-    .fetch(config.SECURITY_URL + "credentials", {
+    .fetch(config.security_url + "credentials", {
       ...getRequest
     })
     .then(checkStatus)
@@ -50,9 +50,9 @@ export function* requestPasswordChange(win) {
   try {
     yield put(stopConfirmationPassword());
     const config = yield select(state => state.config),
-      tsURL = config.TOKEN_SERVICE_URL,
+      tsURL = config.token_service_url,
       chpassURL = tsURL + "chpass",
-      dashURL = config.DASHBOARD_URL,
+      dashURL = config.dashboard_url,
       nextURL = dashURL + "chpass",
       url = chpassURL + "?next=" + encodeURIComponent(nextURL);
 
@@ -70,7 +70,7 @@ export function* requestPasswordChange(win) {
 //   try {
 //     yield put(stopConfirmationDeletion());
 //     const config = yield select(state => state.config);
-//     let tsURL = config.TOKEN_SERVICE_URL;
+//     let tsURL = config.token_service_url;
 //     let nextURL = "delete-account";
 //     let url = tsURL + "?next=" + nextURL;
 
@@ -101,7 +101,7 @@ export function* postDeleteAccount() {
 
 export function deleteAccount(config, data) {
   return window
-    .fetch(config.SECURITY_URL + "terminate-account", {
+    .fetch(config.security_url + "terminate-account", {
       ...postRequest,
       body: JSON.stringify(data)
     })
@@ -126,7 +126,7 @@ export function* removeWebauthnToken() {
 
 export function removeToken(config, data) {
   return window
-    .fetch(config.SECURITY_URL + "webauthn/remove", {
+    .fetch(config.security_url + "webauthn/remove", {
       ...postRequest,
       body: JSON.stringify(data)
     })
@@ -139,8 +139,8 @@ export function* verifyWebauthnToken(win) {
     const state = yield select(state => state);
     const keyHandle = state.security.webauthn_token_verify;
 
-    let idpParam = "?idp=" + state.config.TOKEN_VERIFY_IDP;
-    let url = state.config.EIDAS_URL + "verify-token/" + keyHandle + idpParam;
+    let idpParam = "?idp=" + state.config.token_verify_idp;
+    let url = state.config.eidas_url + "verify-token/" + keyHandle + idpParam;
 
     if (win !== undefined && win.location !== undefined) {
       win.location.href = url;
@@ -180,7 +180,7 @@ export function* beginRegisterWebauthn() {
 
 export function beginWebauthnRegistration(config, data) {
   return window
-    .fetch(config.SECURITY_URL + "webauthn/register/begin", {
+    .fetch(config.security_url + "webauthn/register/begin", {
       ...postRequest,
       body: JSON.stringify(data)
     })
@@ -218,7 +218,7 @@ export function* registerWebauthn() {
 
 export function webauthnRegistration(config, data) {
   return window
-    .fetch(config.SECURITY_URL + "webauthn/register/complete", {
+    .fetch(config.security_url + "webauthn/register/complete", {
       ...postRequest,
       body: JSON.stringify(data)
     })

--- a/src/tests/AccountLinking-test.js
+++ b/src/tests/AccountLinking-test.js
@@ -182,7 +182,7 @@ const mockState = {
   },
   config: {
     csrf_token: "csrf-token",
-    ORCID_URL: "/dummy-orcid-url/"
+    orcid_url: "/dummy-orcid-url/"
   },
   intl: {
     locale: "en",
@@ -309,7 +309,7 @@ describe("AccountLinking Container", () => {
         },
         config: {
           csrf_token: "csrf-token",
-          ORCID_URL: "/dummy-orcid-url/"
+          orcid_url: "/dummy-orcid-url/"
         },
         intl: {
           locale: "en",

--- a/src/tests/ActionMain-test.js
+++ b/src/tests/ActionMain-test.js
@@ -29,7 +29,7 @@ const fakeState = {
     is_app_loaded: true,
     redirect: "/",
     //is_fetching: false,
-    available_languages: {}
+    available_languages: []
   },
   notifications: {
     messages: [],
@@ -204,7 +204,7 @@ describe("ActionMain reducer", () => {
     is_app_loaded: false,
     redirect: "/",
     //is_fetching: false,
-    available_languages: {}
+    available_languages: []
   };
 
   //it("Receives app fetching action", () => {

--- a/src/tests/ChangePassword-test.js
+++ b/src/tests/ChangePassword-test.js
@@ -221,9 +221,9 @@ const mockState = {
   },
   config: {
     csrf_token: "csrf-token",
-    DASHBOARD_URL: "/dummy-dash-url/",
-    TOKEN_SERVICE_URL: "/dummy-tok-url/",
-    SECURITY_URL: "/dummy-sec-url"
+    dashboard_url: "/dummy-dash-url/",
+    token_service_url: "/dummy-tok-url/",
+    security_url: "/dummy-sec-url"
   }
 };
 
@@ -309,9 +309,9 @@ const fakeState = custom => ({
   },
   config: {
     csrf_token: "",
-    SECURITY_URL: "/dummy-sec-url",
-    DASHBOARD_URL: "/dummy-dash-url/",
-    TOKEN_SERVICE_URL: "/dummy-tok-url/"
+    security_url: "/dummy-sec-url",
+    dashboard_url: "/dummy-dash-url/",
+    token_service_url: "/dummy-tok-url/"
   },
   personal_data: {
     data: {

--- a/src/tests/ChangePasswordDisplay-test.js
+++ b/src/tests/ChangePasswordDisplay-test.js
@@ -328,9 +328,9 @@ describe("Security Container", () => {
         },
         config: {
           csrf_token: "",
-          // SECURITY_URL: "/dummy-sec-url",
-          DASHBOARD_URL: "/dummy-dash-url/",
-          TOKEN_SERVICE_URL: "/dummy-tok-url/"
+          // security_url: "/dummy-sec-url",
+          dashboard_url: "/dummy-dash-url/",
+          token_service_url: "/dummy-tok-url/"
         },
         intl: {
           locale: "en",
@@ -401,9 +401,9 @@ const mockState = {
   },
   config: {
     csrf_token: "csrf-token",
-    DASHBOARD_URL: "/dummy-dash-url/",
-    TOKEN_SERVICE_URL: "/dummy-tok-url/",
-    SECURITY_URL: "/dummy-sec-url"
+    dashboard_url: "/dummy-dash-url/",
+    token_service_url: "/dummy-tok-url/",
+    security_url: "/dummy-sec-url"
   },
   intl: {
     locale: "en",

--- a/src/tests/DashboardConfig-test.js
+++ b/src/tests/DashboardConfig-test.js
@@ -111,7 +111,7 @@ const mockState = {
     csrf_token: "",
     is_configured: false,
     //is_fetching: false,
-    PERSONAL_DATA_URL: "http://localhost/services/personal-data/user"
+    personal_data_url: "http://localhost/services/personal-data/user"
   }
 };
 const getState = () => mockState;

--- a/src/tests/DeleteAccount-test.js
+++ b/src/tests/DeleteAccount-test.js
@@ -387,8 +387,8 @@ describe("DeleteAccount Container", () => {
         },
         config: {
           csrf_token: "",
-          DASHBOARD_URL: "/dummy-dash-url/",
-          TOKEN_SERVICE_URL: "/dummy-tok-url/"
+          dashboard_url: "/dummy-dash-url/",
+          token_service_url: "/dummy-tok-url/"
         },
         intl: {
           locale: "en",
@@ -475,9 +475,9 @@ describe("Async component", () => {
     },
     config: {
       csrf_token: "csrf-token",
-      DASHBOARD_URL: "/dummy-dash-url/",
-      TOKEN_SERVICE_URL: "/dummy-tok-url/",
-      SECURITY_URL: "/dummy-sec-url"
+      dashboard_url: "/dummy-dash-url/",
+      token_service_url: "/dummy-tok-url/",
+      security_url: "/dummy-sec-url"
     },
     intl: {
       locale: "en",

--- a/src/tests/Eidas-test.js
+++ b/src/tests/Eidas-test.js
@@ -57,8 +57,8 @@ describe("Reducers", () => {
 
 const state = {
   config: {
-    EIDAS_URL: "http://eidas.localhost",
-    TOKEN_VERIFY_IDP: "http://idp.localhost",
+    eidas_url: "http://eidas.localhost",
+    token_verify_idp: "http://idp.localhost",
     csrf_token: "csrf-token"
   },
   intl: {

--- a/src/tests/Emails-test.js
+++ b/src/tests/Emails-test.js
@@ -454,7 +454,7 @@ const state = {
   },
   config: {
     csrf_token: "123456789",
-    EMAILS_URL: "test/localhost",
+    emails_url: "test/localhost",
     email: "email@localhost.com"
   },
   intl: {

--- a/src/tests/Footer-test.js
+++ b/src/tests/Footer-test.js
@@ -8,12 +8,12 @@ import { setupComponent, fakeStore, getState } from "tests/SignupMain-test";
 const config = {
   is_app_loaded: true,
   is_configured: true,
-  AVAILABLE_LANGUAGES: [["en", "English"], ["sv", "Svenska"]],
+  available_languages: [["en", "English"], ["sv", "Svenska"]],
   dashboard_url: "http://example.com",
-  STATIC_STUDENTS_URL: "http://example.com/student",
-  STATIC_TECHNICIANS_URL: "http://example.com",
-  STATIC_STAFF_URL: "http://example.com",
-  STATIC_FAQ_URL: "http://example.com"
+  static_students_url: "http://example.com/student",
+  static_technicians_url: "http://example.com",
+  static_staff_url: "http://example.com",
+  static_faq_url: "http://example.com"
 };
 
 const state = {

--- a/src/tests/LetterProofing-test.js
+++ b/src/tests/LetterProofing-test.js
@@ -192,7 +192,7 @@ const fakeState = {
     errMsg: "",
     letter_sent: ""
   },
-  config: { LETTER_PROOFING_URL: "http://localhost/letter" },
+  config: { letter_proofing_url: "http://localhost/letter" },
   nins: {
     valid_nin: false,
     nin: "dummy-nin"
@@ -283,7 +283,7 @@ describe("LetterProofing Container", () => {
 
 const state = {
   config: {
-    LETTER_PROOFING_URL: "http://localhost/letter",
+    letter_proofing_url: "http://localhost/letter",
     csrf_token: "csrf-token"
   },
   nins: {

--- a/src/tests/LookupMobileProofing-test.js
+++ b/src/tests/LookupMobileProofing-test.js
@@ -89,7 +89,7 @@ const fakeStore = state => ({
 const fakeState = {
   lookup_mobile: {},
   config: {
-    LOOKUP_MOBILE_PROOFING_URL: "http://localhost/lookup-mobile",
+    lookup_mobile_proofing_url: "http://localhost/lookup-mobile",
     csrf_token: "dummy-token"
   },
   intl: {

--- a/src/tests/Mobile-test.js
+++ b/src/tests/Mobile-test.js
@@ -425,7 +425,7 @@ const state = {
   },
   config: {
     csrf_token: "123456789",
-    MOBILE_URL: "test/localhost"
+    mobile_url: "test/localhost"
   },
   intl: {
     locale: "en",

--- a/src/tests/OpenidConnect-test.js
+++ b/src/tests/OpenidConnect-test.js
@@ -141,7 +141,7 @@ const fakeState = {
     showModal: false
   },
   config: {
-    OIDC_PROOFING_URL: "http://localhost/oidc"
+    oidc_proofing_url: "http://localhost/oidc"
   },
   intl: {
     locale: "en",
@@ -253,7 +253,7 @@ describe("OpenidConnect Container", () => {
 
 const state = {
   config: {
-    OIDC_PROOFING_URL: "http://localhost/services/oidc-proofing/proofing",
+    oidc_proofing_url: "http://localhost/services/oidc-proofing/proofing",
     csrf_token: "csrf-token"
   },
   openid_data: {

--- a/src/tests/OpenidConnect-test.js
+++ b/src/tests/OpenidConnect-test.js
@@ -295,7 +295,7 @@ describe("Async component", () => {
     };
 
     expect(oidcData.value).toEqual(
-      call(fetchQRcode, state.config.OIDC_PROOFING_URL, data)
+      call(fetchQRcode, state.config.oidc_proofing_url, data)
     );
 
     const action = {

--- a/src/tests/OpenidConnectFreja-test.js
+++ b/src/tests/OpenidConnectFreja-test.js
@@ -200,7 +200,7 @@ describe("OpenidConnectFreja Container before initiated vetting", () => {
       openid_freja_data: {
         iaRequestData: ''
       },
-      config: {OIDC_PROOFING_FREJA_URL: 'http://localhost/services/oidc-proofing/freja/proofing'},
+      config: {oidc_proofing_freja_url: 'http://localhost/services/oidc-proofing/freja/proofing'},
     });
 
     mockProps = {
@@ -254,7 +254,7 @@ describe("OpenidConnectFreja Container after initiated vetting", () => {
       openid_freja_data: {
         iaRequestData: 'abc123'
       },
-      config: {OIDC_PROOFING_FREJA_URL: 'http://localhost/services/oidc-proofing/freja/proofing'},
+      config: {oidc_proofing_freja_url: 'http://localhost/services/oidc-proofing/freja/proofing'},
     });
 
     mockProps = {
@@ -289,7 +289,7 @@ describe("OpenidConnectFreja Container after initiated vetting", () => {
 
 const state = {
   config: {
-    OIDC_PROOFING_FREJA_URL:
+    oidc_proofing_freja_url:
       "http://localhost/services/oidc-proofing/freja/proofing",
     csrf_token: "csrf-token"
   },

--- a/src/tests/OpenidConnectFreja-test.js
+++ b/src/tests/OpenidConnectFreja-test.js
@@ -325,7 +325,7 @@ describe("Async component", () => {
       csrf_token: "csrf-token"
     };
     expect(oidcFrejaData.value).toEqual(
-      call(fetchFrejaData, state.config.OIDC_PROOFING_FREJA_URL, data)
+      call(fetchFrejaData, state.config.oidc_proofing_freja_url, data)
     );
 
     const action = {

--- a/src/tests/PersonalData-test.js
+++ b/src/tests/PersonalData-test.js
@@ -245,7 +245,7 @@ const fakeState = {
   config: {
     csrf_token: "",
     is_configured: true,
-    PERSONAL_DATA_URL: "http://localhost/services/personal-data/user"
+    personal_data_url: "http://localhost/services/personal-data/user"
   },
   intl: {
     locale: "en",
@@ -295,7 +295,7 @@ describe("Async component", () => {
     expect(next.value).toEqual(put(actions.getAllUserdata()));
 
     const config = {
-      PERSONAL_DATA_URL: "http://localhost/services/personal-data/user"
+      personal_data_url: "http://localhost/services/personal-data/user"
     };
     next = generator.next();
 

--- a/src/tests/Security-test.js
+++ b/src/tests/Security-test.js
@@ -692,9 +692,9 @@ const mockState = {
   },
   config: {
     csrf_token: "csrf-token",
-    DASHBOARD_URL: "/dummy-dash-url/",
-    TOKEN_SERVICE_URL: "/dummy-tok-url/",
-    SECURITY_URL: "/dummy-sec-url"
+    dashboard_url: "/dummy-dash-url/",
+    token_service_url: "/dummy-tok-url/",
+    security_url: "/dummy-sec-url"
   },
   intl: {
     locale: "en",
@@ -1000,9 +1000,9 @@ describe("Security Container", () => {
         },
         config: {
           csrf_token: "",
-          SECURITY_URL: "/dummy-sec-url",
-          DASHBOARD_URL: "/dummy-dash-url/",
-          TOKEN_SERVICE_URL: "/dummy-tok-url/"
+          security_url: "/dummy-sec-url",
+          dashboard_url: "/dummy-dash-url/",
+          token_service_url: "/dummy-tok-url/"
         },
         intl: {
           locale: "en",

--- a/src/tests/SignupMain-test.js
+++ b/src/tests/SignupMain-test.js
@@ -35,7 +35,7 @@ const fakeState = {
     tou: "",
     is_app_loaded: true,
     //is_fetching: false,
-    DEBUG: true,
+    debug: true,
     available_languages: {}
   },
   captcha: {
@@ -208,7 +208,7 @@ describe("SignupMain reducer", () => {
     tou: "",
     is_app_loaded: false,
     //is_fetching: false,
-    DEBUG: true,
+    debug: true,
     available_languages: {}
   };
 

--- a/src/tests/SignupMain-test.js
+++ b/src/tests/SignupMain-test.js
@@ -36,7 +36,7 @@ const fakeState = {
     is_app_loaded: true,
     //is_fetching: false,
     debug: true,
-    available_languages: {}
+    available_languages: []
   },
   captcha: {
     captcha_verification: ""

--- a/src/tests/SignupMain-test.js
+++ b/src/tests/SignupMain-test.js
@@ -209,7 +209,7 @@ describe("SignupMain reducer", () => {
     is_app_loaded: false,
     //is_fetching: false,
     debug: true,
-    available_languages: {}
+    available_languages: []
   };
 
   it("Receives app loaded action", () => {

--- a/src/tests/VerifyIdentity-test.js
+++ b/src/tests/VerifyIdentity-test.js
@@ -43,7 +43,7 @@ describe("VerifyIdentity component, no nin added ", () => {
     },
     config: {
       is_configured: false,
-      PROOFING_METHODS: ["letter", "lookup_mobile", "oidc", "eidas"]
+      proofing_methods: ["letter", "lookup_mobile", "oidc", "eidas"]
     },
     letter_proofing: {
       confirmingLetter: false
@@ -103,9 +103,9 @@ describe("VerifyIdentity component, when nin is saved", () => {
     },
     config: {
       is_configured: false,
-      PROOFING_METHODS: ["letter", "lookup_mobile", "oidc", "eidas"],
-      TOKEN_VERIFY_IDP: "http://dev.test.swedenconnect.se/idp",
-      EIDAS_URL: "http://eidas.eduid.docker:8080/"
+      proofing_methods: ["letter", "lookup_mobile", "oidc", "eidas"],
+      token_verify_idp: "http://dev.test.swedenconnect.se/idp",
+      eidas_url: "http://eidas.eduid.docker:8080/"
     },
     letter_proofing: {
       confirmingLetter: false
@@ -190,9 +190,9 @@ describe("VerifyIdentity component, when nin is saved", () => {
     },
     config: {
       is_configured: false,
-      PROOFING_METHODS: ["letter", "lookup_mobile", "oidc", "eidas"],
-      TOKEN_VERIFY_IDP: "http://dev.test.swedenconnect.se/idp",
-      EIDAS_URL: "http://eidas.eduid.docker:8080/"
+      proofing_methods: ["letter", "lookup_mobile", "oidc", "eidas"],
+      token_verify_idp: "http://dev.test.swedenconnect.se/idp",
+      eidas_url: "http://eidas.eduid.docker:8080/"
     },
     letter_proofing: {
       confirmingLetter: false


### PR DESCRIPTION
#### Description:
The backend currently provides the same information with both uppercase
and lowercase key names. By completing the move to lowercase names, we
can cut the size of the returned data in half, from roughly 3 KB to 1.5
KB.

The command used to identify the use of uppercase access was programmatically generated with all the keys in the config_upper dict in the backend:

`
git grep -e '\.DEBUG' -e '\.CSRF_TOKEN' -e '\.AVAILABLE_LANGUAGES' -e '\.TOUS' -e '\.STATIC_STAFF_URL' -e '\.STATIC_STUDENTS_URL' -e '\.STATIC_TECHNICIANS_URL' -e '\.STATIC_FAQ_URL' -e '\.RESET_PASSWD_URL' -e '\.PASSWORD_SERVICE_URL' -e '\.DASHBOARD_URL' -e '\.PERSONAL_DATA_URL' -e '\.EMAILS_URL' -e '\.MOBILE_URL' -e '\.OIDC_PROOFING_URL' -e '\.LOOKUP_MOBILE_PROOFING_URL' -e '\.LETTER_PROOFING_URL' -e '\.SECURITY_URL' -e '\.TOKEN_SERVICE_URL' -e '\.OIDC_PROOFING_FREJA_URL' -e '\.ORCID_URL' -e '\.EIDAS_URL' -e '\.TOKEN_VERIFY_IDP' -e '\.PASSWORD_LENGTH' -e '\.PASSWORD_ENTROPY' -e '\.CHPASS_TIMEOUT' -e '\.PROOFING_METHODS' -e '\.DEFAULT_COUNTRY_CODE' -e '\.SIGNUP_AUTHN_URL' -e '\.RECAPTCHA_PUBLIC_KEY' -e '\.SENTRY_DSN'
`


#### For reviewer:
- [x] Read the above description
- [x] Reviewed the code changes
- [x] Navigate to the branch (pulled the latest version)
- [x] Run the code and been able to execute the expected function
- [x] Check any styling on both desktop and mobile sizes

