### PR TITLE
LOGIN: Update to path that renders login form 

### DIFF
--- a/src/login/components/LoginApp/LoginApp.js
+++ b/src/login/components/LoginApp/LoginApp.js
@@ -10,13 +10,11 @@ class LoginApp extends Component {
 
     return (
       <div id="content" className="vertical-content-margin">
-        {url.includes(`login`) && (
-          <Route
-            exact
-            path={`/login/${urlCode}`}
-            render={(props) => <LoginForm {...props} />}
-          />
-        )}
+        <Route
+          exact
+          path={`/login/${urlCode}`}
+          render={(props) => <LoginForm {...props} />}
+        />
       </div>
     );
   }

--- a/src/login/components/LoginApp/LoginApp.js
+++ b/src/login/components/LoginApp/LoginApp.js
@@ -5,13 +5,18 @@ import { withRouter } from "react-router-dom";
 
 class LoginApp extends Component {
   render() {
+    const url = this.props.location.pathname;
+    const urlCode = url.split("/").reverse()[0];
+
     return (
       <div id="content" className="vertical-content-margin">
-        <Route
-          exact
-          path="/login/"
-          render={(props) => <LoginForm {...props} />}
-        />
+        {url.includes(`login`) && (
+          <Route
+            exact
+            path={`/login/${urlCode}`}
+            render={(props) => <LoginForm {...props} />}
+          />
+        )}
       </div>
     );
   }


### PR DESCRIPTION
#### Description:
This PR updates the path at which LoginForm renders to align with the new idp. 

> The updated login app will start with a reference at the end of the URL. The reference is only relevant for the login flow. It will be sent to the backend together with user credentials and enables the backend to evaluate what steps of security the user needs to complete to gain access to the end service. (**See at the bottom how to activate the updated idp**). **Remember to deactivate when working on other things!**

**Summary:**

The path at which the LoginForm renders is updated:  
 - from `/login/` 
 - to `/login/${urlCode}`

---

###### LoginForm renders with updated idp (ref in the URL and next_url in state.config)

<img width="500" alt="Screenshot 2021-05-26 at 11 49 41" src="https://user-images.githubusercontent.com/30963614/119640032-7cf73380-be18-11eb-985e-94151f7e965b.png">



---

**Accessing the updated idp**: 
1. Remove comment (`#`) from `login_bundle_url` in file `/opt/eduid/src/eduid-developer/config/config.yaml`:
```
  # uncomment login_bundle_url to enable the IdP API (and disable the template IdP)
  # login_bundle_url: https://login.eduid.docker/login
```
2. Restart `eduid_idp_1`
3. Go to log in 

**Remember to deactivate when working on other things.**

---

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

