### PR TITLE
GROUP MANAGEMENT: Updates group data render after new backend data structure 

### DIFF
--- a/src/login/components/GroupManagement/GroupManagementContainer.js
+++ b/src/login/components/GroupManagement/GroupManagementContainer.js
@@ -9,11 +9,11 @@ const mapStateToProps = (state) => {
   let hasNoGroups =
     Object.entries(state.groups.data).length === 0 ||
     Object.entries(state.groups.data.groups).length === 0;
-  let userGroupData = state.groups.data.groups;
+  let groupsData = state.groups.data.groups;
 
   return {
     hasNoGroups,
-    userGroupData,
+    groupsData,
     loading: state.groups.loading,
   };
 };

--- a/src/login/components/GroupManagement/GroupManagementContainer.js
+++ b/src/login/components/GroupManagement/GroupManagementContainer.js
@@ -5,38 +5,13 @@ import * as allDataActions from "../../redux/actions/getAllGroupMgmtDataActions"
 import i18n from "../../translation/InjectIntl_HOC_factory";
 
 const mapStateToProps = (state) => {
-  // check if user has any gropus
-  let hasNoGroups =
-    Object.entries(state.groups.member_of).length === 0 &&
-    Object.entries(state.groups.owner_of).length === 0;
-
-  // filter out duplicate groups to generate only one list of groups
-  let allGroups = state.groups.member_of.concat(state.groups.owner_of);
-  let uniqueGroupIds = [...new Set(allGroups.map((group) => group.identifier))];
-  let uniqueGroups = allGroups.filter((group, i) => {
-    return i === uniqueGroupIds.findIndex((id) => id === group.identifier);
-  });
-
-  // create new object listing user relationship with each group
-  let userIdentifier = state.groups.data.user_identifier;
-  let userGroupsAndRoles = uniqueGroups.map((group) => {
-    let membershipObj = { group: group, isMember: false, isOwner: false };
-    group.members.some((member) => {
-      if (member.identifier === userIdentifier) {
-        return (membershipObj.isMember = true);
-      }
-    });
-    group.owners.some((owner) => {
-      if (owner.identifier === userIdentifier) {
-        return (membershipObj.isOwner = true);
-      }
-    });
-    return membershipObj;
-  });
+  // check if user has any groups
+  let hasNoGroups = Object.entries(state.groups.data).length === 0;
+  let userGroupData = state.groups.data.groups;
 
   return {
     hasNoGroups,
-    uniqueGroups: userGroupsAndRoles,
+    userGroupData,
     loading: state.groups.loading,
   };
 };

