### PR TITLE
ADD PHONE/EMAIL: Missing "confirm" button after resending or cancel verification code

### DIFF
--- a/src/login/styles/_buttons.scss
+++ b/src/login/styles/_buttons.scss
@@ -171,7 +171,7 @@ button.btn.icon-button {
   }
 }
 
-button.btn.table-button {
+button.btn.table-button.btn.btn-primary  {
   color: #ff500d;
   font-size: 0.75rem;
   background-color: transparent;


### PR DESCRIPTION

#### Description:

Issue https://github.com/SUNET/eduid-front/issues/449
Issue https://github.com/SUNET/eduid-front/issues/406

After pressing confirm, the button will disappear even if the modal is cancelled. to activate the page need to be reloaded.


#### Summary:
- it was caused due to overwriting button styling so I have added detailed class name to avoid overwriting styling  

----
- Before / After
![Screenshot 2020-10-22 at 08 48 31](https://user-images.githubusercontent.com/44289056/96835097-654f6b00-1443-11eb-8bc0-461b493ef518.png)




#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

