### PR TITLE
PERSONALDATA:  Button disabled when input is empty

### DIFF
--- a/src/components/PersonalData.js
+++ b/src/components/PersonalData.js
@@ -48,11 +48,9 @@ let PdataForm = (props) => {
         } else setIsDisable(false)
   }, [pdata, isDisable]);
   
-  // if field value is present, setPdata key and value.
+  // setPdata key and value.
   const handleFormChange = (field)=> {
-    if(field.value){
-      setPdata({...pdata,[field.name]: field.value.trim()})
-    }else setPdata({pdata});
+    setPdata({...pdata,[field.name]: field.value.trim()})
   };
   
   return (

--- a/src/components/PersonalData.js
+++ b/src/components/PersonalData.js
@@ -43,7 +43,9 @@ let PdataForm = (props) => {
       pdata.display_name === props.initialValues.display_name &&
       pdata.language === props.initialValues.language){ 
         setIsDisable(true)
-      } else setIsDisable(false)
+      } else if(Object.keys(pdata).length < 5){
+          setIsDisable(true)
+        } else setIsDisable(false)
   }, [pdata, isDisable]);
   
   // if field value is present, setPdata key and value.

--- a/src/components/PersonalData.js
+++ b/src/components/PersonalData.js
@@ -38,14 +38,14 @@ let PdataForm = (props) => {
   }, [props.data])
   // if all the updateded values are matched with initial values, button will be disabled.
   useEffect(() => {
-    if(pdata.given_name === props.initialValues.given_name && 
+    if(!pdata.given_name || !pdata.surname || !pdata.display_name || !pdata.language){
+      setIsDisable(true)
+    } else if(pdata.given_name === props.initialValues.given_name && 
       pdata.surname === props.initialValues.surname && 
       pdata.display_name === props.initialValues.display_name &&
       pdata.language === props.initialValues.language){ 
         setIsDisable(true)
-      } else if(Object.keys(pdata).length < 5){
-          setIsDisable(true)
-        } else setIsDisable(false)
+      }else setIsDisable(false)
   }, [pdata, isDisable]);
   
   // setPdata key and value.


### PR DESCRIPTION
#### Description:
**When creating a new account**, user is required to fill all personal information data inputs before the "Save" button is enabled
Previously only one input was required to enable the "Save" button

---
- Before and after
<img width="780" alt="Screenshot 2021-02-02 at 13 54 12" src="https://user-images.githubusercontent.com/44289056/106717996-b81eee00-6600-11eb-9124-cea15d0342e5.png">
<img width="782" alt="Screenshot 2021-02-02 at 13 53 50" src="https://user-images.githubusercontent.com/44289056/106718014-be14cf00-6600-11eb-831a-64469855ae47.png">


---


**please, create a new account and test to fill  the personal data**


#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

