### PR TITLE
LOGIN: Adds prop types to props relevant to username and password page

### DIFF
--- a/src/login/components/Inputs/EmailInput.js
+++ b/src/login/components/Inputs/EmailInput.js
@@ -1,8 +1,8 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { Field } from "redux-form";
 import CustomInput from "./CustomInput";
 import InjectIntl from "../../translation/InjectIntl_HOC_factory";
+import PropTypes from "prop-types";
 
 let EmailInput = ({ translate, required, autoFocus }) => (
   <Field
@@ -21,8 +21,9 @@ let EmailInput = ({ translate, required, autoFocus }) => (
 );
 
 EmailInput.propTypes = {
-  translate: PropTypes.func,
-  validate: PropTypes.func,
+  translate: PropTypes.func.isRequired,
+  required: PropTypes.bool,
+  autoFocus: PropTypes.bool,
 };
 
 export default InjectIntl(EmailInput);

--- a/src/login/components/Inputs/InputWithIcons.js
+++ b/src/login/components/Inputs/InputWithIcons.js
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import Input from "reactstrap/lib/Input";
 import InjectIntl from "../../translation/InjectIntl_HOC_factory";
+import PropTypes from "prop-types";
 
 let RenderHidePasswordIcon = ({ setInputType, translate }) => (
   <button
@@ -62,6 +63,19 @@ let InputWithIcons = (props) => {
       ) : null}
     </div>
   );
+};
+
+InputWithIcons.propTypes = {
+  input: PropTypes.object,
+  name: PropTypes.string.isRequired,
+  disable: PropTypes.bool,
+  placeholder: PropTypes.string,
+  valid: PropTypes.bool,
+  invalid: PropTypes.bool,
+  autoComplete: PropTypes.string,
+  autoFocus: PropTypes.bool,
+  ariaLabel: PropTypes.string,
+  required: PropTypes.bool,
 };
 
 export default InjectIntl(InputWithIcons);

--- a/src/login/components/Inputs/PasswordInput.js
+++ b/src/login/components/Inputs/PasswordInput.js
@@ -1,8 +1,8 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { Field } from "redux-form";
 import CustomInput from "./CustomInput";
 import InjectIntl from "../../translation/InjectIntl_HOC_factory";
