### PR TITLE
Clean up LookupMobileProofing saga and Add a test for checking p#nin-number is existing

### DIFF
--- a/src/sagas/LookupMobileProofing.js
+++ b/src/sagas/LookupMobileProofing.js
@@ -6,40 +6,8 @@ import {
 import { postLookupMobileFail } from "actions/LookupMobileProofing";
 import * as ninActions from "actions/Nins";
 
-// export function* requestLookupMobileProof() {
-//   console.log("this is lookupMobileData response");
-//   // try {
-//   //   const state = yield select((state) => state);
-//   //   console.log("this is state", state);
-//   //   const unconfirmed = document.getElementById("nin-number");
-//   //   console.log("this is unconfirmed", unconfirmed.textContent());
-//   //   // nin = input ? input.value : unconfirmed ? state.nins.nin : "testing",
-//   //   (nin = unconfirmed ? state.nins.nin : "testing"),
-//   //     (data = {
-//   //       nin: nin,
-//   //       csrf_token: state.config.csrf_token,
-//   //     });
-
-//   //   const lookupMobileData = yield call(
-//   //     fetchLookupMobileProof,
-//   //     state.config,
-//   //     data
-//   //   );
-//   //   console.log(
-//   //     "this is the lookupMobileData response returning data",
-//   //     lookupMobileData
-//   //   );
-//   //   yield put(putCsrfToken(lookupMobileData));
-//   //   yield put(lookupMobileData);
-//   // } catch (error) {
-//   //   yield* failRequest(error, postLookupMobileFail);
-//   // }
-// }
-
 // take user data into request 
 export function fetchLookupMobileProof(config, data) {
-  console.log("this is config in fetchLookupMobileProof", config);
-  console.log("this is data in fetchLookupMobileProof", data);
   const url = config.lookup_mobile_proofing_url;
   return window
     .fetch(url, {
@@ -52,7 +20,6 @@ export function fetchLookupMobileProof(config, data) {
 
 // get user data for request  
 const getData = (state) => {
-  console.log("this is state in get data", state);
   const unconfirmed = document.getElementById("nin-number");
   const nin = unconfirmed ? state.nins.nin : "testing";
   return {

--- a/src/tests/NinDisplay-test.js
+++ b/src/tests/NinDisplay-test.js
@@ -121,6 +121,12 @@ describe("NinDisplay component (/verify-identity), when a nin is saved and verif
     const number = wrapper.find("p");
     expect(number.text()).toBe("19990110****");
   });
+
+  it("Check p#nin-number exists", () => {
+    const { wrapper } = setupComponent();
+    const ninNumber = wrapper.find("p#nin-number");
+    expect(ninNumber.exists()).toEqual(true);
+  });
 });
 
 history.push("/profile");


### PR DESCRIPTION
#### Summary: 
- LookupMobileProofing saga cleaned up .
- Add a test for checking if p#nin-number is existing to prevent sending incorrect nin data
#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

