### PR TITLE
LOGIN: Adds validation to password input  

### DIFF
--- a/src/login/app_utils/validation/emptyValueValidation.js
+++ b/src/login/app_utils/validation/emptyValueValidation.js
@@ -2,9 +2,14 @@ import { emptyStringPattern } from "./regexPatterns";
 
 export const emptyValueValidation = (values) => {
   const errors = {};
-  const groupName = values.groupName;
-  if (!groupName || emptyStringPattern.test(groupName)) {
-    errors.groupName = "required";
+  let inputValue = "";
+  let inputName = "";
+  if (values !== undefined) {
+    inputValue = Object.values(values)[0];
+    inputName = Object.keys(values)[0];
+  }
+  if (!inputValue || emptyStringPattern.test(inputValue)) {
+    errors[inputName] = "required";
   }
   return errors;
 };

--- a/src/login/components/GroupManagement/GroupNameForm.js
+++ b/src/login/components/GroupManagement/GroupNameForm.js
@@ -7,30 +7,40 @@ import EduIDButton from "../../../components/EduIDButton";
 import { emptyValueValidation } from "../../app_utils/validation/emptyValueValidation";
 import InjectIntl from "../../translation/InjectIntl_HOC_factory";
 
+export let RenderInput = ({
+  placeholder,
+  label,
+  required,
+  form,
+  helpBlock,
+  autoFocus,
+}) => (
+  <fieldset id={`${form}-fieldset`} className="tabpane">
+    <Field
+      label={label}
+      required={required}
+      component={CustomInput}
+      componentClass="input"
+      type="text"
+      name={form}
+      autoFocus={autoFocus}
+      placeholder={placeholder}
+      helpBlock={helpBlock}
+    />
+  </fieldset>
+);
+
 let GroupNameForm = (props) => {
   const {
     handleSubmit,
     invalid,
     form,
-    label,
-    placeholder,
-    helpBlock,
     submitButton,
   } = props;
 
   return (
     <Form id={`${form}-form`} role="form" onSubmit={handleSubmit}>
-      <fieldset id={`${form}-fieldset`} className="tabpane">
-        <Field
-          label={label}
-          component={CustomInput}
-          componentClass="input"
-          type="text"
-          name={form}
-          placeholder={placeholder}
-          helpBlock={helpBlock}
-        />
-      </fieldset>
+      <RenderInput {...props} />
       {submitButton && (
         <EduIDButton
           type="submit"

--- a/src/login/components/GroupManagement/GroupNameForm.js
+++ b/src/login/components/GroupManagement/GroupNameForm.js
@@ -13,7 +13,6 @@ export let RenderInput = ({
   required,
   form,
   helpBlock,
-  autoFocus,
 }) => (
   <fieldset id={`${form}-fieldset`} className="tabpane">
     <Field
@@ -23,7 +22,6 @@ export let RenderInput = ({
       componentClass="input"
       type="text"
       name={form}
-      autoFocus={autoFocus}
       placeholder={placeholder}
       helpBlock={helpBlock}
     />

--- a/src/login/components/LoginApp/Login/Login.js
+++ b/src/login/components/LoginApp/Login/Login.js
@@ -4,6 +4,7 @@ import LinkRedirect from "../../Links/LinkRedirect";
 import Link from "../../Links/Link";
 import LoginForm from "./LoginForm";
 import InjectIntl from "../../../translation/InjectIntl_HOC_factory";
+import ButtonPrimary from "../../Buttons/ButtonPrimary";
 
 const RenderRegisterLink = () => (
   <p>
@@ -11,7 +12,7 @@ const RenderRegisterLink = () => (
     <Link
       className={"text-link"}
       href={`https://signup.eduid.se/`}
-      text={"Register here"}
+      text={"Register here."}
     />
   </p>
 );
@@ -22,22 +23,33 @@ const RenderResetPasswordLink = () => (
     id={"link-forgot-password"}
     className={""}
     to={`/reset-password/`}
-    text={"Set a new password"}
+    text={"Forgot your password?"}
   />
 );
 
 const Login = (props) => (
   <Fragment>
     <p className="heading">Log in</p>
-    <LoginForm {...props} />
+    <div>
+      <LoginForm {...props} />
+      <RenderResetPasswordLink />
+      <div>
+        <ButtonPrimary
+          type={"submit"}
+          onClick={() => {}}
+          id={""}
+          className={"settings-button"}
+        >
+          Log in
+        </ButtonPrimary>
+      </div>
+    </div>
     <RenderRegisterLink />
-    <RenderResetPasswordLink />
   </Fragment>
 );
 
 Login.propTypes = {
   translate: PropTypes.func,
-  validate: PropTypes.func,
 };
 
 export default InjectIntl(Login);

--- a/src/login/components/LoginApp/Login/LoginForm.js
+++ b/src/login/components/LoginApp/Login/LoginForm.js
@@ -5,14 +5,14 @@ import Form from "reactstrap/lib/Form";
 import { RenderEmailInput } from "../../GroupManagement/EmailForm";
 import { RenderInput } from "../../GroupManagement/GroupNameForm";
 import { validate } from "../../../app_utils/validation/validateEmail";
+import { emptyValueValidation } from "../../../app_utils/validation/emptyValueValidation";
 import InjectIntl from "../../../translation/InjectIntl_HOC_factory";
 
 const validateLoginForm = (values) => {
   let errors = {};
-  if (values ?? undefined) {
-    const { username } = values;
-    errors.username = validate(username);
-  }
+  const { username, credentials } = values;
+  errors.username = validate(username);
+  errors.credentials = emptyValueValidation(credentials);
   return errors;
 };
 
@@ -27,7 +27,7 @@ let LoginForm = (props) => {
           autoFocus={true}
         />
       </FormSection>
-      <FormSection name={"loginPassword"}>
+      <FormSection name={"credentials"}>
         <RenderInput
           form={"password"}
           label={"Password"}
@@ -49,7 +49,7 @@ LoginForm = reduxForm({
 LoginForm = connect(() => ({
   initialValues: {
     username: { email: "" },
-    loginPassword: { password: "" },
+    credentials: { password: "" },
   },
   destroyOnUnmount: false,
   touchOnChange: true,

--- a/src/login/components/LoginApp/Login/LoginForm.js
+++ b/src/login/components/LoginApp/Login/LoginForm.js
@@ -1,48 +1,58 @@
-import React, { Fragment } from "react";
+import React from "react";
 import { connect } from "react-redux";
-import { reduxForm } from "redux-form";
-import EmailForm from "../../GroupManagement/EmailForm";
-import PasswordFormMock from "../../GroupManagement/GroupNameForm";
-import ButtonPrimary from "../../Buttons/ButtonPrimary";
+import { reduxForm, FormSection } from "redux-form";
+import Form from "reactstrap/lib/Form";
+import { RenderEmailInput } from "../../GroupManagement/EmailForm";
+import { RenderInput } from "../../GroupManagement/GroupNameForm";
 import { validate } from "../../../app_utils/validation/validateEmail";
 import InjectIntl from "../../../translation/InjectIntl_HOC_factory";
 
+const validateLoginForm = (values) => {
+  let errors = {};
+  if (values ?? undefined) {
+    const { username } = values;
+    errors.username = validate(username);
+  }
+  return errors;
+};
+
 let LoginForm = (props) => {
   return (
-    <Fragment>
-      <EmailForm
-        {...props}
-        required={true}
-        submitButton={false}
-        onSubmit={() => {}}
-      />
-      <PasswordFormMock
-        form={"password"}
-        label={"Password"}
-        submitButton={false}
-        placeholder={"Enter a password"}
-        helpBlock={""}
-        handleSubmit={() => {}}
-      />
-      <ButtonPrimary
-        type={"submit"}
-        onClick={() => {}}
-        id={""}
-        className={"settings-button"}
-      >
-        Log in
-      </ButtonPrimary>
-    </Fragment>
+    <Form id={"create-invite-form"} role="form" onSubmit={() => {}}>
+      <FormSection name={"username"}>
+        <RenderEmailInput
+          {...props}
+          submitButton={false}
+          required={true}
+          autoFocus={true}
+        />
+      </FormSection>
+      <FormSection name={"loginPassword"}>
+        <RenderInput
+          form={"password"}
+          label={"Password"}
+          submitButton={false}
+          placeholder={"enter a password"}
+          helpBlock={""}
+          handleSubmit={() => {}}
+        />
+      </FormSection>
+    </Form>
   );
 };
 
 LoginForm = reduxForm({
   form: "loginForm",
-  validate,
+  validate: validateLoginForm,
 })(LoginForm);
 
 LoginForm = connect(() => ({
-  enableReinitialize: true,
+  initialValues: {
+    username: { email: "" },
+    loginPassword: { password: "" },
+  },
+  destroyOnUnmount: false,
+  touchOnChange: true,
 }))(LoginForm);
 
 export default InjectIntl(LoginForm);

--- a/src/login/components/LoginApp/Login/LoginForm.js
+++ b/src/login/components/LoginApp/Login/LoginForm.js
@@ -24,7 +24,6 @@ let LoginForm = (props) => {
           {...props}
           submitButton={false}
           required={true}
-          autoFocus={true}
         />
       </FormSection>
       <FormSection name={"credentials"}>

--- a/src/tests/validation/emptyValueValidation-test.js
+++ b/src/tests/validation/emptyValueValidation-test.js
@@ -1,0 +1,52 @@
+import expect from "expect";
+import { emptyValueValidation } from "../../login/app_utils/validation/emptyValueValidation";
+
+// input values
+let anyValue = { key: "anyValue" };
+let minmalValue = { key: "X" };
+let noPasswordValue = { password: "" };
+let noGroupNameValue = { groupName: "" };
+
+// expected error replies
+const valid = {};
+const pwRequiredError = { password: "required" };
+const groupNameRequiredError = { groupName: "required" };
+
+describe("emptyValueValidation indicates a valid answer if any value", () => {
+  it("with password value", () => {
+    let validation = emptyValueValidation(anyValue);
+    expect(validation).toEqual(valid);
+  });
+
+  it("with minimal value", () => {
+    let validation = emptyValueValidation(minmalValue);
+    expect(validation).toEqual(valid);
+  });
+});
+
+describe("emptyValueValidation indicates an error if no value", () => {
+  it("without password value", () => {
+    let validation = emptyValueValidation(noPasswordValue);
+    expect(validation).toEqual(pwRequiredError);
+  });
+
+  it("without group name value", () => {
+    let validation = emptyValueValidation(noGroupNameValue);
+    expect(validation).toEqual(groupNameRequiredError);
+  });
+});
+
+describe("emptyValueValidation returns an error object with a value for a specific key", () => {
+  it("error specific for the key 'password'", () => {
+    let validation = emptyValueValidation(noPasswordValue);
+    expect(validation).toEqual(pwRequiredError);
+    expect(validation).not.toEqual(groupNameRequiredError);
+  });
+
+  it("error specific for the key 'group name'", () => {
+    let validation = emptyValueValidation(noGroupNameValue);
+    expect(validation).toEqual(groupNameRequiredError);
+    expect(validation).not.toEqual(pwRequiredError);
+  });
+
+});


### PR DESCRIPTION
#### Description:
This PR adds validation to the password input in the login form.

**Summary**: 

1. Second validation added to `LoginForm`
   - `emptyValueValidation` added to the password input 
 
2. validation of empty values is refactored 
   - used both for group names and password 
   - function has been made generic to fit any input 
 
3. Tests added to validation
   - ensure that the validation returns expected errors at different inputs
   - check that the function is generic

**Known limitations**:

- no functionality other than validation of email address has been added
- the submit button does not work yet
- the input values are not passed anywhere
- the styling is not final
- behaviour of inputs not final

---
###### error message on no password value
<img width="500" alt="Screenshot 2021-05-31 at 18 00 18" src="https://user-images.githubusercontent.com/30963614/120292748-d94cce00-c2c4-11eb-88c1-d0b0e9cad64e.png">

###### success indicator on any value
<img width="500" alt="Screenshot 2021-05-31 at 18 00 29" src="https://user-images.githubusercontent.com/30963614/120292625-c1754a00-c2c4-11eb-825c-c4f14fe8cb99.png"> 

---



#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

