### PR TITLE
GROUP MANAGEMENT: Changes null in styling ternary operator to empty string

### DIFF
--- a/src/login/components/GroupManagement/InviteRoleCheckboxes.js
+++ b/src/login/components/GroupManagement/InviteRoleCheckboxes.js
@@ -17,8 +17,8 @@ export const RenderCheckboxInput = ({
 }) => {
   const { error } = meta;
   const { onChange, value } = input;
-  const checkedStyling = value ? "checked" : null;
-  const disabledStyling = disabled ? "disabled" : null;
+  const checkedStyling = value ? "checked" : "";
+  const disabledStyling = disabled ? "disabled" : "";
   return (
     <Fragment>
       <div className="checkbox-label">


### PR DESCRIPTION
#### Description:
This is a fix to [PR568](https://github.com/SUNET/eduid-front/pull/568) that I merged by mistake (before fix was added). 
This fix replaces `null` into an empty string `""` for use to not show a className when values are false.

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

