### PR TITLE
LOGIN: Adds mobile styles to login flow

### DIFF
--- a/src/login/styles/_Login.scss
+++ b/src/login/styles/_Login.scss
@@ -1,14 +1,20 @@
 @import "./variables.scss";
 
 .username-pw,
-.tou {
+.tou,
+.mfa {
   display: flex;
   flex-direction: column;
   .heading {
     line-height: $line-height;
   }
-  button {
+  button.btn {
     width: fit-content;
+    @media (max-width: 320px) {
+      width: 100%;
+      font-size: 1rem;
+      margin-top: 0;
+    }
   }
 }
 
@@ -17,15 +23,20 @@
   form {
     margin-top: 0;
     .form-group {
-      margin-bottom: 1rem;
+      margin-bottom: $margin;
     }
     button {
-      margin: 0.25rem 0 3rem;
+      margin: 0.25rem 0 #{3 * $margin};
     }
   }
   .secondary-link {
     font-size: 1rem;
     align-self: flex-end;
+    @media (max-width: 320px) {
+      margin-top: #{3 * $margin};
+      display: flex;
+      flex-direction: column;
+    }
   }
 }
 
@@ -39,7 +50,7 @@
 // terms of use page
 .tou {
   .tou-text {
-    margin-bottom: 1rem;
+    margin-bottom: $margin;
     p {
       line-height: $line-height;
       margin-bottom: 0;
@@ -61,15 +72,22 @@
 // multi-factor authentication
 .mfa {
   .options {
-    margin-top: 2rem;
+    margin-top: #{2 * $margin};
     display: flex;
     justify-content: space-between;
+    @media (max-width: 320px) {
+      flex-direction: column;
+    }
     .primary {
       display: flex;
       flex: 1;
       flex-direction: column;
-      margin-right: 1rem;
+      margin-right: $margin;
       transition: all 0.5s ease;
+      @media (max-width: 320px) {
+        margin-right: 0;
+        margin-bottom: #{2 * $margin};
+      }
       .bottom {
         align-items: flex-end;
       }
@@ -92,7 +110,7 @@
         }
       }
       .help-link {
-        margin-top: 1rem;
+        margin-top: $margin;
         font-size: 1rem;
         margin-left: 0.25rem;
       }
@@ -100,7 +118,11 @@
     .secondary {
       flex: 1;
       border: solid transparent 2px;
-      margin-left: 2rem;
+      margin-left: #{2 * $margin};
+      @media (max-width: 320px) {
+        margin-top: #{2 * $margin};
+        margin-left: 0;
+      }
       button,
       button:active,
       button:focus,

--- a/src/login/styles/_Login.scss
+++ b/src/login/styles/_Login.scss
@@ -162,7 +162,7 @@
 }
 
 // breakpoint at .option width + 2 * margin (.mfa)
-@media (max-width: 368px) {
+@media (max-width: 382px) {
   .mfa .options {
     .primary {
       margin-right: 0;

--- a/src/login/styles/_Login.scss
+++ b/src/login/styles/_Login.scss
@@ -1,5 +1,6 @@
 @import "./variables.scss";
 
+// for all login pages
 .username-pw,
 .tou,
 .mfa {
@@ -10,15 +11,10 @@
   }
   button.btn {
     width: fit-content;
-    @media (max-width: 320px) {
-      width: 100%;
-      font-size: 1rem;
-      margin-top: 0;
-    }
   }
 }
 
-// usename and password page
+// usename and password
 .username-pw {
   form {
     margin-top: 0;
@@ -32,11 +28,6 @@
   .secondary-link {
     font-size: 1rem;
     align-self: flex-end;
-    @media (max-width: 320px) {
-      margin-top: #{3 * $margin};
-      display: flex;
-      flex-direction: column;
-    }
   }
 }
 
@@ -47,9 +38,10 @@
   }
 }
 
-// terms of use page
+// terms of use
 .tou {
   .tou-text {
+    margin-top: $margin;
     margin-bottom: $margin;
     p {
       line-height: $line-height;
@@ -72,22 +64,12 @@
 // multi-factor authentication
 .mfa {
   .options {
-    margin-top: #{2 * $margin};
     display: flex;
+    flex-wrap: wrap;
     justify-content: space-between;
-    @media (max-width: 320px) {
-      flex-direction: column;
-    }
+    margin-top: #{2 * $margin};
     .primary {
-      display: flex;
-      flex: 1;
-      flex-direction: column;
-      margin-right: $margin;
-      transition: all 0.5s ease;
-      @media (max-width: 320px) {
-        margin-right: 0;
-        margin-bottom: #{2 * $margin};
-      }
+      margin: 0 #{3 * $margin} #{3.5 * $margin} 0;
       .bottom {
         align-items: flex-end;
       }
@@ -95,7 +77,7 @@
         margin-bottom: 0;
       }
       img {
-        width: 50%;
+        max-width: 178px;
       }
       .icon {
         background: transparent;
@@ -110,28 +92,11 @@
         }
       }
       .help-link {
-        margin-top: $margin;
+        max-width: 350px;
+        margin-top: 0.5rem;
         font-size: 1rem;
         margin-left: 0.25rem;
-      }
-    }
-    .secondary {
-      flex: 1;
-      border: solid transparent 2px;
-      margin-left: #{2 * $margin};
-      @media (max-width: 320px) {
-        margin-top: #{2 * $margin};
-        margin-left: 0;
-      }
-      button,
-      button:active,
-      button:focus,
-      button:active:focus {
-        color: $orange-highlight;
-        border: none;
-        border: solid 2px $orange-highlight;
-        background-color: $white;
-        text-transform: uppercase;
+        padding-bottom: 0;
       }
     }
     .option {
@@ -139,12 +104,74 @@
       background: $white;
       box-shadow: 0 4px 14px rgba(89, 89, 89, 0.07);
       padding: 1rem;
-      button,
-      button:active,
-      button:focus,
-      button:active:focus {
-        margin-top: 2.75rem;
-        margin-bottom: 0;
+      width: 350px;
+      height: 168px;
+    }
+  }
+}
+
+// styles to counteract bootstrap button styles (.mfa)
+.option {
+  button,
+  button:active,
+  button:focus,
+  button:active:focus {
+    margin-top: 2.75rem;
+    margin-bottom: 0;
+  }
+}
+.mfa .secondary .option {
+  button,
+  button:active,
+  button:focus,
+  button:active:focus {
+    color: $orange-highlight;
+    border: none;
+    border: solid 2px $orange-highlight;
+    background-color: $white;
+    text-transform: uppercase;
+    margin-top: 2.75rem;
+    margin-bottom: 0;
+    .lowercase {
+      text-transform: none;
+    }
+  }
+}
+
+// iPhone 6/7/8+ and smaller
+@media (max-width: 414px) {
+  .username-pw,
+  .tou,
+  .mfa {
+    button.btn {
+      width: 100%;
+      font-size: 1rem;
+    }
+  }
+  .username-pw .button-pair {
+    flex-direction: column-reverse;
+  }
+  .username-pw .secondary-link {
+    margin-top: #{3 * $margin};
+    display: flex;
+    flex-direction: column;
+  }
+  .tou .tou-text {
+    margin-top: #{2 * $margin};
+  }
+}
+
+// breakpoint at .option width + 2 * margin (.mfa)
+@media (max-width: 368px) {
+  .mfa .options {
+    .primary {
+      margin-right: 0;
+    }
+    .primary,
+    .secondary {
+      flex: 1;
+      .option {
+        width: unset;
       }
     }
   }

--- a/src/login/styles/_Login.scss
+++ b/src/login/styles/_Login.scss
@@ -132,7 +132,7 @@
     text-transform: uppercase;
     margin-top: 2.75rem;
     margin-bottom: 0;
-    .lowercase {
+    .verbatim {
       text-transform: none;
     }
   }

--- a/src/login/styles/_Notifications.scss
+++ b/src/login/styles/_Notifications.scss
@@ -195,7 +195,7 @@
   }
 }
 
-@media (max-width: 320px) {
+@media (max-width: 414px) {
   .notifications-area {
     z-index: 2;
     margin-bottom: 0;

--- a/src/login/styles/_Notifications.scss
+++ b/src/login/styles/_Notifications.scss
@@ -77,7 +77,7 @@
   left: calc(50%);
   -webkit-transform: translateX(-50%);
   -ms-transform: translateX(-50%);
-      transform: translateX(-50%);
+  transform: translateX(-50%);
   padding: 6px;
   color: $white;
   background: $black;
@@ -192,5 +192,17 @@
   }
   .speech-bubbletip.settings.en::before {
     left: 30%;
+  }
+}
+
+@media (max-width: 320px) {
+  .notifications-area {
+    z-index: 2;
+    margin-bottom: 0;
+  }
+  .alert.alert-dismissible {
+    & span {
+      width: calc(100% - #{2 * $margin});
+    }
   }
 }

--- a/src/login/styles/_base.scss
+++ b/src/login/styles/_base.scss
@@ -90,3 +90,9 @@ fieldset {
     width: calc(100% - 1.25rem);
   }
 }
+
+@media (max-width: 320px) {
+  .vertical-content-margin {
+    width: calc(100% - #{2 * $margin});
+  }
+}

--- a/src/login/styles/_base.scss
+++ b/src/login/styles/_base.scss
@@ -31,7 +31,6 @@ body {
   flex-direction: column;
   flex: 1;
   padding-bottom: 2rem;
-  // background: lightyellow;
   background-color: #f4f4f4;
 }
 
@@ -91,7 +90,7 @@ fieldset {
   }
 }
 
-@media (max-width: 320px) {
+@media (max-width: 414px) {
   .vertical-content-margin {
     width: calc(100% - #{2 * $margin});
   }

--- a/src/login/styles/_buttons.scss
+++ b/src/login/styles/_buttons.scss
@@ -17,7 +17,6 @@ button.btn {
   text-transform: uppercase;
   height: 3rem;
   border-radius: 20px;
-  padding: 0.625rem 1.25rem;
   margin: 1rem 0 2rem 0;
   box-shadow: 0 5px 17px rgba(89, 89, 89, 0.07);
   transition: all 0.5s ease;

--- a/src/login/styles/_buttons.scss
+++ b/src/login/styles/_buttons.scss
@@ -192,8 +192,7 @@ button.btn.icon-button {
 }
 
 button.btn.table-button.btn.btn-primary,
-button.btn-link.nobutton.verify-status-label,
-.show-hide-button {
+button.btn-link.nobutton.verify-status-label {
   color: #ff500d;
   font-size: 0.75rem;
   background-color: transparent;
@@ -211,6 +210,11 @@ button.btn-link.nobutton.verify-status-label,
 }
 
 .show-hide-button {
+  color: #ff500d;
+  font-size: 0.75rem;
+  background-color: transparent;
+  border: solid 1px transparent;
+  box-shadow: none;
   margin: 0;
 }
 

--- a/src/login/styles/_forms.scss
+++ b/src/login/styles/_forms.scss
@@ -11,6 +11,11 @@ form {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
+  @media (max-width: 320px) {
+    display: flex;
+    flex-direction: column-reverse;
+    align-items: baseline;
+  }
 }
 
 #reset-password-email-form {

--- a/src/login/styles/_forms.scss
+++ b/src/login/styles/_forms.scss
@@ -11,11 +11,6 @@ form {
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  @media (max-width: 320px) {
-    display: flex;
-    flex-direction: column-reverse;
-    align-items: baseline;
-  }
 }
 
 #reset-password-email-form {

--- a/src/login/styles/_inputs.scss
+++ b/src/login/styles/_inputs.scss
@@ -165,3 +165,18 @@ input:focus {
     font-size: 1rem;
   }
 }
+
+.form-control,
+input,
+.radio-input-container span {
+  @media (max-width: 320px) {
+    font-size: 1.5rem;
+  }
+}
+
+.form-control::placeholder,
+input::placeholder {
+  @media (max-width: 320px) {
+    font-size: 1.5rem;
+  }
+}

--- a/src/login/styles/_inputs.scss
+++ b/src/login/styles/_inputs.scss
@@ -166,15 +166,10 @@ input:focus {
   }
 }
 
+// increased font size on smallest screens
 .form-control,
-input,
-.radio-input-container span {
-  @media (max-width: 320px) {
-    font-size: 1.5rem;
-  }
-}
-
 .form-control::placeholder,
+input,
 input::placeholder {
   @media (max-width: 320px) {
     font-size: 1.5rem;

--- a/src/login/styles/_inputs.scss
+++ b/src/login/styles/_inputs.scss
@@ -166,12 +166,3 @@ input:focus {
   }
 }
 
-// increased font size on smallest screens
-.form-control,
-.form-control::placeholder,
-input,
-input::placeholder {
-  @media (max-width: 320px) {
-    font-size: 1.5rem;
-  }
-}

--- a/src/login/styles/variables.scss
+++ b/src/login/styles/variables.scss
@@ -16,6 +16,7 @@ $dark-gray: #d8d8d8;
 $mid-gray: #ebebeb;
 
 $line-height: 1.4;
+$margin: 1rem;
 
 /*
  * Typography

--- a/src/login/translation/defaultMessages/login.js
+++ b/src/login/translation/defaultMessages/login.js
@@ -82,7 +82,7 @@ export const login = {
   "login.mfa.secondary-option.button": (
     <FormattedHTMLMessage
       id="login.mfa.secondary-option.button"
-      defaultMessage={`Use my <span class="lowercase">Freja&nbspe</span>id+`}
+      defaultMessage={`Use my <span class="verbatim">Freja&nbsp;eID+</span>`}
     />
   ),
   "login.mfa.primary-option.hint": (

--- a/src/login/translation/defaultMessages/login.js
+++ b/src/login/translation/defaultMessages/login.js
@@ -80,9 +80,9 @@ export const login = {
     />
   ),
   "login.mfa.secondary-option.button": (
-    <FormattedMessage
+    <FormattedHTMLMessage
       id="login.mfa.secondary-option.button"
-      defaultMessage={`Use freja eid+`}
+      defaultMessage={`Use my <span class="lowercase">Freja&nbspe</span>id+`}
     />
   ),
   "login.mfa.primary-option.hint": (

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -190,7 +190,7 @@
   "login.mfa.primary-option.button": "Use my security key",
   "login.mfa.primary-option.hint": "If your security key has a button, don’t forget to tap it.",
   "login.mfa.primary-option.title": "Security key",
-  "login.mfa.secondary-option.button": "Use my <span class=\"lowercase\">Freja&nbspe</span>id+",
+  "login.mfa.secondary-option.button": "Use my <span class=\"verbatim\">Freja&nbsp;eID+</span>",
   "login.mfa.secondary-option.title": "Freja eID+",
   "login.tou.button": "I accept",
   "login.tou.h2-heading": "Log in: Terms of use",

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -190,7 +190,7 @@
   "login.mfa.primary-option.button": "Use my security key",
   "login.mfa.primary-option.hint": "If your security key has a button, don’t forget to tap it.",
   "login.mfa.primary-option.title": "Security key",
-  "login.mfa.secondary-option.button": "Use my freja eid+",
+  "login.mfa.secondary-option.button": "Use my <span class=\"lowercase\">Freja&nbspe</span>id+",
   "login.mfa.secondary-option.title": "Freja eID+",
   "login.tou.button": "I accept",
   "login.tou.h2-heading": "Log in: Terms of use",

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -190,7 +190,7 @@
   "login.mfa.primary-option.button": "Använd min säkerhetsnyckel",
   "login.mfa.primary-option.hint": "Om din säkerhetsnyckel har en knapp, glöm inte att trycka på den.",
   "login.mfa.primary-option.title": "Säkerhetsnyckel",
-  "login.mfa.secondary-option.button": "Använd mitt <span class=\"lowercase\">Freja&nbspe</span>id+",
+  "login.mfa.secondary-option.button": "Använd mitt <span class=\"verbatim\">Freja&nbsp;eID+</span>",
   "login.mfa.secondary-option.title": "Freja eID+",
   "login.tou.button": "Jag accepterar",
   "login.tou.h2-heading": "Logga in: Användarvillkor",

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -190,7 +190,7 @@
   "login.mfa.primary-option.button": "Använd min säkerhetsnyckel",
   "login.mfa.primary-option.hint": "Om din säkerhetsnyckel har en knapp, glöm inte att trycka på den.",
   "login.mfa.primary-option.title": "Säkerhetsnyckel",
-  "login.mfa.secondary-option.button": "Använd mitt Freja eID+",
+  "login.mfa.secondary-option.button": "Använd mitt <span class=\"lowercase\">Freja&nbspe</span>id+",
   "login.mfa.secondary-option.title": "Freja eID+",
   "login.tou.button": "Jag accepterar",
   "login.tou.h2-heading": "Logga in: Användarvillkor",

--- a/src/login/translation/src/login/translation/defaultMessages/login.json
+++ b/src/login/translation/src/login/translation/defaultMessages/login.json
@@ -49,7 +49,7 @@
   },
   {
     "id": "login.mfa.secondary-option.button",
-    "defaultMessage": "Use my <span class=\"lowercase\">Freja&nbspe</span>id+"
+    "defaultMessage": "Use my <span class=\"verbatim\">Freja&nbsp;eID+</span>"
   },
   {
     "id": "login.mfa.primary-option.hint",

--- a/src/login/translation/src/login/translation/defaultMessages/login.json
+++ b/src/login/translation/src/login/translation/defaultMessages/login.json
@@ -49,7 +49,7 @@
   },
   {
     "id": "login.mfa.secondary-option.button",
-    "defaultMessage": "Use freja eid+"
+    "defaultMessage": "Use my <span class=\"lowercase\">Freja&nbspe</span>id+"
   },
   {
     "id": "login.mfa.primary-option.hint",


### PR DESCRIPTION
#### Description:
This PR adds styling to login flow to make it functional on smaller screen. Smallest screen width at `320px` is prioritised but some changes take effect from `414px`.

**Summary**: 
1. Sets outer margin at `320px` to `1 rem`
    - also adjust the margins of the error messages at this size 

2. Removes padding from inside buttons, allows for better centring of text when two lines

3. Adds custom breakpoint for mfa page at `382px`
    - represents the .option (`width: 350px`) and margins (`16px`) on each side 

---
###### MOBLIE: Username and pw (fold and main interaction)

<img src="https://user-images.githubusercontent.com/30963614/126133801-2e4fd7dd-b619-47dd-b078-99e592315db1.png" height="500"> <img src="https://user-images.githubusercontent.com/30963614/126133814-9d9fac2a-ceee-4d1a-a274-cef0cd5d22a8.png" height="500">

###### MOBLIE: Terms of use (fold and main interaction)
<img src="https://user-images.githubusercontent.com/30963614/126134615-a722a5f6-c4e8-4a4d-ad3e-46487390413e.png" height="500"> <img src="https://user-images.githubusercontent.com/30963614/126134620-8b7476d4-ed99-41f7-b2ab-508d39efd37c.png" height="500">

###### MOBLIE: Multi-factor authentication (fold and main interaction)
<img src="https://user-images.githubusercontent.com/30963614/126134638-5e686ead-2028-41ed-9bf1-012871f0454c.png" height="500"> <img src="https://user-images.githubusercontent.com/30963614/126134642-92d52c3c-120e-4a01-bd73-13b267106856.png" height="500"> <img src="https://user-images.githubusercontent.com/30963614/126134643-b87f1503-08f0-4d3a-9d13-ac90c8f897b7.png" height="500">

---


#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

