### PR TITLE
Handle available_languages as both list of lists and map

### DIFF
--- a/src/containers/Footer.js
+++ b/src/containers/Footer.js
@@ -6,11 +6,17 @@ import Footer from "components/Footer";
 import i18n from "../login/translation/InjectIntl_HOC_factory";
 
 const mapStateToProps = (state, props) => {
-  const languages = {};
+  let languages = {};
   if (state.config.available_languages !== undefined) {
-    state.config.available_languages.forEach(l => {
-      languages[l[0]] = l[1];
-    });
+    // Old format of lists in list, remove after config update
+    if (Array.isArray(state.config.available_languages)) {
+      state.config.available_languages.forEach(l => {
+        languages[l[0]] = l[1];
+      });
+    } else {
+      // This is the new format, keep this after config update
+      languages = state.config.available_languages
+    }
   }
   return {
     language: state.intl.locale,


### PR DESCRIPTION
#### Description:
Currently available_languages in jsapps config is a list of lists but in the actions config it is a map. A map is also used in the backend. This change should let us use both until we remove the list of lists format.

#### For reviewer:
- [x] Read the above description
- [x] Reviewed the code changes
- [x] Navigate to the branch (pulled the latest version)
- [x] Run the code and been able to execute the expected function
- [x] Check any styling on both desktop and mobile sizes

