### PR TITLE
LOGIN: Adds completion of login process with security key

### DIFF
--- a/src/login/components/LoginApp/Login/Login.js
+++ b/src/login/components/LoginApp/Login/Login.js
@@ -4,11 +4,11 @@ import { useHistory } from "react-router-dom";
 import UsernamePw from "./UsernamePw";
 import TermOfUse from "./TermsOfUse";
 import MultiFactorAuth from "./MultiFactorAuth";
+import SubmitSamlResponse from "./SubmitSamlResponse";
 import InjectIntl from "../../../translation/InjectIntl_HOC_factory";
 import PropTypes from "prop-types";
 
 const Login = (props) => {
-  // update url when next_page changes
   let history = useHistory();
   const next_page = useSelector((state) => state.login.next_page);
   const ref = useSelector((state) => state.login.ref);
@@ -19,8 +19,6 @@ const Login = (props) => {
       history.push(`/login/tou/${ref}`);
     } else if (next_page === "MFA") {
       history.push(`/login/mfa/${ref}`);
-    } else if (next_page === "FINISHED") {
-      history.push(`/login/finished/`);
     }
   }, [next_page]);
   return (
@@ -31,6 +29,8 @@ const Login = (props) => {
         <TermOfUse {...props} />
       ) : next_page === "MFA" ? (
         <MultiFactorAuth {...props} />
+      ) : next_page === "FINISHED" ? (
+        <SubmitSamlResponse />
       ) : null}
     </Fragment>
   );

--- a/src/login/components/LoginApp/Login/SubmitSamlResponse.js
+++ b/src/login/components/LoginApp/Login/SubmitSamlResponse.js
@@ -1,0 +1,26 @@
+import React, { useEffect } from "react";
+import { useSelector } from "react-redux"
+import InjectIntl from "../../../translation/InjectIntl_HOC_factory";
+
+const SubmitSamlResponse = () => {
+  const SAMLResponse = useSelector(
+    (state) => state.login.mfa.parameters.SAMLResponse
+  );
+  const targetUrl = useSelector((state) => state.login.post_to);
+
+  useEffect(() => {
+    document.forms[0].submit();
+  })
+
+  return (
+    <form action={targetUrl} method="post">
+      <input type="hidden" name="SAMLResponse" value={SAMLResponse} />
+      <noscript>
+        <input type="submit" value="Continue" />
+      </noscript>
+    </form>
+  );
+};
+
+
+export default InjectIntl(SubmitSamlResponse);

--- a/src/login/redux/actions/postRefLoginActions.js
+++ b/src/login/redux/actions/postRefLoginActions.js
@@ -13,29 +13,28 @@ export function postRefFail(err) {
     type: POST_IDP_NEXT_FAIL,
     error: true,
     payload: {
-      error: err,
       message: err,
     },
   };
 }
 
 // mock actions to trigger a set order of redirects
-export const NEXT_MOCK_URL_TOU = "NEXT_MOCK_URL_TOU";
-export const NEXT_MOCK_URL_MFA = "NEXT_MOCK_URL_MFA";
-export const NEXT_MOCK_URL_FINISHED = "NEXT_MOCK_URL_FINISHED";
+// export const NEXT_MOCK_URL_TOU = "NEXT_MOCK_URL_TOU";
+// export const NEXT_MOCK_URL_MFA = "NEXT_MOCK_URL_MFA";
+// export const NEXT_MOCK_URL_FINISHED = "NEXT_MOCK_URL_FINISHED";
 
