### PR TITLE
SECURITY KEY: Fix undefined value for description

### DIFF
--- a/src/containers/Security.js
+++ b/src/containers/Security.js
@@ -67,7 +67,7 @@ const mapDispatchToProps = (dispatch, props) => {
     handleStartWebauthnRegistration: function(e) {
       const description = document.getElementById(
         "describeWebauthnTokenDialogControl"
-      ).children[0].value;
+      ).children[1].value;
       dispatch(stopAskWebauthnDescription());
       dispatch(startWebauthnRegistration(description));
     },


### PR DESCRIPTION
#### Description
When adding a security key, the value didn't send to backend,  it caused below response.
"type": "POST_WEBAUTHN_WEBAUTHN_REGISTER_COMPLETE_FAIL"

This problem was caused by security key input value was undefined.
- Fixed: Description value change to **children[1].value**

----
<img width="721" alt="Screenshot 2020-09-23 at 19 48 10" src="https://user-images.githubusercontent.com/44289056/94050689-e54bcc00-fdd6-11ea-8941-6765e8f4b219.png">

**please check in response when adding a security key.**

<img width="637" alt="Screenshot 2020-09-23 at 19 47 51" src="https://user-images.githubusercontent.com/44289056/94050738-f8f73280-fdd6-11ea-950c-c75a90842abc.png">

---







#### For reviewer:
- [x] Read the above description
- [x] Reviewed the code changes
- [x] Navigate to the branch (pulled the latest version)
- [x] Run the code and been able to execute the expected function
- [x] Check any styling on both desktop and mobile sizes

