### PR TITLE
Replace travis with GitHub actions

### DIFF
--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -27,3 +27,6 @@ jobs:
       - name: Run tests
         run: |
           make test
+
+      - name: Audit
+        run: npm audit

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -29,4 +29,5 @@ jobs:
           make test
 
       - name: Audit
-        run: npm audit
+        # Don't error out on this until we are somewhere close to up-to-date.
+        run: npm audit || true

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,0 +1,29 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Node.js CI
+
+on: [push, pull_request]
+
+jobs:
+
+  unittests:
+    runs-on: ubuntu-18.04
+
+    strategy:
+      matrix:
+        node-version: [10.x]
+    env:
+      PIP_INDEX_URL: https://pypi.sunet.se/simple/
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Run tests
+        run: |
+          make test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,0 @@
-language: node_js
-node_js:
-  - 10
-before_script:
-  - npm install
-script: npm run-script test-headless && npm run build && npm run build-pro && npm run manage:plugins:staging && npm run manage:plugins:pro

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+test:
+	npm install
+	npm run-script test-headless
+	npm run build
+	npm run build-pro
+	npm run manage:plugins:staging
+	npm run manage:plugins:pro


### PR DESCRIPTION
#### Description:

Move CI testing from Travis to Github Actions, since Travis has started requiring full write access to all the repositories in the organisation.

Two topics of possible further improvements here:

- The tests run with Node 10, just like on Travis. It is trivial to also run them with Node 12.x, but I don't know if that is desired.
- I added a separate step running 'npm audit' but did not make the build fail on that since it reports 894 vulnerabilities. I guess someone with some JS knowledge should run 'npm audit fix' and make a PR updating all those dependencies. For now, I made the CI continue even when 'npm audit' raises issues.

#### For reviewer:
- [x] Read the above description
- [x] Reviewed the code changes
- [x] Navigate to the branch (pulled the latest version)
- [x] Run the code and been able to execute the expected function
- [x] Check any styling on both desktop and mobile sizes

