### PR TITLE
GROUP MANAGEMENT: Replaces username for user_identifier in user/group relationship hack

### DIFF
--- a/src/login/components/GroupManagement/GroupList.js
+++ b/src/login/components/GroupManagement/GroupList.js
@@ -4,7 +4,7 @@ import i18n from "../../translation/InjectIntl_HOC_factory";
 import GroupListItem from "./GroupListItem";
 
 const GroupList = (props) => {
-  return props.uniqueGroups !== undefined ? (
+  return (
     <div className="view-data">
       <div className="list-grid">
         <div className="list-cell"></div>
@@ -26,7 +26,7 @@ const GroupList = (props) => {
         ))}
       </ul>
     </div>
-  ) : null;
+  );
 };
 
 GroupList.propTypes = {};

--- a/src/login/components/GroupManagement/GroupManagementContainer.js
+++ b/src/login/components/GroupManagement/GroupManagementContainer.js
@@ -17,31 +17,17 @@ const mapStateToProps = (state, props) => {
     return i === uniqueGroupIds.findIndex((id) => id === group.identifier);
   });
 
-  // filter out primary email address to look for username among members and owners in groups
-  let emailAddresses = state.emails.emails;
-  const primaryEmailAddress = emailAddresses.filter(
-    (email) => email.primary
-  )[0];
-
-  // email request sometimes happens after group data
-  const getUsername = () => {
-    if (primaryEmailAddress !== undefined) {
-      return primaryEmailAddress.email;
-    }
-    return null;
-  };
-
-  //create new object listing user relationship with each group
+  // create new object listing user relationship with each group
+  let userIdentifier = state.groups.data.user_identifier;
   let userGroupsAndRoles = uniqueGroups.map((group, i) => {
-    let username = getUsername();
     let membershipObj = { group: group, isMember: false, isOwner: false };
     group.members.some((member, i) => {
-      if (member.display_name === username) {
+      if (member.identifier === userIdentifier) {
         return (membershipObj.isMember = true);
       }
     });
     group.owners.some((owner, i) => {
-      if (owner.display_name === username) {
+      if (owner.identifier === userIdentifier) {
         return (membershipObj.isOwner = true);
       }
     });


### PR DESCRIPTION
#### Description:
While going through the members and owners lists to establish a users' relationship with each group, the user itself was identified based on "username" (acquired via primary email address) and now we use `user_identifier` provided by the backend. 

**Summary:**
1.  Reduced the user/group relationship hack:
    - removed functionality passing all user email addressed from the redux store and filtering out the primary one
    - removed conditional to only filter primary address if alla email addresses were available 
    - updated the creation of the user/group relationship object to check all member/owner identifiers against the `user_identifier`  
2. Removed component error handling
    - Removal of `<GroupList/>` to render `null` if user/group relationship info is not available 


#### For reviewer:
- [x] Read the above description
- [x] Reviewed the code changes
- [x] Navigate to the branch (pulled the latest version)
- [x] Run the code and been able to execute the expected function
- [x] Check any styling on both desktop and mobile sizes