--- a/src/login/components/GroupManagement/GroupManagementContainer.js
+++ b/src/login/components/GroupManagement/GroupManagementContainer.js
@@ -6,7 +6,9 @@ import i18n from "../../translation/InjectIntl_HOC_factory";
 
 const mapStateToProps = (state) => {
   // check if user has any groups
-  let hasNoGroups = Object.entries(state.groups.data).length === 0;
+  let hasNoGroups =
+    Object.entries(state.groups.data).length === 0 ||
+    Object.entries(state.groups.data.groups).length === 0;
   let userGroupData = state.groups.data.groups;
 
   return {

--- a/src/login/components/GroupManagement/Groups/EditGroup.js
+++ b/src/login/components/GroupManagement/Groups/EditGroup.js
@@ -3,14 +3,16 @@ import i18n from "../../../translation/InjectIntl_HOC_factory";
 import InvitesParent from "../Invites/InvitesParentContainer";
 
 const EditGroup = (props) => {
+  const { group } = props;
+  const { display_name } = props.group;
   return (
     <div className="edit-data">
       <div className="title">
-        <p>Edit your group {props.group.group.display_name}</p>
+        <p>Edit your group {display_name}</p>
         <button
           className="save-button"
           onClick={() => {
-            props.toggleGroupsListOrEditGroup(props.group.group);
+            props.toggleGroupsListOrEditGroup(group);
           }}
         >
           save
@@ -27,7 +29,7 @@ const EditGroup = (props) => {
           <p>Delete</p>
         </li>
       </nav>
-      <InvitesParent group={props.group.group} />
+      <InvitesParent group={group} />
     </div>
   );
 };

--- a/src/login/components/GroupManagement/Groups/GroupListItem.js
+++ b/src/login/components/GroupManagement/Groups/GroupListItem.js
@@ -2,7 +2,7 @@ import React, { Component, Fragment } from "react";
 import i18n from "../../../translation/InjectIntl_HOC_factory";
 
 export const RenderOwnerList = (props) => {
-  let owners = props.group.group.owners;
+  let owners = props.group.owners;
   return (
     <Fragment>
       <label>Owner</label>
@@ -16,7 +16,7 @@ export const RenderOwnerList = (props) => {
 };
 
 export const RenderMemberList = (props) => {
-  let members = props.group.group.members;
+  let members = props.group.members;
   return (
     <Fragment>
       <label>Member</label>
@@ -52,6 +52,8 @@ class GroupListItem extends Component {
   };
 
   render() {
+    const { group } = this.props;
+    const { display_name } = this.props.group;
     return (
       <li
         className="closed"
@@ -69,23 +71,23 @@ class GroupListItem extends Component {
               >
                 ^
               </button>
-              <p>{this.props.group.group.display_name}</p>
+              <p>{display_name}</p>
             </div>
           </div>
           <div className="list-cell">
             <div className={this.state.openGroup ? "transparent" : null}>
-              {this.props.group.isOwner ? "X" : null}
+              {group.is_owner ? "X" : null}
             </div>
           </div>
           <div className="list-cell">
             <div className={this.state.openGroup ? "transparent" : null}>
-              {this.props.group.isMember ? "X" : null}
+              {group.is_member ? "X" : null}
             </div>
           </div>
           <div className="list-cell">
             <button
               onClick={() => {
-                this.props.toggleGroupsListOrEditGroup(this.props.group);
+                this.props.toggleGroupsListOrEditGroup(group);
               }}
             >
               edit

--- a/src/login/components/GroupManagement/Groups/GroupsList.js
+++ b/src/login/components/GroupManagement/Groups/GroupsList.js
@@ -16,9 +16,9 @@ const GroupsList = (props) => {
         <div className="list-cell"></div>
       </div>
       <ul>
-        {props.uniqueGroups.map((group) => (
+        {props.userGroupData.map((group) => (
           <GroupListItem
-            key={group.group.identifier}
+            key={group.identifier}
             group={group}
             toggleGroupsListOrEditGroup={props.toggleGroupsListOrEditGroup}
           />

--- a/src/login/components/GroupManagement/Groups/GroupsList.js
+++ b/src/login/components/GroupManagement/Groups/GroupsList.js
@@ -16,7 +16,7 @@ const GroupsList = (props) => {
         <div className="list-cell"></div>
       </div>
       <ul>
-        {props.userGroupData.map((group) => (
+        {props.groupsData.map((group) => (
           <GroupListItem
             key={group.identifier}
             group={group}

--- a/src/login/components/GroupManagement/Groups/GroupsParent.js
+++ b/src/login/components/GroupManagement/Groups/GroupsParent.js
@@ -28,11 +28,11 @@ class GroupParent extends Component {
     );
   }
 
-  toggleGroupsListOrEditGroup = (groupData) => {
+  toggleGroupsListOrEditGroup = (groupsData) => {
       this.setState((prevState) => {
         return {
           editGroup: !prevState.editGroup,
-          group: groupData,
+          group: groupsData,
         };
       });
   };

--- a/src/login/components/GroupManagement/Groups/GroupsParent.js
+++ b/src/login/components/GroupManagement/Groups/GroupsParent.js
@@ -28,11 +28,11 @@ class GroupParent extends Component {
     );
   }
 
-  toggleGroupsListOrEditGroup = (groupsData) => {
+  toggleGroupsListOrEditGroup = (groupData) => {
       this.setState((prevState) => {
         return {
           editGroup: !prevState.editGroup,
-          group: groupsData,
+          group: groupData,
         };
       });
   };

--- a/src/login/components/GroupManagement/Groups/GroupsParent.js
+++ b/src/login/components/GroupManagement/Groups/GroupsParent.js
@@ -28,13 +28,13 @@ class GroupParent extends Component {
     );
   }
 
-  toggleGroupsListOrEditGroup = (singleGroupData) => {
-    this.setState((prevState) => {
-      return {
-        editGroup: !prevState.editGroup,
-        group: singleGroupData,
-      };
-    });
+  toggleGroupsListOrEditGroup = (groupData) => {
+      this.setState((prevState) => {
+        return {
+          editGroup: !prevState.editGroup,
+          group: groupData,
+        };
+      });
   };
 
   render() {

--- a/src/login/redux/reducers/groupsReducer.js
+++ b/src/login/redux/reducers/groupsReducer.js
@@ -4,8 +4,6 @@ const groupsData = {
   message: "",
   loading: true,
   data: [],
-  member_of: [],
-  owner_of: [],
   payload: ""
 };
 
@@ -16,8 +14,6 @@ let groupsReducer = (state = groupsData, action) => {
         ...state,
         loading: false,
         data: action.payload,
-        member_of: action.payload.member_of,
-        owner_of: action.payload.owner_of,
       };
     default:
       return state;


### PR DESCRIPTION
#### Description:
Listing of groups has been updated to render the updated data structure that describes a user's role in each of their groups. 

Summary: 
- The previous "hack" that created this object has been removed (GroupManagementContainer.js)
- The data reaching the app has been renamed from `uniqueGroups` to `groupsData` and updated throughout (GroupManagement, GroupsList and GroupListItem)  
- props have been destructured in places where the data is nested deep in the object (EditGroup and GroupListItem)

---

###### User without groups
<img width="500" alt="Screenshot 2021-01-14 at 14 32 06" src="https://user-images.githubusercontent.com/30963614/104597551-c1f2a880-5675-11eb-91fd-dee583461507.png">

###### User with groups, closed list
<img width="500" alt="Screenshot 2021-01-14 at 14 33 41" src="https://user-images.githubusercontent.com/30963614/104597573-c7e88980-5675-11eb-9cee-22a8f1869505.png">

###### User with groups, open list
<img width="500" alt="Screenshot 2021-01-14 at 14 33 38" src="https://user-images.githubusercontent.com/30963614/104597591-cdde6a80-5675-11eb-9282-f1396f987ad0.png">

----


#### For reviewer:
- [x] Read the above description
- [x] Reviewed the code changes
- [x] Navigate to the branch (pulled the latest version)
- [x] Run the code and been able to execute the expected function
- [x] Check any styling on both desktop and mobile sizes

