### PR TITLE
MODAL BUTTON: Remove border to prevent hovering effect of disabled button

### DIFF
--- a/src/login/styles/_buttons.scss
+++ b/src/login/styles/_buttons.scss
@@ -103,7 +103,6 @@ button.close:hover {
 a.btn.modal-button,
 button.btn.modal-button {
   box-shadow: none;
-  border: solid 1px transparent;
   background-color: transparent;
   margin: 0.5rem 1rem;
   &:hover {


### PR DESCRIPTION
#### Description:
Issue https://github.com/SUNET/eduid-front/issues/454
When hovering past the disabled OK button it briefly (not able to catch in screenshot) has a gray outline which could indicate that it is clickable.

#### Summary:
- Removed  `border: solid 1px transparent; `
#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

