### PR TITLE
Migrating confirm modal components and container

### DIFF
--- a/src/components/Emails.js
+++ b/src/components/Emails.js
@@ -6,7 +6,7 @@ import Form from "reactstrap/lib/Form";
 import CustomInput from "../login/components/Inputs/CustomInput";
 import EduIDButton from "./EduIDButton";
 import DataTable from "../login/components/DataTable/DataTable";
-import ConfirmModal from "../containers/ConfirmModal";
+import ConfirmModal from "../login/components/Modals/ConfirmModalContainer";
 import "../login/styles/index.scss";
 import { validate } from "../login/app_utils/validation/validateEmail";
 import { longCodePattern } from "../login/app_utils/validation/regexPatterns";

--- a/src/components/Mobile.js
+++ b/src/components/Mobile.js
@@ -7,7 +7,7 @@ import Form from "reactstrap/lib/Form";
 import CustomInput from "../login/components/Inputs/CustomInput";
 import EduIDButton from "components/EduIDButton";
 import TableList from "../login/components/DataTable/DataTable";
-import ConfirmModal from "../containers/ConfirmModal";
+import ConfirmModal from "../login/components/Modals/ConfirmModalContainer";
 import "../login/styles/index.scss";
 import { shortCodePattern } from "../login/app_utils/validation/regexPatterns";
 

--- a/src/components/Security.js
+++ b/src/components/Security.js
@@ -2,7 +2,7 @@ import React, { Component } from "react";
 import PropTypes from "prop-types";
 import EduIDButton from "components/EduIDButton";
 import NotificationModal from "../login/components/Modals/NotificationModal";
-import ConfirmModal from "../containers/ConfirmModal";
+import ConfirmModal from "../login/components/Modals/ConfirmModalContainer";
 import { securityKeyPattern } from "../login/app_utils/validation/regexPatterns";
 import "../login/styles/index.scss";
 

--- a/src/login/components/LetterProofing/LetterProofing.js
+++ b/src/login/components/LetterProofing/LetterProofing.js
@@ -1,7 +1,7 @@
 import React, { Component } from "react";
 import PropTypes from "prop-types";
 import NotificationModal from "../Modals/NotificationModal";
-import ConfirmModal from "../../../containers/ConfirmModal";
+import ConfirmModal from "../Modals/ConfirmModalContainer";
 import { shortCodePattern } from "../../app_utils/validation/regexPatterns";
 
 class LetterProofingButton extends Component {

--- a/src/login/components/Modals/ConfirmModal.js
+++ b/src/login/components/Modals/ConfirmModal.js
@@ -4,8 +4,8 @@ import Modal from "reactstrap/lib/Modal";
 import ModalHeader from "reactstrap/lib/ModalHeader";
 import ModalBody from "reactstrap/lib/ModalBody";
 import ModalFooter from "reactstrap/lib/ModalFooter";
-import ConfirmModalForm from "./ConfirmModalForm";
-import EduIDButton from "components/EduIDButton";
+import ConfirmModalForm from "../../../components/ConfirmModalForm";
+import EduIDButton from "../../../components/EduIDButton";
 
 const RenderCloseButton = ({closeModal}) => {
   return (

--- a/src/login/components/Modals/ConfirmModalContainer.js
+++ b/src/login/components/Modals/ConfirmModalContainer.js
@@ -1,6 +1,6 @@
 import { connect } from "react-redux";
-import i18n from "../login/translation/InjectIntl_HOC_factory";
-import ConfirmModal from "../components/ConfirmModal";
+import i18n from "../../translation/InjectIntl_HOC_factory";
+import ConfirmModal from "./ConfirmModal";
 import { isValid, isSubmitting } from 'redux-form';
 
 const mapStateToProps = state => {


### PR DESCRIPTION
#### Description:
ConfirmModal has been updated with the new design in previous [PR 495](https://github.com/SUNET/eduid-front/pull/495) 
as we agreed I have moved the improved files to the new location(login). login is only temporary folder name so far.
so this PR is covering the move of ConfirmModal component file from `src/component` and container file from `src/containers` to `/login/component/Modals`

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

