### PR TITLE
ESLINT: Turn on eslint rules:  no case declarations by removing "off" in rules

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,7 +22,6 @@ module.exports = {
         "react"
     ],
     "rules": {
-        "no-case-declarations": "off",
         "no-useless-escape": "off",
         "react/jsx-key": "off",
         "react/jsx-no-duplicate-props": "off",

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -22,7 +22,6 @@ module.exports = {
         "react"
     ],
     "rules": {
-        "react/jsx-no-undef": "off", 
         "no-case-declarations": "off",
         "no-useless-escape": "off",
         "react/jsx-key": "off",

--- a/src/reducers/DashboardConfig.js
+++ b/src/reducers/DashboardConfig.js
@@ -88,7 +88,7 @@ let configReducer = (state = configData, action) => {
         ...state,
         ...action.payload
       };
-    case "@@router/LOCATION_CHANGE":
+    case "@@router/LOCATION_CHANGE": {
       let show_sidebar = true;
       if (
         urls_with_no_sidebar.filter(v => action.payload.pathname.endsWith(v))
@@ -100,6 +100,7 @@ let configReducer = (state = configData, action) => {
         ...state,
         show_sidebar: show_sidebar
       };
+    }
     default:
       //if (action.type.endsWith("_SUCCESS") || action.type.endsWith("_FAIL")) {
         //return {

--- a/src/reducers/Emails.js
+++ b/src/reducers/Emails.js
@@ -79,7 +79,7 @@ let emailsReducer = (state = emailsData, action) => {
         ...state,
         ...action.payload
       };
-    case "@@redux-form/CHANGE":
+    case "@@redux-form/CHANGE":{
       const form = {};
       if (action.meta.form === "emails" && action.meta.field === "email") {
         form.email = action.payload;
@@ -88,6 +88,7 @@ let emailsReducer = (state = emailsData, action) => {
         ...state,
         ...form
       };
+    }
     default:
       return state;
   }

--- a/src/reducers/LetterProofing.js
+++ b/src/reducers/LetterProofing.js
@@ -24,7 +24,7 @@ let letterProofingReducer = (state = letterData, action) => {
         confirmingLetter: false,
         verifyingLetter: false
       };
-    case actions.GET_LETTER_PROOFING_PROOFING_SUCCESS:
+    case actions.GET_LETTER_PROOFING_PROOFING_SUCCESS: {
       let verifying = false,
         confirming = false;
       if (action.payload.letter_sent === undefined) {
@@ -38,6 +38,7 @@ let letterProofingReducer = (state = letterData, action) => {
         verifyingLetter: verifying,
         confirmingLetter: confirming
       };
+    }
     case actions.GET_LETTER_PROOFING_PROOFING_FAIL:
       return {
         ...state,

--- a/src/reducers/Mobile.js
+++ b/src/reducers/Mobile.js
@@ -68,7 +68,7 @@ let mobileReducer = (state = mobileData, action) => {
         ...state,
         ...action.payload
       };
-    case "@@redux-form/CHANGE":
+    case "@@redux-form/CHANGE": {
       const form = {};
       if (action.meta.form === "phones" && action.meta.field === "number") {
         form.phone = action.payload;
@@ -77,6 +77,7 @@ let mobileReducer = (state = mobileData, action) => {
         ...state,
         ...form
       };
+    }
     default:
       return state;
   }

--- a/src/reducers/Nins.js
+++ b/src/reducers/Nins.js
@@ -9,7 +9,7 @@ const ninState = {
 
 let ninsReducer = (state = ninState, action) => {
   switch (action.type) {
-    case actions.GET_NINS_SUCCESS:
+    case actions.GET_NINS_SUCCESS:{
       const nins = action.payload.nins,
         nin = nins.length ? nins[0].number : state.nin;
       return {
@@ -17,6 +17,7 @@ let ninsReducer = (state = ninState, action) => {
         ...action.payload,
         nin: nin
       };
+    }
     case actions.GET_NINS_FAIL:
       return {
         ...state,
@@ -37,7 +38,7 @@ let ninsReducer = (state = ninState, action) => {
         ...state,
         data: { ...action.payload }
       };
-    case "@@redux-form/CHANGE":
+    case "@@redux-form/CHANGE": {
       const form = {};
       if (
         action.meta.form === "nins" &&
@@ -49,6 +50,7 @@ let ninsReducer = (state = ninState, action) => {
         ...state,
         ...form
       };
+    }
     default:
       return state;
   }


### PR DESCRIPTION
#### Description:
The "`extends`": "`eslint:recommended`" property in a configuration file enables this rule.

This rule disallows lexical declarations (let, const, function and class) in case/default clauses. The reason is that the lexical declaration is visible in the entire switch block but it only gets initialized when it is assigned, which will only happen if the case where it is defined is reached. 
To ensure that the lexical declaration only applies to the current case clause wrap your clauses in blocks. 



This PR, is for **no-case-declararions** : 
- Remove **no-case-declarations: off** in .eslint.js
- Use **{ }** to create the block scope with case

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