+import PropTypes from "prop-types";
 
 let PasswordInput = ({ required, translate }) => {
   return (
@@ -20,8 +20,8 @@ let PasswordInput = ({ required, translate }) => {
 };
 
 PasswordInput.propTypes = {
-  translate: PropTypes.func,
-  validate: PropTypes.func,
+  translate: PropTypes.func.isRequired,
+  required: PropTypes.bool,
 };
 
 export default InjectIntl(PasswordInput);

--- a/src/login/components/LoginApp/Login/Login.js
+++ b/src/login/components/LoginApp/Login/Login.js
@@ -1,11 +1,11 @@
 import React, { Fragment, useEffect } from "react";
 import { useSelector } from "react-redux";
 import { useHistory } from "react-router-dom";
-import PropTypes from "prop-types";
 import UsernamePw from "./UsernamePw";
 import TermOfUse from "./TermsOfUse";
 import MultiFactorAuth from "./MultiFactorAuth";
 import InjectIntl from "../../../translation/InjectIntl_HOC_factory";
+import PropTypes from "prop-types";
 
 const Login = (props) => {
   // update url when next_page changes
@@ -35,7 +35,8 @@ const Login = (props) => {
 };
 
 Login.propTypes = {
-  translate: PropTypes.func,
+  history: PropTypes.object.isRequired,
+  location: PropTypes.shape({ pathname: PropTypes.string.isRequired }),
 };
 
 export default InjectIntl(Login);

--- a/src/login/components/LoginApp/Login/UsernamePw.js
+++ b/src/login/components/LoginApp/Login/UsernamePw.js
@@ -1,5 +1,4 @@
 import React from "react";
-import PropTypes from "prop-types";
 import { useSelector } from "react-redux";
 import { reduxForm, submit } from "redux-form";
 import LinkRedirect from "../../Links/LinkRedirect";
@@ -7,6 +6,7 @@ import Link from "../../Links/Link";
 import UsernamePwForm from "./UsernamePwForm";
 import InjectIntl from "../../../translation/InjectIntl_HOC_factory";
 import ButtonPrimary from "../../Buttons/ButtonPrimary";
+import PropTypes from "prop-types";
 
 const RenderRegisterLink = ({ translate }) => (
   <p className="secondary-link">
@@ -50,6 +50,8 @@ let UsernamePwFormButton = ({ invalid, dispatch, translate }) => {
 UsernamePwFormButton = reduxForm({
   form: "usernamePwForm",
   destroyOnUnmount: false,
+  invalid: PropTypes.func.isRequired,
+  dispatch: PropTypes.func.isRequired,
 })(UsernamePwFormButton);
 
 const UsernamePw = (props) => {
@@ -69,7 +71,16 @@ const UsernamePw = (props) => {
 };
 
 UsernamePw.propTypes = {
-  translate: PropTypes.func,
+  translate: PropTypes.func.isRequired,
+};
+UsernamePwFormButton.propTypes = {
+  translate: PropTypes.func.isRequired,
+};
+RenderResetPasswordLink.propTypes = {
+  translate: PropTypes.func.isRequired,
+};
+RenderRegisterLink.propTypes = {
+  translate: PropTypes.func.isRequired,
 };
 
 export default InjectIntl(UsernamePw);

--- a/src/login/components/LoginApp/Login/UsernamePwForm.js
+++ b/src/login/components/LoginApp/Login/UsernamePwForm.js
@@ -8,6 +8,7 @@ import { validate } from "../../../app_utils/validation/validateEmail";
 import emptyValueValidation from "../../../app_utils/validation/emptyValueValidation";
 import InjectIntl from "../../../translation/InjectIntl_HOC_factory";
 import { postUsernamePassword } from "../../../redux/actions/postUsernamePasswordActions";
+import PropTypes from "prop-types";
 
 export const submitUsernamePassword = (values, dispatch) => {
   const { email, "current-password": currentPassword } = values;
@@ -28,25 +29,16 @@ export const validateLoginForm = (values) => {
   return errors;
 };
 
-let UsernamePwForm = (props) => {
-  return (
-    <Form
-      id="login-form"
-      aria-label="login form"
-      onSubmit={submitUsernamePassword}
-    >
-      <EmailInput
-        {...props}
-        autoFocus={true}
-        required={true}
-      />
-      <PasswordInput
-        {...props}
-        required={true}
-      />
-    </Form>
-  );
-};
+let UsernamePwForm = (props) => (
+  <Form
+    id="login-form"
+    aria-label="login form"
+    onSubmit={submitUsernamePassword}
+  >
+    <EmailInput {...props} autoFocus={true} required={true} />
+    <PasswordInput {...props} required={true} />
+  </Form>
+);
 
 UsernamePwForm = reduxForm({
   form: "usernamePwForm",
@@ -62,5 +54,9 @@ UsernamePwForm = connect(() => ({
   destroyOnUnmount: false,
   touchOnChange: true,
 }))(UsernamePwForm);
+
+UsernamePwForm.propTypes = {
+  translate: PropTypes.func.isRequired,
+};
 
 export default InjectIntl(UsernamePwForm);

--- a/src/login/components/LoginApp/LoginApp.js
+++ b/src/login/components/LoginApp/LoginApp.js
@@ -6,6 +6,7 @@ import Login from "./Login/Login";
 import { useLoginRef } from "../../redux/actions/postRefLoginActions";
 import ResetPasswordForm from "./ResetPassword/ResetPasswordForm";
 import EmailLinkSent from "./ResetPassword/EmailLinkSent";
+import PropTypes from "prop-types";
 
 const RenderResetPassword = (props) => {
   const { urlCode } = props;
@@ -61,6 +62,8 @@ class LoginApp extends Component {
   }
 }
 
-LoginApp.propTypes = {};
+LoginApp.propTypes = {
+  location: PropTypes.shape({ pathname: PropTypes.string.isRequired }),
+};
 
 export default withRouter(LoginApp);


### PR DESCRIPTION
#### Description:
This PR adds prop types to relevant props. For props crucial to render logic `.isRequired` has been added.

**Summary**:

1. prop types added to files: 

    - LoginApp/Login
    - UsernamePw/UsernamePwForm
    - EmailInput/PasswordInput
    - InputWithIcon

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

