### PR TITLE
IDENTITY: Fix Incorrect nin data and specific fault massage added

### DIFF
--- a/i18n/src/login/translation/defaultMessages/errors.json
+++ b/i18n/src/login/translation/defaultMessages/errors.json
@@ -72,6 +72,10 @@
     "defaultMessage": "Service Unavailable. Check your internet connection."
   },
   {
+    "id": "nin needs to be formatted as 18|19|20yymmddxxxx",
+    "defaultMessage": "National identity number needs to be in the form of yyyymmddxxxx"
+  },
+  {
     "id": "error_in_form",
     "defaultMessage": "Check the form below for errors."
   },

--- a/src/components/NinDisplay.js
+++ b/src/components/NinDisplay.js
@@ -25,7 +25,7 @@ const RenderShowHideNin = props => {
   
   return(
     <div data-ninnumber={nin} className={`${props.delete ? "data-with-delete" : "display-nin-show-hide"}`} >
-      <p className={`display-data ${props.verifiedNinStatus ? "verified" : "unverified"}`}>
+      <p id="nin-number" className={`display-data ${props.verifiedNinStatus ? "verified" : "unverified"}`}>
         {showNin ? nin : nin.replace(/\d{4}$/, '****')}
       </p>
       <button className="show-hide-button" onClick={toggleShowNin}>

--- a/src/login/translation/defaultMessages/errors.js
+++ b/src/login/translation/defaultMessages/errors.js
@@ -130,6 +130,14 @@ export const generalErrors = {
     />
   ),
 
+  // user errors
+  "nin needs to be formatted as 18|19|20yymmddxxxx": (
+    <FormattedMessage
+      id="nin needs to be formatted as 18|19|20yymmddxxxx"
+      defaultMessage={`National identity number needs to be in the form of yyyymmddxxxx`}
+    />
+  ),
+
   "Missing data for required field.": (
     <FormattedMessage
       id="Missing data for required field."

--- a/src/login/translation/src/login/translation/defaultMessages/errors.json
+++ b/src/login/translation/src/login/translation/defaultMessages/errors.json
@@ -76,6 +76,10 @@
     "defaultMessage": "Check the form below for errors."
   },
   {
+    "id": "nin needs to be formatted as 18|19|20yymmddxxxx",
+    "defaultMessage": "National identity number needs to be in the form of yyyymmddxxxx"
+  },
+  {
     "id": "Missing data for required field.",
     "defaultMessage": "Missing data for required field"
   },

--- a/src/notify-middleware.js
+++ b/src/notify-middleware.js
@@ -11,9 +11,15 @@ const notifyAndDispatch = () => next => action => {
       ) {
         const msg = "csrf.try-again";
         next(actions.eduidNotify(msg, "errors"));
-      } else {
+      } 
+      else if(action.payload.error.nin){
         const msg =
-          action.payload.errorMsg || action.payload.message || "error_in_form";
+          action.payload.error.nin[0];
+        next(actions.eduidNotify(msg, "errors"));
+      }
+      else {
+        const msg =
+          action.payload.errorMsg || action.payload.message || "error_in_form" ;
         next(actions.eduidNotify(msg, "errors"));
       }
       setTimeout(() => {


### PR DESCRIPTION
#### Description:
fix for issue [564](https://github.com/SUNET/eduid-front/issues/564)
`id=nin-number` was removed so data nin was not found, så text "testing" was sent instead of nin number.
I added`id=nin-number` to p tag and added specific error message for "nin needs to be formatted as 18|19|20yymmddxxxx".
this error message will show when user send incorrect format of nin (but we have a input validation so this should not happen)




#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

