### PR TITLE
RESETPASSWORD: Add return to login with url ref

### DIFF
--- a/src/login/components/LoginApp/LoginApp.js
+++ b/src/login/components/LoginApp/LoginApp.js
@@ -5,6 +5,18 @@ import { withRouter } from "react-router-dom";
 import ResetPasswordMain from "./ResetPassword/ResetPasswordMain";
 
 class LoginApp extends Component {
+  state = {
+    urlCode: "",
+  };
+
+  componentDidMount() {
+    const url = this.props.location.pathname;
+    const urlCode = url.split("/").reverse()[0];
+    this.setState(() => ({
+      urlCode: urlCode
+    }));
+  }
+
   render() {
     // all these paths need need to render the ResetPassword component, which in turn handles the logic of what is displayed at each path
     const resetPasswordPaths = [
@@ -27,20 +39,18 @@ class LoginApp extends Component {
         />
       );
     });
-    const url = this.props.location.pathname;
-    const urlCode = url.split("/").reverse()[0];
 
     return (
       <div id="content" className="vertical-content-margin">
         <Route
           exact
-          path={`/login/${urlCode}`}
+          path={`/login/${this.state.urlCode}`}
           render={(props) => <LoginForm {...props} />}
         />
         <Route
           exact
           path="/reset-password/"
-          component={ResetPasswordMain}
+          render={(props) => <ResetPasswordMain urlCode={this.state.urlCode} {...props} />}
         />
         {resetPasswordPages}
       </div>

--- a/src/login/components/LoginApp/ResetPassword/ResetPasswordForm.js
+++ b/src/login/components/LoginApp/ResetPassword/ResetPasswordForm.js
@@ -60,7 +60,7 @@ function ResetPasswordForm(props){
       <p className="heading">{props.translate("resetpw.heading-add-email")}</p>
       <EmailForm sendLink={sendLink} {...props} />
       <div className="return-login-link">
-        <a href={"/login"}>
+        <a href={`/login/${props.urlCode}`}>
           {props.translate("resetpw.return-login")}
         </a>
       </div>

--- a/src/login/components/LoginApp/ResetPassword/ResetPasswordMain.js
+++ b/src/login/components/LoginApp/ResetPassword/ResetPasswordMain.js
@@ -19,7 +19,7 @@ const ResetPasswordMain = (props) => {
   return (
     <>
       { 
-        url === `/reset-password/` ? <ResetPasswordForm {...props}/> : 
+        url === `/reset-password/` ? <ResetPasswordForm urlCode={props.urlCode} {...props}/> : 
         url ===`/reset-password/email-link-sent` ? <EmailLinkSent {...props}/> 
         : null
       }


### PR DESCRIPTION
#### Description:
This PR is for adjusting of reference url code.
Due to the lates change of the login url, there is an update to the URL link needed to return to login page by the return link button in reset password page.
Now when directed from the reset password page to the login page, the URL reference is included.

#### Summary:
- added setState urlCode on componentDidMount
- inject "urlCode" props to ResetPasswordForm
- changed href="login" to  href={`/login/${props.urlCode}`} in ResetPasswordForm.js

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

