### PR TITLE
LOGIN: Render text on terms of use page

### DIFF
--- a/src/login/components/Inputs/InputToggleShowHide.js
+++ b/src/login/components/Inputs/InputToggleShowHide.js
@@ -78,4 +78,4 @@ InputToggleShowHide.propTypes = {
   required: PropTypes.bool,
 };
 
-export default InjectIntl(InputToggleShowHides);
+export default InjectIntl(InputToggleShowHide);

--- a/src/login/components/LoginApp/Login/Login.js
+++ b/src/login/components/LoginApp/Login/Login.js
@@ -35,8 +35,8 @@ const Login = (props) => {
 };
 
 Login.propTypes = {
-  history: PropTypes.object.isRequired,
-  location: PropTypes.shape({ pathname: PropTypes.string.isRequired }),
+  history: PropTypes.object,
+  location: PropTypes.shape({ pathname: PropTypes.string }),
 };
 
 export default InjectIntl(Login);

--- a/src/login/components/LoginApp/Login/TermsOfUse.js
+++ b/src/login/components/LoginApp/Login/TermsOfUse.js
@@ -1,12 +1,90 @@
-import React from "react";
+import React, { Fragment } from "react";
+import ButtonPrimary from "../../Buttons/ButtonPrimary";
 import PropTypes from "prop-types";
 import InjectIntl from "../../../translation/InjectIntl_HOC_factory";
 
+let TermOfUseText = () => (
+  <div className="tou-text">
+    <p className="heading">General rules for eduID users:</p>
+    <ul>
+      <p>The following generally applies:</p>
+      <li>
+        <p>that all usage of user accounts follow Sweden's laws and by-laws,</p>
+      </li>
+      <li>
+        <p>
+          that all personal information that you provide, such as name and
+          contact information shall be truthful,
+        </p>
+      </li>
+      <li>
+        <p>
+          that user accounts, password and codes are individual and shall only
+          be used by the intended individual,
+        </p>
+      </li>
+      <li>
+        <p>that SUNET's ethical rules regulate the "other" usage.</p>
+      </li>
+    </ul>
+    <ul>
+      <p>SUNET judges unethical behaviour to be when someone:</p>
+      <li>
+        <p>
+          attempts to gain access to network resources that they do not have the
+          right
+        </p>
+      </li>
+      <li>
+        <p>attempts to conceal their user identity</p>
+      </li>
+      <li>
+        <p>
+          attempts to interfere or disrupt the intended usage of the network
+        </p>
+      </li>
+      <li>
+        <p>
+          clearly wastes available resources (personnel, hardware or software)
+        </p>
+      </li>
+      <li>
+        <p>attempts to disrupt or destroy computer-based information</p>
+      </li>
+      <li>
+        <p>infringes on the privacy of others</p>
+      </li>
+      <li>
+        <p>attempts to insult or offend others</p>
+      </li>
+    </ul>
+    <p className="heading">
+      Any person found violating or suspected of violating these rules can be
+      disabled from eduID.se for investigation. Furthermore, legal action can be
+      taken.
+    </p>
+  </div>
+);
+let AcceptButton = ({ loading, translate }) => (
+  <ButtonPrimary
+    type="submit"
+    onClick={() => {}}
+    disabled={loading}
+    aria-disabled={loading}
+    id="accept-button"
+  >
+    accept
+  </ButtonPrimary>
+);
+
 let TermOfUse = (props) => {
+  const { loading, translate } = props;
   return (
     <div className="tou">
-      <h2 className="heading">{props.translate("login.tou.h2-heading")}</h2>
-      <p>{props.translate("login.tou.paragraph")}</p>
+      <h2 className="heading">{translate("login.tou.h2-heading")}</h2>
+      <p>{translate("login.tou.paragraph")}</p>
+      <TermOfUseText />
+      <AcceptButton loading={loading} translate={translate} />
     </div>
   );
 };

