### PR TITLE
NOTIFICATION: Fix console log error and show correct error message after letter proofing failed

### DIFF
--- a/src/notify-middleware.js
+++ b/src/notify-middleware.js
@@ -2,9 +2,11 @@ import * as actions from "./login/components/Notifications/Notifications_actions
 
 const notifyAndDispatch = () => next => action => {
   if (action.type.endsWith("SUCCESS") || action.type.endsWith("FAIL")) {
-    if (action.error && action.payload) {
-      console.log("this is action.payload", action.payload);
-      console.log("this is action.error", action.error);
+    if(action.type.startsWith("GET_LETTER")){
+      delete action.payload.message;
+      delete action.payload.error;
+    }
+    else if (action.error && action.payload) {
       if (
         action.payload.error &&
         action.payload.error.csrf_token !== undefined
@@ -12,7 +14,7 @@ const notifyAndDispatch = () => next => action => {
         const msg = "csrf.try-again";
         next(actions.eduidNotify(msg, "errors"));
       } 
-      else if(action.payload.error.nin){
+      else if(action.payload.error && action.payload.error.nin){
         const msg =
           action.payload.error.nin[0];
         next(actions.eduidNotify(msg, "errors"));
@@ -25,7 +27,7 @@ const notifyAndDispatch = () => next => action => {
       setTimeout(() => {
         window.scroll(0, 0);
       }, 100);
-    } else if (action.payload && action.payload.message && !action.payload.message.includes("letter")) {
+    } else if (action.payload && action.payload.message) {
       next(actions.eduidNotify(action.payload.message, "messages"));
       setTimeout(() => {
         window.scroll(0, 0);
@@ -37,6 +39,5 @@ const notifyAndDispatch = () => next => action => {
     }
   }
   return next(action);
-};
-
+}
 export default notifyAndDispatch;


### PR DESCRIPTION
#### Description:
not able to see error message when failed letter proofing 
After failed letter proofing an error(can not read property) in console

- before fix
![Screenshot 2021-04-29 at 16 34 19](https://user-images.githubusercontent.com/44289056/116568718-ffb7cc00-a908-11eb-8d31-ce2ac5566dd5.png)

- after fix
![Screenshot 2021-04-29 at 16 33 35](https://user-images.githubusercontent.com/44289056/116568729-034b5300-a909-11eb-9840-158f46b52e86.png)





#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