-export function nextMockUrlTou() {
-  return {
-    type: NEXT_MOCK_URL_TOU,
-  };
-}
-export function nextMockUrlMfa() {
-  return {
-    type: NEXT_MOCK_URL_MFA,
-  };
-}
-export function nextMockUrlFinished() {
-  return {
-    type: NEXT_MOCK_URL_FINISHED,
-  };
-}
+// export function nextMockUrlTou() {
+//   return {
+//     type: NEXT_MOCK_URL_TOU,
+//   };
+// }
+// export function nextMockUrlMfa() {
+//   return {
+//     type: NEXT_MOCK_URL_MFA,
+//   };
+// }
+// export function nextMockUrlFinished() {
+//   return {
+//     type: NEXT_MOCK_URL_FINISHED,
+//   };
+// }

--- a/src/login/redux/actions/postUpdatedTouAcceptActions.js
+++ b/src/login/redux/actions/postUpdatedTouAcceptActions.js
@@ -16,7 +16,6 @@ export function updateTouAcceptFail(err) {
     type: POST_IDP_TOU_FAIL,
     error: true,
     payload: {
-      error: err,
       message: err,
     },
   };

--- a/src/login/redux/actions/postUsernamePasswordActions.js
+++ b/src/login/redux/actions/postUsernamePasswordActions.js
@@ -17,7 +17,6 @@ export function postUsernamePasswordFail(err) {
     type: POST_IDP_PW_AUTH_FAIL,
     error: true,
     payload: {
-      error: err,
       message: err,
     },
   };

--- a/src/login/redux/reducers/loginReducer.js
+++ b/src/login/redux/reducers/loginReducer.js
@@ -13,6 +13,7 @@ const loginData = {
   mfa: {
     webauthn_challenge: null,
     webauthn_assertion: null,
+    parameters: null,
   },
   tou: {},
 };
@@ -25,27 +26,33 @@ let loginReducer = (state = loginData, action) => {
         ref: action.payload.ref,
       };
     case nextPageActions.POST_IDP_NEXT_SUCCESS:
+      const samlParameters =
+        action.payload.action === "FINISHED" ? action.payload.parameters : null;
       return {
         ...state,
-        next_page: "USERNAMEPASSWORD",
-        // next_page: action.payload.action,
-        // post_to: action.payload.target,
+        // next_page: "USERNAMEPASSWORD",
+        next_page: action.payload.action,
+        post_to: action.payload.target,
+        mfa: {
+          ...state.mfa,
+          parameters: samlParameters,
+        },
       };
