### PR TITLE
Refactoring letter-proofing test for using same base state

### DIFF
--- a/src/tests/LetterProofing-test.js
+++ b/src/tests/LetterProofing-test.js
@@ -410,12 +410,7 @@ describe("LetterProofing component, without id number", () => {
 });
 
 describe("LetterProofing component, letter has been sent", () => {
-  const fakeState = getFakeState({
-    nins: {
-      valid_nin: false,
-      nins: []
-    }
-  })
+  const fakeState = getFakeState()
 
   function setupComponent() {
     const wrapper = mount(
@@ -453,12 +448,7 @@ describe("LetterProofing component, letter has been sent", () => {
 });
 
 describe("LetterProofing component, when letter has expired", () => {
-  const fakeState = getFakeState({
-    nins: {
-      valid_nin: false,
-      nins: []
-    }
-  })
+  const fakeState = getFakeState()
   
   function setupComponent() {
     const wrapper = mount(

--- a/src/tests/LetterProofing-test.js
+++ b/src/tests/LetterProofing-test.js
@@ -28,7 +28,8 @@ const baseState = {
     verifyingLetter: false,
     letter_expires: "",
     letter_expired: false,
-    confirmingLetter: false
+    confirmingLetter: false,
+    code: ""
   },
   config: { letter_proofing_url: "http://localhost/letter" },
   nins: {
@@ -162,54 +163,47 @@ describe("Letter proofing Actions", () => {
 });
 
 describe("Reducers", () => {
-  const mockState = {
-    confirmingLetter: false,
-    verifyingLetter: false,
-    code: "",
-    letter_sent: "",
-    letter_expires: "",
-    letter_expired: false,
-    message: ""
-  };
+  const fakeState = getFakeState();
+  const letterProofingState = fakeState.letter_proofing;
 
   it("Receives a STOP_LETTER_VERIFICATION action", () => {
     expect(
-      letterProofingReducer(mockState, {
+      letterProofingReducer(letterProofingState, {
         type: actions.STOP_LETTER_VERIFICATION
       })
     ).toEqual({
-      ...mockState,
+      ...letterProofingState,
       confirmingLetter: false
     });
   });
 
   it("Receives a POST_LETTER_PROOFING_CODE action", () => {
     expect(
-      letterProofingReducer(mockState, {
+      letterProofingReducer(letterProofingState, {
         type: actions.STOP_LETTER_VERIFICATION
       })
     ).toEqual({
-      ...mockState
+      ...letterProofingState
     });
   });
 
   it("Receives a POST_LETTER_PROOFING_PROOFING_SUCCESS action", () => {
     expect(
-      letterProofingReducer(mockState, {
+      letterProofingReducer(letterProofingState, {
         type: actions.POST_LETTER_PROOFING_PROOFING_SUCCESS,
         payload: {
           message: "success"
         }
       })
     ).toEqual({
-      ...mockState,
+      ...letterProofingState,
       message: "success"
     });
   });
 
   it("Receives a POST_LETTER_PROOFING_PROOFING_FAIL action", () => {
     expect(
-      letterProofingReducer(mockState, {
+      letterProofingReducer(letterProofingState, {
         type: actions.POST_LETTER_PROOFING_PROOFING_FAIL,
         error: true,
         payload: {
@@ -217,27 +211,27 @@ describe("Reducers", () => {
         }
       })
     ).toEqual({
-      ...mockState
+      ...letterProofingState
     });
   });
 
   it("Receives a POST_LETTER_PROOFING_CODE action", () => {
     expect(
-      letterProofingReducer(mockState, {
+      letterProofingReducer(letterProofingState, {
         type: actions.POST_LETTER_PROOFING_CODE,
         payload: {
           code: "dummy-code"
         }
       })
     ).toEqual({
-      ...mockState,
+      ...letterProofingState,
       code: "dummy-code"
     });
   });
 
   it("Receives a POST_LETTER_PROOFING_CODE_SUCCESS action", () => {
     expect(
-      letterProofingReducer(mockState, {
+      letterProofingReducer(letterProofingState, {
         type: actions.POST_LETTER_PROOFING_CODE_SUCCESS,
         payload: {
           success: true,
@@ -245,14 +239,14 @@ describe("Reducers", () => {
         }
       })
     ).toEqual({
-      ...mockState,
+      ...letterProofingState,
       message: "success"
     });
   });
 
   it("Receives a POST_LETTER_PROOFING_CODE_FAIL action", () => {
     expect(
-      letterProofingReducer(mockState, {
+      letterProofingReducer(letterProofingState, {
         type: actions.POST_LETTER_PROOFING_CODE_FAIL,
         error: true,
         payload: {
@@ -260,7 +254,7 @@ describe("Reducers", () => {
         }
       })
     ).toEqual({
-      ...mockState
+      ...letterProofingState
     });
   });
 });

--- a/src/tests/LetterProofing-test.js
+++ b/src/tests/LetterProofing-test.js
@@ -21,6 +21,33 @@ import {
 const messages = require("../login/translation/messageIndex");
 addLocaleData("react-intl/locale-data/en");
 
+const fakeStore = fakeState => ({
+  default: () => {},
+  dispatch: mock.fn(),
+  subscribe: mock.fn(),
+  getState: () => ({ ...fakeState })
+});
+
+const fakeState = {
+  letter_proofing: {
+    message: "",
+    letter_sent: "",
+    verifyingLetter: false,
+    letter_expires: "",
+    letter_expired: false,
+    confirmingLetter: false
+  },
+  config: { letter_proofing_url: "http://localhost/letter" },
+  nins: {
+    valid_nin: false,
+    nins: []
+  },
+  intl: {
+    locale: "en",
+    messages: messages
+  }
+};
+
 describe("LetterProofing Component", () => {
   it("The component does not render 'false' or 'null'", () => {
     const wrapper = shallow(
@@ -33,27 +60,6 @@ describe("LetterProofing Component", () => {
 });
 
 describe("Letter Proofing, when letter has been expired", () => {
-  const fakeState = {
-    letter_proofing: {
-      confirmingLetter: false,
-      verifyingLetter: false,
-      code: "",
-      letter_sent: "",
-      letter_expires: "",
-      letter_expired: false,
-      message: ""
-    },
-    config: { letter_proofing_url: "http://localhost/letter" },
-    nins: {
-      valid_nin: true,
-      nin: "dummy-nin"
-    },
-    intl: {
-      locale: "en",
-      messages: messages
-    }
-  }
-
   function setupComponent() {
     const props =  {
       confirmingLetter: false,
@@ -362,33 +368,6 @@ describe("Async component", () => {
     expect(next.value).toEqual(put(action));
   });
 });
-
-const fakeStore = fakeState => ({
-  default: () => {},
-  dispatch: mock.fn(),
-  subscribe: mock.fn(),
-  getState: () => ({ ...fakeState })
-});
-
-const fakeState = {
-  letter_proofing: {
-    message: "",
-    letter_sent: "",
-    verifyingLetter: false,
-    letter_expires: "",
-    letter_expired: false,
-    confirmingLetter: false
-  },
-  config: { letter_proofing_url: "http://localhost/letter" },
-  nins: {
-    valid_nin: false,
-    nins: []
-  },
-  intl: {
-    locale: "en",
-    messages: messages
-  }
-};
 
 describe("LetterProofing component, without id number", () => {
   function setupComponent() {

--- a/src/tests/LetterProofing-test.js
+++ b/src/tests/LetterProofing-test.js
@@ -248,25 +248,6 @@ describe("Reducers", () => {
   });
 });
 
-function setupComponent(store) {
-  const props = {
-    letter_expires:"",
-    handleLetterProofing: mock.fn(),
-    sendConfirmationLetter: mock.fn(),
-    handleConfirmationLetter: mock.fn(),
-    handleStopConfirmationLetter: mock.fn()
-  };
-  const wrapper = shallow(
-    <Provider store={store}>
-      <LetterProofingContainer {...props} />
-    </Provider>
-  );
-  return {
-    props,
-    wrapper
-  };
-}
-
 describe("LetterProofing Container", () => {
   let mockProps, wrapper, buttontext, dispatch;
 

--- a/src/tests/LetterProofing-test.js
+++ b/src/tests/LetterProofing-test.js
@@ -264,7 +264,7 @@ describe("Reducers", () => {
 });
 
 describe("LetterProofing Container", () => {
-  let mockProps, wrapper, buttontext, dispatch;
+  let mockProps, wrapper, buttontext;
 
   beforeEach(() => {
     const store = fakeStore(fakeState);

--- a/src/tests/LetterProofing-test.js
+++ b/src/tests/LetterProofing-test.js
@@ -94,8 +94,6 @@ describe("Letter Proofing, when letter has been expired", () => {
       wrapper,
     };
   }
-  const state = { ...fakeState };
-  state.letter_proofing.letter_expired = true; 
 
   it("Renders when letter has been expired", () => {
     const { wrapper } = setupComponent();

--- a/src/tests/LetterProofing-test.js
+++ b/src/tests/LetterProofing-test.js
@@ -31,7 +31,9 @@ const baseState = {
     confirmingLetter: false
   },
   config: { letter_proofing_url: "http://localhost/letter" },
-  nins: {},
+  nins: {
+    nin:""
+  },
   intl: {
     locale: "en",
     messages: messages
@@ -265,10 +267,9 @@ describe("Reducers", () => {
 
 describe("LetterProofing Container", () => {
   let mockProps, wrapper, buttontext;
-
+  const fakeState = getFakeState();
   beforeEach(() => {
     const store = fakeStore(fakeState);
-
     mockProps = {};
 
     wrapper = mount(
@@ -286,20 +287,20 @@ describe("LetterProofing Container", () => {
   });
 });
 
-const state = {
-  config: {
-    letter_proofing_url: "http://localhost/letter",
-    csrf_token: "csrf-token"
-  },
-  nins: {
-    nin: "dummy-nin"
-  },
-  letter_proofing: {
-    code: "dummy-code"
-  }
-};
-
 describe("Async component", () => {
+  const fakeState = {
+    config: {
+      letter_proofing_url: "http://localhost/letter",
+      csrf_token: "csrf-token"
+    },
+    nins: {
+      nin: "dummy-nin"
+    },
+    letter_proofing: {
+      code: "dummy-code"
+    }
+  };
+
   it("Sagas sendLetterProfing", () => {
     const generator = sendLetterProofing();
 
@@ -310,8 +311,8 @@ describe("Async component", () => {
       csrf_token: "csrf-token"
     };
 
-    const resp = generator.next(state);
-    expect(resp.value).toEqual(call(fetchLetterProofing, state.config, data));
+    const resp = generator.next(fakeState);
+    expect(resp.value).toEqual(call(fetchLetterProofing, fakeState.config, data));
 
     const action = {
       type: "POST_LETTER_PROOFING_PROOFING_SUCCESS",
@@ -333,8 +334,8 @@ describe("Async component", () => {
     let next = generator.next();
 
     const nin = "dummy-nin";
-    const resp = generator.next(state);
-    expect(resp.value).toEqual(call(fetchGetLetterProofing, state.config, nin));
+    const resp = generator.next(fakeState);
+    expect(resp.value).toEqual(call(fetchGetLetterProofing, fakeState.config, nin));
 
     const action = {
       type: "GET_LETTER_PROOFING_PROOFING_SUCCESS",
@@ -359,9 +360,8 @@ describe("Async component", () => {
       code: "dummy-code",
       csrf_token: "csrf-token"
     };
-
-    const resp = generator.next(state);
-    expect(resp.value).toEqual(call(fetchLetterCode, state.config, data));
+    const resp = generator.next(fakeState);
+    expect(resp.value).toEqual(call(fetchLetterCode, fakeState.config, data));
 
     const action = {
       type: "POST_LETTER_PROOFING_CODE_SUCCESS",

--- a/src/tests/LetterProofing-test.js
+++ b/src/tests/LetterProofing-test.js
@@ -31,7 +31,10 @@ const baseState = {
     confirmingLetter: false,
     code: ""
   },
-  config: { letter_proofing_url: "http://localhost/letter" },
+  config: { 
+    letter_proofing_url: "http://localhost/letter",
+    csrf_token: "csrf-token" 
+  },
   nins: {
     nin:""
   },

--- a/src/tests/LetterProofing-test.js
+++ b/src/tests/LetterProofing-test.js
@@ -21,14 +21,7 @@ import {
 const messages = require("../login/translation/messageIndex");
 addLocaleData("react-intl/locale-data/en");
 
-const fakeStore = fakeState => ({
-  default: () => {},
-  dispatch: mock.fn(),
-  subscribe: mock.fn(),
-  getState: () => ({ ...fakeState })
-});
-
-const fakeState = {
+const baseState = {
   letter_proofing: {
     message: "",
     letter_sent: "",
@@ -38,15 +31,26 @@ const fakeState = {
     confirmingLetter: false
   },
   config: { letter_proofing_url: "http://localhost/letter" },
-  nins: {
-    valid_nin: false,
-    nins: []
-  },
+  nins: {},
   intl: {
     locale: "en",
     messages: messages
   }
 };
+
+const fakeStore = fakeState => ({
+  default: () => {},
+  dispatch: mock.fn(),
+  subscribe: mock.fn(),
+  getState: () => ({ ...fakeState })
+});
+
+function getFakeState(newState) {
+  if (newState === undefined) {
+    newState = {}
+  }
+  return Object.assign(baseState, newState)
+}
 
 describe("LetterProofing Component", () => {
   it("The component does not render 'false' or 'null'", () => {
@@ -60,6 +64,13 @@ describe("LetterProofing Component", () => {
 });
 
 describe("Letter Proofing, when letter has been expired", () => {
+  const fakeState = getFakeState({
+    nins: {
+      valid_nin: true,
+      nin: "dummy-nin"
+    },
+  })
+
   function setupComponent() {
     const props =  {
       confirmingLetter: false,
@@ -370,6 +381,13 @@ describe("Async component", () => {
 });
 
 describe("LetterProofing component, without id number", () => {
+  const fakeState = getFakeState({
+    nins: {
+      valid_nin: false,
+      nins: []
+    }
+  })
+
   function setupComponent() {
     const wrapper = mount(
       <Provider store={fakeStore(fakeState)}>
@@ -397,6 +415,13 @@ describe("LetterProofing component, without id number", () => {
 });
 
 describe("LetterProofing component, letter has been sent", () => {
+  const fakeState = getFakeState({
+    nins: {
+      valid_nin: false,
+      nins: []
+    }
+  })
+
   function setupComponent() {
     const wrapper = mount(
       <Provider store={fakeStore(fakeState)}>
@@ -433,6 +458,13 @@ describe("LetterProofing component, letter has been sent", () => {
 });
 
 describe("LetterProofing component, when letter has expired", () => {
+  const fakeState = getFakeState({
+    nins: {
+      valid_nin: false,
+      nins: []
+    }
+  })
+  
   function setupComponent() {
     const wrapper = mount(
       <Provider store={fakeStore(fakeState)}>


### PR DESCRIPTION
#### Description:
Quick refactoring letter-proofing test for avoiding similar boilerplate code
- Added getFakeState function that return fakeStore where we can change what we want to change with arguments. 
that will avoid duplicated code and typing errors.
- Removed unused code


#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

