### PR TITLE
Relocating of password-input to common styling to use in both login and reset password

### DIFF
--- a/src/login/styles/_Login.scss
+++ b/src/login/styles/_Login.scss
@@ -29,28 +29,6 @@
   }
 }
 
-// login username-pw / set-new-password toggle show hide 
-.password-input {
-  display: flex;
-  .show-hide-button {
-    color: $black;
-    font-size: 1rem;
-    position: absolute;
-    right: 1rem;
-    background: transparent;
-    height: 3rem;
-    border-radius: 0;
-    padding: 0;
-    margin: 0;
-    box-shadow: 0 0 0;
-    border: none;
-    cursor: pointer;
-  }
-  .is-valid ~ .icon {
-    right: 3rem;
-  }
-}
-
 // terms of use page
 .tou {
   .tou-text {

--- a/src/login/styles/_inputs.scss
+++ b/src/login/styles/_inputs.scss
@@ -129,6 +129,28 @@ input:focus {
   color: $orange-highlight;
 }
 
+// login username-pw / reset-password set-new-password
+.password-input {
+  display: flex;
+  .show-hide-button {
+    color: $black;
+    font-size: 1rem;
+    position: absolute;
+    right: 1rem;
+    background: transparent;
+    height: 3rem;
+    border-radius: 0;
+    padding: 0;
+    margin: 0;
+    box-shadow: 0 0 0;
+    border: none;
+    cursor: pointer;
+  }
+  .is-valid ~ .icon {
+    right: 3rem;
+  }
+}
+
 @media (max-width: 568px) {
   .form-control,
   input,

--- a/src/login/styles/_inputs.scss
+++ b/src/login/styles/_inputs.scss
@@ -146,7 +146,7 @@ input:focus {
     border: none;
     cursor: pointer;
   }
-  .is-valid ~ .icon {
+  .is-valid ~ .show-hide-button {
     right: 3rem;
   }
 }


### PR DESCRIPTION
#### Summary:
Relocate `.password-input `styling code from `_Login.scss` to` _inputs.scss` 
#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

