### PR TITLE
SECURITY KEY:  updated styling for security key table

### DIFF
--- a/src/components/Security.js
+++ b/src/components/Security.js
@@ -79,7 +79,7 @@ class Security extends Component {
       }
 
       return (
-        <tr key={index} className="webauthn-token-holder" data-token={cred.key}>
+        <tr key={index} className={`webauthn-token-holder ${cred.verified ? "verified" : ""}`} data-token={cred.key}>
           <td>{cred.description}</td>
           <td
             data-toggle="tooltip"

--- a/src/components/Security.js
+++ b/src/components/Security.js
@@ -128,7 +128,7 @@ class Security extends Component {
               <th className="security-creation-date">{this.props.translate("security.creation_date")}</th>
               <th className="security-last-used-date">{this.props.translate("security.last_used")}</th>
               <th />
-              <th className="remove-data"/>
+              <th className="security-remove-data"/>
             </tr>
             {secirutykey_table_data}
           </tbody>

--- a/src/components/Security.js
+++ b/src/components/Security.js
@@ -127,7 +127,7 @@ class Security extends Component {
               <th className="security-name">{this.props.translate("security.description")}</th>
               <th className="security-creation-date">{this.props.translate("security.creation_date")}</th>
               <th className="security-last-used-date">{this.props.translate("security.last_used")}</th>
-              <th />
+              <th className="security-verify-link" />
               <th className="security-remove-data"/>
             </tr>
             {secirutykey_table_data}

--- a/src/components/Security.js
+++ b/src/components/Security.js
@@ -124,11 +124,11 @@ class Security extends Component {
         <table className="table-form passwords">
           <tbody>
             <tr>
-              <th>{this.props.translate("security.description")}</th>
-              <th>{this.props.translate("security.creation_date")}</th>
-              <th>{this.props.translate("security.last_used")}</th>
+              <th className="security-name">{this.props.translate("security.description")}</th>
+              <th className="security-creation-date">{this.props.translate("security.creation_date")}</th>
+              <th className="security-last-used-date">{this.props.translate("security.last_used")}</th>
               <th />
-              <th />
+              <th className="remove-data"/>
             </tr>
             {secirutykey_table_data}
           </tbody>

--- a/src/components/Security.js
+++ b/src/components/Security.js
@@ -50,9 +50,9 @@ class Security extends Component {
       // verify button/ verified badge
       if (cred.verified) {
         btnVerify = (
-          <span className="nobutton verified" disabled>
+          <label className="nobutton verified" disabled>
             {this.props.translate("security.verified")}
-          </span>
+          </label>
         );
       } else {
         btnVerify = (

--- a/src/login/styles/_buttons.scss
+++ b/src/login/styles/_buttons.scss
@@ -171,7 +171,8 @@ button.btn.icon-button {
   }
 }
 
-button.btn.table-button.btn.btn-primary  {
+button.btn.table-button.btn.btn-primary,
+button.btn-link.nobutton.verify-status-label {
   color: #ff500d;
   font-size: 0.75rem;
   background-color: transparent;

--- a/src/login/styles/_tables.scss
+++ b/src/login/styles/_tables.scss
@@ -52,9 +52,11 @@ table {
             padding: 0;
           }
         }
-        .verified{
+        .verified {
           text-transform: uppercase;
-          padding: 0.625rem 1.25rem;;
+          padding: 0.625rem 1.25rem;
+          font-family: "ProximaNova-Regular";
+          font-weight: 700;
         }
         &.remove-data {
           width: 5%;

--- a/src/login/styles/_tables.scss
+++ b/src/login/styles/_tables.scss
@@ -70,29 +70,6 @@ table {
         }
       }
     }
-
-
-
-    // & th {
-    //   //   padding: 0.75rem;
-    //   background-color: white;
-    //   // border-bottom: #7c7c7c 1px solid;
-    // }
-
-    //   &.value-status {
-    //     text-align: center;
-    //     & label {
-    //       font-family: "ProximaNova-Regular";
-    //       font-weight: 400;
-    //     }
-    //   }
-    //   &.data {
-    //     width: 80%;
-    //   }
-    //   &.data-remove-button,
-    //   &.status-label {
-    //     width: 10%;
-    //   }
   }
 }
 table.table-form.passwords{
@@ -128,36 +105,3 @@ table.table-form.passwords{
     display: none;
   }
 }
-
-// td table th {
-//   color: #171717;
-//   font-size: 12px;
-//   text-transform: uppercase;
-//   padding: 0.75rem;
-//   background-color: transparent;
-// }
-
-// span.nobutton,
-// .primary,
-// tr.primary {
-//   font-weight: 300;
-//   color: $black;
-// }
-
-// span.nobutton,
-// button.verify-status-label {
-//   font-size: 12px;
-// }
-
-// span.nobutton {
-//   font-family: "ProximaNova-Regular";
-//   text-transform: uppercase;
-// }
-
-// @media (max-width: 568px) {
-//   table {
-//     font-size: 1.25rem;
-//     font-weight: 400;
-//     // color: #161616;
-//   }
-// }

--- a/src/login/styles/_tables.scss
+++ b/src/login/styles/_tables.scss
@@ -100,6 +100,15 @@ table {
   }
 }
 
+@media (max-width: 568px) {
+  .security-creation-date,
+  .security-last-used-date,
+  .webauthn-token-holder td:nth-child(2),
+  .webauthn-token-holder td:nth-child(3){
+    display: none;
+  }
+}
+
 // td table th {
 //   color: #171717;
 //   font-size: 12px;

--- a/src/login/styles/_tables.scss
+++ b/src/login/styles/_tables.scss
@@ -9,6 +9,9 @@ table {
   table-layout: fixed;
   & tbody {
     margin-bottom: 1rem;
+    & th:first-child{
+      padding-left: 1.25rem;
+    }
     & tr.webauthn-token-holder {
       color: $black;
     }
@@ -20,7 +23,8 @@ table {
         text-align: left;
         vertical-align: middle;
         line-height: 1;
-        &.value-status {
+        &.value-status,
+        &.verify {
           width: 25%;
           & button {
             margin: 0;
@@ -34,7 +38,8 @@ table {
         }
         &.remove-data {
           width: 5%;
-          & .icon-button {
+          & .icon-button
+           {
             margin: 0;
             padding: 0;
           }
@@ -54,7 +59,7 @@ table {
     }
     .security-creation-date,
     .security-last-used-date {
-      width: 25%;
+      width: 23%;
     }
 
 

--- a/src/login/styles/_tables.scss
+++ b/src/login/styles/_tables.scss
@@ -13,7 +13,8 @@ table {
       padding-left: 1.25rem;
     }
     th {
-      padding-top: 10px;
+      padding-top: 0.625rem;
+      padding-bottom: 0.625rem;
       line-height: 1;
     }
     & tr.webauthn-token-holder {

--- a/src/login/styles/_tables.scss
+++ b/src/login/styles/_tables.scss
@@ -70,21 +70,7 @@ table {
         }
       }
     }
-    .security-name{
-      width: 36%;
-    }
-    .security-creation-date{
-      width: 21%;
-    }
-    .security-last-used-date {
-      width: 21%;
-    }
-    .security-verify-link {
-      width: 17%;
-    }
-    .security-remove-data {
-      width: 5%;
-    }
+
 
 
     // & th {
@@ -116,6 +102,21 @@ table.table-form.passwords{
     color: $black;
     font-family: "ProximaNova-Bold";
     height: auto;
+  }
+  .security-name{
+    width: 36%;
+  }
+  .security-creation-date{
+    width: 21%;
+  }
+  .security-last-used-date {
+    width: 21%;
+  }
+  .security-verify-link {
+    width: 17%;
+  }
+  .security-remove-data {
+    width: 5%;
   }
 }
 

--- a/src/login/styles/_tables.scss
+++ b/src/login/styles/_tables.scss
@@ -25,7 +25,7 @@ table {
       }
     }
     & tr {
-      background-color: white;
+      background-color:$white;
       height: 3rem;
       & td:first-child{
         padding-left: 1.25rem;
@@ -58,7 +58,7 @@ table {
           }
         }
         &.primary {
-          color: #161616;
+          color:$black;
         }
         &.unverified,
         &.verified,

--- a/src/login/styles/_tables.scss
+++ b/src/login/styles/_tables.scss
@@ -17,12 +17,15 @@ table {
       line-height: 1;
     }
     & tr.webauthn-token-holder {
-      color: $black;
+      color: $gray;
       & td:first-child{
         white-space: nowrap;
         text-overflow: ellipsis;
         overflow: hidden;
       }
+    }  
+    & tr.webauthn-token-holder.verified {
+      color: $black;
     }
     & tr {
       background-color:$white;

--- a/src/login/styles/_tables.scss
+++ b/src/login/styles/_tables.scss
@@ -55,6 +55,9 @@ table {
         &.primary {
           color: #161616;
         }
+        &.btn-remove-webauthn {
+          padding: 0;
+        }
         &.unverified,
         &.verified,
         &.primary {

--- a/src/login/styles/_tables.scss
+++ b/src/login/styles/_tables.scss
@@ -55,9 +55,6 @@ table {
         &.primary {
           color: #161616;
         }
-        &.btn-remove-webauthn {
-          padding: 0;
-        }
         &.unverified,
         &.verified,
         &.primary {
@@ -69,13 +66,13 @@ table {
       }
     }
     .security-name{
-      width: 34%;
+      width: 36%;
     }
     .security-creation-date{
-      width: 22%;
+      width: 21%;
     }
     .security-last-used-date {
-      width: 22%;
+      width: 21%;
     }
     .security-verify-link {
       width: 17%;

--- a/src/login/styles/_tables.scss
+++ b/src/login/styles/_tables.scss
@@ -14,7 +14,6 @@ table {
     }
     th {
       padding-top: 0.625rem;
-      padding-bottom: 0.625rem;
       line-height: 1;
     }
     & tr.webauthn-token-holder {

--- a/src/login/styles/_tables.scss
+++ b/src/login/styles/_tables.scss
@@ -59,14 +59,20 @@ table {
         &.primary {
           padding: 0.625rem 1.25rem;
         }
+        .btn-remove-webauthn {
+          padding: 0;
+        }
       }
     }
     .security-name{
-      width: 30%;
+      width: 25%;
     }
     .security-creation-date,
     .security-last-used-date {
-      width: 23%;
+      width: 20%;
+    }
+    .security-remove-data {
+      width: 5%;
     }
 
 

--- a/src/login/styles/_tables.scss
+++ b/src/login/styles/_tables.scss
@@ -51,10 +51,10 @@ table {
             font-weight: 700;
             padding: 0;
           }
-          .verified {
-            text-transform: uppercase;
-            padding: 0.625rem 1.25rem;;
-          }
+        }
+        .verified{
+          text-transform: uppercase;
+          padding: 0.625rem 1.25rem;;
         }
         &.remove-data {
           width: 5%;

--- a/src/login/styles/_tables.scss
+++ b/src/login/styles/_tables.scss
@@ -69,11 +69,16 @@ table {
       }
     }
     .security-name{
-      width: 25%;
+      width: 39%;
     }
-    .security-creation-date,
+    .security-creation-date{
+      width: 22%;
+    }
     .security-last-used-date {
       width: 20%;
+    }
+    .security-verify-link {
+      width: 18%;
     }
     .security-remove-data {
       width: 5%;

--- a/src/login/styles/_tables.scss
+++ b/src/login/styles/_tables.scss
@@ -30,6 +30,7 @@ table {
       height: 3rem;
       & td:first-child{
         padding-left: 1.25rem;
+        padding-right: 1.5rem;
       }
       & td {
         word-wrap: break-word;

--- a/src/login/styles/_tables.scss
+++ b/src/login/styles/_tables.scss
@@ -9,6 +9,9 @@ table {
   table-layout: fixed;
   & tbody {
     margin-bottom: 1rem;
+    & tr.webauthn-token-holder {
+      color: $black;
+    }
     & tr {
       background-color: white;
       height: 3rem;

--- a/src/login/styles/_tables.scss
+++ b/src/login/styles/_tables.scss
@@ -19,6 +19,11 @@ table {
     }
     & tr.webauthn-token-holder {
       color: $black;
+      & td:first-child{
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
+      }
     }
     & tr {
       background-color: white;

--- a/src/login/styles/_tables.scss
+++ b/src/login/styles/_tables.scss
@@ -69,16 +69,16 @@ table {
       }
     }
     .security-name{
-      width: 39%;
+      width: 34%;
     }
     .security-creation-date{
       width: 22%;
     }
     .security-last-used-date {
-      width: 20%;
+      width: 22%;
     }
     .security-verify-link {
-      width: 18%;
+      width: 17%;
     }
     .security-remove-data {
       width: 5%;

--- a/src/login/styles/_tables.scss
+++ b/src/login/styles/_tables.scss
@@ -49,6 +49,14 @@ table {
         }
       }
     }
+    .security-name{
+      width: 30%;
+    }
+    .security-creation-date,
+    .security-last-used-date {
+      width: 25%;
+    }
+
 
     // & th {
     //   //   padding: 0.75rem;

--- a/src/login/styles/_tables.scss
+++ b/src/login/styles/_tables.scss
@@ -18,6 +18,9 @@ table {
     & tr {
       background-color: white;
       height: 3rem;
+      & td:first-child{
+        padding-left: 1.25rem;
+      }
       & td {
         word-wrap: break-word;
         text-align: left;

--- a/src/login/styles/_tables.scss
+++ b/src/login/styles/_tables.scss
@@ -51,6 +51,10 @@ table {
             font-weight: 700;
             padding: 0;
           }
+          .verified {
+            text-transform: uppercase;
+            padding: 0.625rem 1.25rem;;
+          }
         }
         &.remove-data {
           width: 5%;

--- a/src/login/styles/_tables.scss
+++ b/src/login/styles/_tables.scss
@@ -109,6 +109,15 @@ table {
     //   }
   }
 }
+table.table-form.passwords{
+  tr:first-child{
+    font-size: 1rem;
+    letter-spacing: 0;
+    color: $black;
+    font-family: "ProximaNova-Bold";
+    height: auto;
+  }
+}
 
 @media (max-width: 568px) {
   .security-creation-date,

--- a/src/login/styles/_tables.scss
+++ b/src/login/styles/_tables.scss
@@ -12,6 +12,10 @@ table {
     & th:first-child{
       padding-left: 1.25rem;
     }
+    th {
+      padding-top: 10px;
+      line-height: 1;
+    }
     & tr.webauthn-token-holder {
       color: $black;
     }


### PR DESCRIPTION
#### Description:
old security key table was unreadable in mobile mode and not balanced in the desktop mode.
[Figma design]( https://www.figma.com/file/IBBTDRxd5dKQa7Ltj0Hd0l/eduID%3A-website-user-flow?node-id=179%3A580)
I followed confirmed design. however spacing between columns is not exactly same as design because I used percentage of columns.

#### Summary:
- Added className for table headings and width
  `security-name: 36%`,
  `security-creation-date: 21%`, 
 `security-last-used-date: 21%`,
 `security-verify-link: 17%`, 
 `security-remove-data: 5%`

-  Display: none `security-creation-date` and `security-last-used-date` @ max-width: 568px
-  when Security Key name is too long, text will be cropped  and will display followed by dots.


`   white-space: nowrap;`
`   text-overflow: ellipsis;`
`   overflow: hidden;`

-----
**Before and After (@1200px)**
![Screenshot 2020-10-26 at 14 45 22](https://user-images.githubusercontent.com/44289056/97180144-facb6180-1799-11eb-8650-aed6808f7810.png)

**Before and After (@320px)**
![Screenshot 2020-10-26 at 14 45 39](https://user-images.githubusercontent.com/44289056/97180191-07e85080-179a-11eb-87fb-ca4e656e1f29.png)



-----


#### For reviewer:
- [x] Read the above description
- [x] Reviewed the code changes
- [x] Navigate to the branch (pulled the latest version)
- [x] Run the code and been able to execute the expected function
- [x] Check any styling on both desktop and mobile sizes

