### PR TITLE
Fix minor spelling error, giltig to giltigt

### DIFF
--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -400,7 +400,7 @@
   "verify-identity.vetting_letter_order_new_code": "Tryck här om du vill beställa en ny kod",
   "verify-identity.vetting_letter_received": "Tryck här igen när du har fått brevet",
   "verify-identity.vetting_letter_sent": "Ett brev skickades",
-  "verify-identity.vetting_letter_valid": "Brevet är giltig till",
+  "verify-identity.vetting_letter_valid": "Brevet är giltigt till",
   "verify-identity.vetting_phone_tagline": "För dig som har ett svenskt telefonabonnemang i ditt eget namn",
   "verify-identity.vetting_post_tagline": "För dig som har tillgång till din folkbokföringsaddress"
 }


### PR DESCRIPTION
#### Description:
issue https://github.com/SUNET/eduid-front/issues/489
correct spelling error in vetting button by post
- Brevet är giltig till -> Brevet är giltigt till

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

