### PR TITLE
Fix: ReferenceError in production

### DIFF
--- a/webpack.prod.config.js
+++ b/webpack.prod.config.js
@@ -44,18 +44,6 @@ webpackProd.plugins = [
     threshold: 10240,
     minRatio: 0.8
   }),
-  // new BundleAnalyzerPlugin()
-];
-
-webpackProd.mode = 'production';
-
-webpackProd.optimization = {
-  minimizer: [
-    new UglifyJsPlugin()
-  ],
-};
-
-webpackProd.plugins = [
   ...["errors", "login", "dashboard", "signup"].map((entryName) =>{
     return new HtmlWebpackPlugin({
       hash: true,
@@ -65,6 +53,14 @@ webpackProd.plugins = [
     })
   }),
 ];
+
+webpackProd.mode = 'production';
+
+webpackProd.optimization = {
+  minimizer: [
+    new UglifyJsPlugin()
+  ],
+};
 
 webpackProd.performance= {
   hints: false


### PR DESCRIPTION
#### Description:
Fix for referenceError in production 

- Remove one of the duplicated `webpackProd.plugins` array and add `htmlWebpackPlugin `within `initialConfigPlugin` in the array
#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

