### PR TITLE
ERRORS: load errors html for staging and production

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -23,7 +23,7 @@ module.exports = {
     signup: "./src/entry-points/signup",
     dashboard: "./src/entry-points/dashboard",
     login: "./src/login/app_init/index",
-    errors: "./src/entry-points/errors",
+    errors: ['babel-polyfill',"./src/entry-points/errors"],
   },
   output: {
     path: path.join(__dirname, "build"),
@@ -92,10 +92,8 @@ module.exports = {
     new HtmlWebpackPlugin({
       hash: true,
       template: "./public/errors.html",
-      filename:  
-        environment === "production" ? "errors.html" :
-        environment === "development" ? "errors.staging.html" :  "errors.dev.html",
-        chunks: ["errors"]
+      filename: "errors.dev.html",
+      chunks: ["errors"]
     }),
     // Initial configuration
     initialConfigPlugin,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,8 +6,6 @@ const initialConfigPlugin = require("./src/init-config").initialConfigPlugin;
 // const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 
-let environment =  process.argv[5];
-
 module.exports = {
   mode: "development",
   devServer: {
@@ -23,7 +21,7 @@ module.exports = {
     signup: "./src/entry-points/signup",
     dashboard: "./src/entry-points/dashboard",
     login: "./src/login/app_init/index",
-    errors: ['babel-polyfill',"./src/entry-points/errors"],
+    errors: "./src/entry-points/errors",
   },
   output: {
     path: path.join(__dirname, "build"),
@@ -111,6 +109,5 @@ module.exports = {
         }
       }
     }),
-    // new BundleAnalyzerPlugin()
   ]
 };

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -5,6 +5,7 @@ const CompressionPlugin = require("compression-webpack-plugin");
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const initialConfigPlugin = require("./src/init-config").initialConfigPlugin;
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 var webpackProd = {
   entry: webpackConfig.entry,
@@ -52,8 +53,17 @@ webpackProd.mode = 'production';
 webpackProd.optimization = {
   minimizer: [
     new UglifyJsPlugin()
-  ]
+  ],
 };
+
+webpackProd.plugins = [
+  new HtmlWebpackPlugin({
+    hash: true,
+    template: "./public/errors.html",
+    filename: "errors.html",
+    chunks: ["errors"]
+  })
+];
 
 webpackProd.performance= {
   hints: false

--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -2,7 +2,6 @@ const path = require("path");
 const webpack = require("webpack");
 const webpackConfig = require("./webpack.config");
 const CompressionPlugin = require("compression-webpack-plugin");
-const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const initialConfigPlugin = require("./src/init-config").initialConfigPlugin;
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');

--- a/webpack.staging.config.js
+++ b/webpack.staging.config.js
@@ -1,5 +1,6 @@
 const path = require("path");
 const webpackProd = require("./webpack.prod.config");
+const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 var webpackStaging = {
   ...webpackProd
@@ -10,6 +11,16 @@ webpackStaging.output = {
   publicPath: "https://www.dev.eduid.se/static/front-build/",
   path: path.join(__dirname, "build")
 };
+
+webpackStaging.plugins = [
+  new HtmlWebpackPlugin({
+    hash: true,
+    template: "./public/errors.html",
+    filename: "errors.staging.html",
+    chunks: ["errors"]
+  })
+];
+
 
 webpackStaging.devtool = "source-map";
 


### PR DESCRIPTION
#### Description:
previous PR #548 was not able to load errors.html for staging and production. now I have added/separated htmlwebpackplugin for each environment config. 

- Development
<img width="660" alt="Screenshot 2021-04-13 at 08 47 39" src="https://user-images.githubusercontent.com/44289056/114509368-b3e10380-9c35-11eb-883d-832ca3075c24.png">

- Staging
<img width="717" alt="Screenshot 2021-04-13 at 08 47 48" src="https://user-images.githubusercontent.com/44289056/114509382-b80d2100-9c35-11eb-8ebe-ae405167d059.png">

- Production
<img width="672" alt="Screenshot 2021-04-13 at 08 47 55" src="https://user-images.githubusercontent.com/44289056/114509386-b8a5b780-9c35-11eb-8ae0-1ac7ebf31cd3.png">


#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