--- a/src/login/components/LoginApp/Login/TermsOfUse.js
+++ b/src/login/components/LoginApp/Login/TermsOfUse.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React from "react";
 import ButtonPrimary from "../../Buttons/ButtonPrimary";
 import PropTypes from "prop-types";
 import InjectIntl from "../../../translation/InjectIntl_HOC_factory";
@@ -9,7 +9,9 @@ let TermOfUseText = () => (
     <ul>
       <p>The following generally applies:</p>
       <li>
-        <p>that all usage of user accounts follow Sweden's laws and by-laws,</p>
+        <p>
+          that all usage of user accounts follow Sweden&apos;s laws and by-laws,
+        </p>
       </li>
       <li>
         <p>
@@ -24,7 +26,10 @@ let TermOfUseText = () => (
         </p>
       </li>
       <li>
-        <p>that SUNET's ethical rules regulate the "other" usage.</p>
+        <p>
+          that SUNET&apos;s ethical rules regulate the &ldquo;other&ldquo;
+          usage.
+        </p>
       </li>
     </ul>
     <ul>
@@ -65,7 +70,7 @@ let TermOfUseText = () => (
     </p>
   </div>
 );
-let AcceptButton = ({ loading, translate }) => (
+let AcceptButton = ({ loading }) => (
   <ButtonPrimary
     type="submit"
     onClick={() => {}}

--- a/src/login/components/LoginApp/Login/UsernamePw.js
+++ b/src/login/components/LoginApp/Login/UsernamePw.js
@@ -56,7 +56,7 @@ UsernamePwFormButton = reduxForm({
 
 const UsernamePw = (props) => {
   return (
-    <div className="login">
+    <div className="username-pw">
       <h2 className="heading">
         {props.translate("login.usernamePw.h2-heading")}
       </h2>

--- a/src/login/styles/_Login.scss
+++ b/src/login/styles/_Login.scss
@@ -1,11 +1,19 @@
 @import "./variables.scss";
 
-.login {
+.username-pw,
+.tou {
   display: flex;
   flex-direction: column;
   .heading {
     line-height: $line-height;
   }
+  button {
+    width: fit-content;
+  }
+}
+
+// usename and password page
+.username-pw {
   form {
     margin-top: 0;
     .form-group {
@@ -31,13 +39,35 @@
         right: 3rem;
       }
     }
-  }
-  button {
-    margin: 0.25rem 0 3rem;
+    button {
+      margin: 0.25rem 0 3rem;
+    }
   }
   .secondary-link {
     font-size: 1rem;
     align-self: flex-end;
+  }
+}
+
+// terms of use page
+.tou {
+  .tou-text {
+    margin-bottom: 1rem;
+    p {
+      line-height: $line-height;
+      margin-bottom: 0;
+      padding-bottom: 0;
+    }
+    ul {
+      margin-bottom: #{1rem * $line-height};
+      list-style-type: disc;
+      li {
+        margin: 0 1.5rem;
+      }
+    }
+  }
+  button {
+    align-self: center;
   }
 }
 


### PR DESCRIPTION
#### Description:
This PR adds terms of use text and button to the /tou/ page.

**Summary**: 

1. Renders hardcoded terms of use text 
2. Adds styling
   - the _Login.scss file has been refactored

> Note: Due to the current forced page flow (usernamePw > tou> mfa) adding incorrect details currently allows users to advance to the Terms of use page

**Known limitations**: 
- The text is currently hardcoded in the component
- The accept button does not work 
- Reloading the terms of use page takes the user back to the start of the forced login flow 

---

###### Terms of use page (top half)
<img width="500" alt="Screenshot 2021-06-18 at 12 10 43" src="https://user-images.githubusercontent.com/30963614/122547025-e3dec580-d02f-11eb-9795-ae13d2ce666c.png">

###### Terms of use page (bottom half)
<img width="500" alt="Screenshot 2021-06-18 at 12 11 04" src="https://user-images.githubusercontent.com/30963614/122547038-e6411f80-d02f-11eb-8010-0af0d2c0670e.png">

---

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

