### PR TITLE
VETTING: change of vetting help text color triggered by added of NIN

### DIFF
--- a/src/components/VerifyIdentity.js
+++ b/src/components/VerifyIdentity.js
@@ -73,6 +73,8 @@ class VerifyIdentity extends Component {
             return (
               <div key={index}>
                 {vettingOptionsObject[key]}
+                {/* vettingRegistry object letter(index 0) and lookup_mobile(index 1) needs nin, 
+                if index is less then 2 and nin is not added, class name will be disabled */}
                 <p key={index} className={"proofing-btn-help" + (index < 2 && !addedNin ? " disabled":"")}>
                   {helpText}
                 </p>

--- a/src/components/VerifyIdentity.js
+++ b/src/components/VerifyIdentity.js
@@ -65,6 +65,7 @@ class VerifyIdentity extends Component {
       const vettingOptionsObject = vettingRegistry(!this.props.valid_nin);
       // extract the keys from the vettingOptionsObject
       const vettingOptionsKeys = Object.keys(vettingOptionsObject);
+      const addedNin = this.props.nins[0];
       vettingButtons = [
         <div key="1" id="nins-btn-grid"> 
           {vettingOptionsKeys.map((key, index) => {
@@ -72,7 +73,7 @@ class VerifyIdentity extends Component {
             return (
               <div key={index}>
                 {vettingOptionsObject[key]}
-                <p key={index} className="proofing-btn-help">
+                <p key={index} className={"proofing-btn-help" + (index < 2 && !addedNin ? " disabled":"")}>
                   {helpText}
                 </p>
               </div>

--- a/src/login/styles/_Nins.scss
+++ b/src/login/styles/_Nins.scss
@@ -65,16 +65,16 @@
 .vetting-button {
   & button:disabled{
     background-color: #f4f4f4;
-    border-color: #7c7c7c;
+    border-color: $gray;
     & .text {
-      color: #7c7c7c;
+      color: $gray;
     }
     & .explanation {
       color: $black;
       margin-top: 1rem;
     }
     & .name {
-      color: #7c7c7c;
+      color: $gray;
     }
     &:hover {
       transform: unset;
@@ -92,7 +92,7 @@
 }
 
 .proofing-btn-help.disabled {
-  color: #7c7c7c;
+  color: $gray;
 }
 
 @media (max-width: 768px) {

--- a/src/login/styles/_Nins.scss
+++ b/src/login/styles/_Nins.scss
@@ -82,12 +82,17 @@
   }
 }
 
+
 .proofing-btn-help {
   margin: 0 0.5rem 1rem 0.5rem;
   line-height: 1.2;
-  color: #7c7c7c;
+  color: $black;
   font-size: 0.875rem;
   width: 300px;
+}
+
+.proofing-btn-help.disabled {
+  color: #7c7c7c;
 }
 
 @media (max-width: 768px) {

--- a/src/login/styles/variables.scss
+++ b/src/login/styles/variables.scss
@@ -9,6 +9,7 @@ $hcolor: #fff;
 
 $white: #fff;
 $black: #161616;
+$gray: #7c7c7c;
 
 $orange-highlight: #ff4500;
 $orange-opaque: #ffe7dd;


### PR DESCRIPTION
#### Description:
changed help text color under the vetting button depends on if id number is added or not.


#### Summary:
- checking index 0(by letter) or 1 (by phone) and no id number, text color will be gray otherwise text color will be black.
----
- disabled button

![Screenshot 2020-10-14 at 12 50 44](https://user-images.githubusercontent.com/44289056/95979459-f444fd80-0e1b-11eb-933e-d4c0b4db085c.png)

- abled button

![Screenshot 2020-10-14 at 12 51 07](https://user-images.githubusercontent.com/44289056/95979463-f60ec100-0e1b-11eb-9c41-0620b14d39dc.png)



----



#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