-    case nextPageActions.NEXT_MOCK_URL_TOU:
-      return {
-        ...state,
-        next_page: "TOU",
-      };
-    case nextPageActions.NEXT_MOCK_URL_MFA:
-      return {
-        ...state,
-        next_page: "MFA",
-      };
-    case nextPageActions.NEXT_MOCK_URL_FINISHED:
-      return {
-        ...state,
-        next_page: "FINISHED",
-      };
+    // case nextPageActions.NEXT_MOCK_URL_TOU:
+    //   return {
+    //     ...state,
+    //     next_page: "TOU",
+    //   };
+    // case nextPageActions.NEXT_MOCK_URL_MFA:
+    //   return {
+    //     ...state,
+    //     next_page: "MFA",
+    //   };
+    // case nextPageActions.NEXT_MOCK_URL_FINISHED:
+    //   return {
+    //     ...state,
+    //     next_page: "FINISHED",
+    //   };
     case usernamePasswordActions.POST_IDP_PW_AUTH_SUCCESS:
       return {
         ...state,

--- a/src/login/redux/sagas/login/postUpdatedTouAcceptSaga.js
+++ b/src/login/redux/sagas/login/postUpdatedTouAcceptSaga.js
@@ -2,38 +2,30 @@ import { call, select, put } from "redux-saga/effects";
 import postRequest from "../postDataRequest";
 import { putCsrfToken } from "../../../../sagas/common";
 import * as actions from "../../actions/postUpdatedTouAcceptActions";
-import { nextMockUrlMfa } from "../../actions/postRefLoginActions";
-import {
-  loadingData,
-  loadingDataComplete,
-} from "../../actions/loadingDataActions";
-import { eduidRMAllNotify } from "../../../../actions/Notifications";
+import { useLoginRef } from "../../actions/postRefLoginActions";
+// import { nextMockUrlMfa } from "../../actions/postRefLoginActions";
 
 export function* postUpdatedTouAcceptSaga(action) {
   const state = yield select((state) => state);
   const url = "https://idp.eduid.docker/tou";
+  const dataToSend = {
+    ref: state.login.ref,
+    csrf_token: state.config.csrf_token,
+    user_accepts: action.payload.user_accepts,
+  };
   try {
-    const dataToSend = {
-      ref: state.login.ref,
-      csrf_token: state.config.csrf_token,
-      user_accepts: action.payload.user_accepts,
-    };
-    yield put(eduidRMAllNotify());
-    yield put(loadingData());
     const postUpdatedTouAcceptResponse = yield call(
       postRequest,
       url,
       dataToSend
     );
     yield put(putCsrfToken(postUpdatedTouAcceptResponse));
-    yield put(postUpdatedTouAcceptResponse);
-    yield put(loadingDataComplete());
     if (postUpdatedTouAcceptResponse.payload.finished) {
-      yield put(nextMockUrlMfa());
+      // MOCK: forced navigation to mfa
+      // yield put(nextMockUrlMfa());
+      yield put(useLoginRef());
     }
   } catch (error) {
-    console.log(error);
     yield put(actions.updateTouAcceptFail(error.toString()));
-    yield put(loadingDataComplete());
   }
 }

--- a/src/login/redux/sagas/login/postUsernamePasswordSaga.js
+++ b/src/login/redux/sagas/login/postUsernamePasswordSaga.js
@@ -2,7 +2,8 @@ import { call, select, put } from "redux-saga/effects";
 import postRequest from "../postDataRequest";
 import { putCsrfToken } from "../../../../sagas/common";
 import * as actions from "../../actions/postUsernamePasswordActions";
-import { nextMockUrlTou } from "../../actions/postRefLoginActions";
+import { useLoginRef } from "../../actions/postRefLoginActions";
+// import { nextMockUrlTou } from "../../actions/postRefLoginActions";
 import {
   loadingData,
   loadingDataComplete,
@@ -11,13 +12,13 @@ import {
 export function* postUsernamePasswordSaga(action) {
   const state = yield select((state) => state);
   const url = "https://idp.eduid.docker/pw_auth";
+  const dataToSend = {
+    ref: state.login.ref,
+    csrf_token: state.config.csrf_token,
+    username: action.payload.username,
+    password: action.payload.password,
+  };
   try {
-    const dataToSend = {
-      ref: state.login.ref,
-      csrf_token: state.config.csrf_token,
-      username: action.payload.username,
-      password: action.payload.password,
-    };
     yield put(loadingData());
     const postUsernamePasswordResponse = yield call(
       postRequest,
@@ -25,9 +26,12 @@ export function* postUsernamePasswordSaga(action) {
       dataToSend
     );
     yield put(putCsrfToken(postUsernamePasswordResponse));
-    yield put(postUsernamePasswordResponse);
     yield put(loadingDataComplete());
-    yield put(nextMockUrlTou());
+    if (postUsernamePasswordResponse.payload.finished) {
+      // MOCK: forced navigation to tou
+      // yield put(nextMockUrlTou());
+      yield put(useLoginRef());
+    }
   } catch (error) {
     yield put(actions.postUsernamePasswordFail(error.toString()));
     yield put(loadingDataComplete());

--- a/src/login/redux/sagas/login/postWebauthnFromAuthenticatorSaga.js
+++ b/src/login/redux/sagas/login/postWebauthnFromAuthenticatorSaga.js
@@ -2,7 +2,7 @@ import { call, select, put } from "redux-saga/effects";
 import postRequest from "../postDataRequest";
 import { putCsrfToken } from "../../../../sagas/common";
 import * as actions from "../../actions/postWebauthnFromAuthenticatorActions";
-import { nextMockUrlFinished } from "../../actions/postRefLoginActions";
+import { useLoginRef } from "../../actions/postRefLoginActions";
 
 function safeEncode(obj) {
   const bytesObj = String.fromCharCode.apply(null, new Uint8Array(obj));
@@ -14,25 +14,25 @@ export function* postWebauthnFromAuthenticatorSaga() {
   const state = yield select((state) => state);
   const url = "https://idp.eduid.docker/mfa_auth";
   const assertion = state.login.mfa.webauthn_assertion;
+  const dataToSend = {
+    ref: state.login.ref,
+    csrf_token: state.config.csrf_token,
+    webauthn_response: {
+      credentialId: safeEncode(assertion.rawId),
+      authenticatorData: safeEncode(assertion.response.authenticatorData),
+      clientDataJSON: safeEncode(assertion.response.clientDataJSON),
+      signature: safeEncode(assertion.response.signature),
+    },
+  };
   try {
-    const dataToSend = {
-      ref: state.login.ref,
-      csrf_token: state.config.csrf_token,
-      webauthn_response: {
-        credentialId: safeEncode(assertion.rawId),
-        authenticatorData: safeEncode(assertion.response.authenticatorData),
-        clientDataJSON: safeEncode(assertion.response.clientDataJSON),
-        signature: safeEncode(assertion.response.signature),
-      },
-    };
     const authenticatorAssertionResponse = yield call(
       postRequest,
       url,
       dataToSend
     );
     yield put(putCsrfToken(authenticatorAssertionResponse));
-     if (authenticatorAssertionResponse.payload.finished) {
-      yield put(nextMockUrlFinished());
+    if (authenticatorAssertionResponse.payload.finished) {
+      yield put(useLoginRef());
     }
   } catch (error) {
     yield put(actions.postWebauthnFromAuthenticatorFail(error.toString()));

--- a/src/login/redux/sagas/rootSaga/loginSagas.js
+++ b/src/login/redux/sagas/rootSaga/loginSagas.js
@@ -12,7 +12,6 @@ import { postRefForWebauthnChallengeSaga } from "../login/postRefForWebauthnChal
 import * as postWebauthnFromAuthenticatorActions from "../../actions/postWebauthnFromAuthenticatorActions";
 import { postWebauthnFromAuthenticatorSaga } from "../login/postWebauthnFromAuthenticatorSaga";
 
-
 const loginSagas = [
   takeLatest(postRefLoginActions.POST_LOGIN_REF_TO_NEXT, postRefLoginSaga),
   takeLatest(
@@ -32,11 +31,6 @@ const loginSagas = [
     postWebauthnFromAuthenticatorActions.POST_WEBAUTHN_ASSERTION,
     postWebauthnFromAuthenticatorSaga
   ),
-  // uncomment to enable call to /next on /pw_auth success
-  // takeLatest(
-  //   postUsernamePasswordActions.POST_IDP_PW_AUTH_SUCCESS,
-  //   postRefLoginSaga
-  // ),
 ];
 
 export default loginSagas;

--- a/src/tests/sagas/postUpdatedTouAcceptSaga-test.js
+++ b/src/tests/sagas/postUpdatedTouAcceptSaga-test.js
@@ -1,5 +1,5 @@
 import expect from "expect";
-import { put, call } from "redux-saga/effects";
+import { call } from "redux-saga/effects";
 import { addLocaleData } from "react-intl";
 addLocaleData("react-intl/locale-data/en");
 import postRequest from "../../login/redux/sagas/postDataRequest";
@@ -25,9 +25,7 @@ describe("API call to /tou fires", () => {
     };
 
     const generator = postUpdatedTouAcceptSaga(action);
-    generator.next();
     generator.next(fakeState);
-    generator.next();
 
     const dataToSend = {
       ref: "dummy-ref",
@@ -48,15 +46,13 @@ describe("API call to /tou fires", () => {
     };
 
     const generator = postUpdatedTouAcceptSaga(action);
-    let next = generator.next();
-    next = generator.next(fakeState);
-    next = generator.next();
+    let next = generator.next(fakeState);
 
-   const dataToSend = {
-     ref: "dummy-ref",
-     csrf_token: "csrf-token",
-     user_accepts: action.payload.user_accepts,
-   };
+    const dataToSend = {
+      ref: "dummy-ref",
+      csrf_token: "csrf-token",
+      user_accepts: action.payload.user_accepts,
+    };
     const url = "https://idp.eduid.docker/tou";
     const resp = generator.next(fakeState).value;
     expect(resp).toEqual(call(postRequest, url, dataToSend));
@@ -71,8 +67,5 @@ describe("API call to /tou fires", () => {
 
     next = generator.next(action);
     expect(next.value.PUT.action.type).toEqual("NEW_CSRF_TOKEN");
-    next = generator.next();
-    delete action.payload.csrf_token;
-    expect(next.value).toEqual(put(action));
   });
 });

--- a/src/tests/sagas/postUsernamePasswordSaga-test.js
+++ b/src/tests/sagas/postUsernamePasswordSaga-test.js
@@ -1,5 +1,5 @@
 import expect from "expect";
-import { put, call } from "redux-saga/effects";
+import { call } from "redux-saga/effects";
 import { addLocaleData } from "react-intl";
 addLocaleData("react-intl/locale-data/en");
 import postRequest from "../../login/redux/sagas/postDataRequest";
@@ -41,7 +41,7 @@ describe("initial API call to /next fires", () => {
     expect(resp).toEqual(call(postRequest, url, dataToSend));
   });
 
-  it("postUsernamePasswordSaga SUCCESS response is followed by 'NEW_CSRF_TOKEN'", () => {
+  it("postUsernamePasswordSaga SUCCESS response is followed by 'NEW_CSRF_TOKEN' and 'LOAD_DATA_COMPLETE'", () => {
     let action = {
       type: "POST_USERNAME_PASSWORD,",
       payload: {
@@ -75,7 +75,6 @@ describe("initial API call to /next fires", () => {
     next = generator.next(action);
     expect(next.value.PUT.action.type).toEqual("NEW_CSRF_TOKEN");
     next = generator.next();
-    delete action.payload.csrf_token;
-    expect(next.value).toEqual(put(action));
+    expect(next.value.PUT.action.type).toEqual("LOAD_DATA_COMPLETE");
   });
 });


### PR DESCRIPTION
#### Description:
This PR adds functionality to complete the login process for users with a registered security key. 

> Note that the forced navigation USERNAMEPW > TOU > MFA has been disabled (commented out). The commented out code will have to remain until the tou page is finalised.

**Summary:**   

1. Adds functionality to complete the login process: 
   - loginReducer: `action.payload.parameters` added to redux store when `action.payload.action === "FINISHED"` 
   - Login: `next_page === "FINISHED"` renders new child`<SubmitSamlResponse />`
   - **NEW** `<SubmitSamlResponse />`:  hidden form submitted on load in order to POST `SAMLResponse` to `targetUrl`
    

2. The forced navigation has been disabled in favour of the repeated calls to /next on _SUCCESS: 
   - Forced navigation code commented out in: loginReducer and postRefLoginActions
   - `useLoginRef()` added at end of following sagas when`{finished : true}`:  postUsernamePasswordSaga, postUpdatedTouAcceptSaga, postWebauthnFromAuthenticatorSaga

3. Minor housekeeping:
    - Actions: redundant `error: err` line deleted from Fail functions
    - Sagas: all variables have been moved outside the `try {}` block 
    - **TEST**: saga tests updated following clean up

**Known limitations**: 
- The Freja option does not work and button click is broken
- Cancelling the security key process generates the general error message  

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

