### PR TITLE
set correct path to actions as next

### DIFF
--- a/plugins/eduid_action.mfa/component.js
+++ b/plugins/eduid_action.mfa/component.js
@@ -176,7 +176,6 @@ const mapStateToProps = (state, props) => {
       next.concat("/");
     }
     next = next + "redirect-action";
-    console.log(next);
     external_mfa_url =
       eidas_sp_url + verify_path + "?idp=" + mfa_auth_idp_url + "&next=" + next;
     console.log(external_mfa_url);

--- a/plugins/eduid_action.mfa/component.js
+++ b/plugins/eduid_action.mfa/component.js
@@ -170,8 +170,13 @@ const mapStateToProps = (state, props) => {
     if (!eidas_sp_url.endsWith("/")) {
       eidas_sp_url.concat("/");
     }
-    // base64 encode next argument to avoid our request sanitation
-    let next = btoa(window.location);
+    let next = window.location.toString();
+    // add actions expected endpoint
+    if (!next.endsWith("/")) {
+      next.concat("/");
+    }
+    next = next + "redirect-action";
+    console.log(next);
     external_mfa_url =
       eidas_sp_url + verify_path + "?idp=" + mfa_auth_idp_url + "&next=" + next;
     console.log(external_mfa_url);


### PR DESCRIPTION
#### Description:
set correct path to actions as next
backend no longer supports base64 encoded redirect

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

