### PR TITLE
PLUGINS: fixes broken text strings rendered on mfa page

### DIFF
--- a/src/login/translation/defaultMessages/instructions.js
+++ b/src/login/translation/defaultMessages/instructions.js
@@ -53,11 +53,28 @@ export const generalInstructions = {
     />
   ),
 
-  // mfa instructions 
-    "mfa.try-again": (
+  // mfa instructions
+  "mfa.try-again": (
     <FormattedMessage id="mfa.try-again" defaultMessage={`Try again`} />
   ),
-
+  "mfa.login-tapit": (
+    <FormattedMessage
+      id="mfa.login-tapit"
+      defaultMessage={`Use your security key to log in. If it has a button, tap it.`}
+    />
+  ),
+  "mfa.two-factor-authn": (
+    <FormattedMessage
+      id="mfa.two-factor-authn"
+      defaultMessage={`Use your security key to log in. If it has a button, tap it.`}
+    />
+  ),
+  "mfa.extra-security-enabled": (
+    <FormattedMessage
+      id="mfa.extra-security-enabled"
+      defaultMessage={`Use your security key to log in. If it has a button, tap it.`}
+    />
+  ),
 };
 
 export const specificInstructions = {};

--- a/src/login/translation/src/login/translation/defaultMessages/instructions.json
+++ b/src/login/translation/src/login/translation/defaultMessages/instructions.json
@@ -26,5 +26,17 @@
   {
     "id": "mfa.try-again",
     "defaultMessage": "Try again"
+  },
+  {
+    "id": "mfa.login-tapit",
+    "defaultMessage": "Use your security key to log in. If it has a button, tap it."
+  },
+  {
+    "id": "mfa.two-factor-authn",
+    "defaultMessage": "Use your security key to log in. If it has a button, tap it."
+  },
+  {
+    "id": "mfa.extra-security-enabled",
+    "defaultMessage": "Use your security key to log in. If it has a button, tap it."
   }
 ]


### PR DESCRIPTION
#### Description:
This PR fixes three broken text strings rendered on the plugin mfa page.

**Summary**: 
- adds default messages for the relevant message ids 
- translations untouched

---
###### only messge ids rendered as text
<img width="300" alt="Screenshot 2021-06-24 at 12 04 42" src="https://user-images.githubusercontent.com/30963614/125434992-3ebdbc05-b36c-49c7-aeb3-037f84c593b7.png">

###### accurate strings rendered as text (Swe and Eng)
<img width="300" alt="Captura de ecrã 2021-07-13, às 12 10 21" src="https://user-images.githubusercontent.com/30963614/125435011-6b8b59cb-7d9f-41cb-b6dd-b442d38b10f2.png"> <img width="300" alt="Captura de ecrã 2021-07-13, às 12 10 39" src="https://user-images.githubusercontent.com/30963614/125435018-5e05fe34-c7d2-4527-8e87-f55a2e4cac57.png">

---

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

