### PR TITLE
LOGIN: Expected error message for /next endpoint

### DIFF
--- a/src/login/redux/sagas/login/postRefLoginSaga.js
+++ b/src/login/redux/sagas/login/postRefLoginSaga.js
@@ -7,15 +7,17 @@ import { eduidRMAllNotify } from "../../../../actions/Notifications";
 export function* postRefLoginSaga() {
   const state = yield select((state) => state);
   const url = state.config.next_url;
+  const dataToSend = {
+    ref: state.login.ref,
+    csrf_token: state.config.csrf_token,
+  };
   try {
-    const dataToSend = {
-      ref: state.login.ref,
-      csrf_token: state.config.csrf_token,
-    };
-    const nextLoginStepResponse = yield call(postRequest, url, dataToSend);
-    yield put(putCsrfToken(nextLoginStepResponse));
-    yield put(nextLoginStepResponse);
-    yield put(eduidRMAllNotify());
+    const response = yield call(postRequest, url, dataToSend);
+    yield put(putCsrfToken(response));
+    yield put(response);
+    if (response.type.endsWith("_SUCCESS")) {
+      yield put(eduidRMAllNotify());
+    }
   } catch (error) {
     yield put(actions.postRefFail(error.toString()));
   }

--- a/src/tests/sagas/postRefToLogin-test.js
+++ b/src/tests/sagas/postRefToLogin-test.js
@@ -4,19 +4,20 @@ import { addLocaleData } from "react-intl";
 addLocaleData("react-intl/locale-data/en");
 import postRequest from "../../login/redux/sagas/postDataRequest";
 import { postRefLoginSaga } from "../../login/redux/sagas/login/postRefLoginSaga";
+import { postRefFail } from "../../login/redux/actions/postRefLoginActions";
+
+const fakeState = {
+  config: {
+    next_url: "http://localhost/next",
+    csrf_token: "csrf-token",
+  },
+  login: {
+    ref: "dummy-ref",
+    next_page: "USERNAMEPASSWORD",
+  },
+};
 
 describe("initial API call to /next fires", () => {
-  const fakeState = {
-    config: {
-      next_url: "http://localhost/next",
-      csrf_token: "csrf-token",
-    },
-    login: {
-      ref: "dummy-ref",
-      next_page: "USERNAMEPASSWORD",
-    },
-  };
-
   it("postRefLoginSaga posts the expected data", () => {
     const generator = postRefLoginSaga();
     generator.next();
@@ -24,37 +25,66 @@ describe("initial API call to /next fires", () => {
       ref: "dummy-ref",
       csrf_token: "csrf-token",
     };
-
     const url = fakeState.config.next_url;
-    const resp = generator.next(fakeState);
-    expect(resp.value).toEqual(call(postRequest, url, dataToSend));
+    const apiCall = generator.next(fakeState).value;
+    expect(apiCall).toEqual(call(postRequest, url, dataToSend));
   });
 
   it("postRefLoginSaga SUCCESS response is followed by 'NEW_CSRF_TOKEN'", () => {
     const generator = postRefLoginSaga();
     let next = generator.next();
-
     const dataToSend = {
       ref: "dummy-ref",
       csrf_token: "csrf-token",
     };
-
     const url = fakeState.config.next_url;
-    const resp = generator.next(fakeState);
-    expect(resp.value).toEqual(call(postRequest, url, dataToSend));
+    const apiCall = generator.next(fakeState).value;
+    expect(apiCall).toEqual(call(postRequest, url, dataToSend));
 
-    const action = {
+    // mock _SUCCESS response
+    const response = {
       type: "POST_IDP_NEXT_SUCCESS",
       payload: {
         csrf_token: "csrf-token",
         message: "success",
       },
     };
-
-    next = generator.next(action);
+    next = generator.next(response);
     expect(next.value.PUT.action.type).toEqual("NEW_CSRF_TOKEN");
     next = generator.next();
-    delete action.payload.csrf_token;
-    expect(next.value).toEqual(put(action));
+    expect(next.value).toEqual(put(response));
+    // remove notifications on _SUCCESS
+    next = generator.next();
+    expect(next.value.PUT.action.type).toEqual("RM_ALL_NOTIFICATION");
+  });
+});
+
+describe("incorrect user details leads to an error response", () => {
+  const generator = postRefLoginSaga();
+  let next = generator.next();
+  it("_FAIL response from backend when ref incorrect", () => {
+    const url = fakeState.config.next_url;
+    const dataToSend = {
+      ref: "incorrect-ref",
+      csrf_token: "csrf-token",
+    };
+    const apiCall = generator.next(fakeState).value;
+    // sending incorrect-ref does not result in the same values as saga
+    expect(apiCall).not.toEqual(call(postRequest, url, dataToSend));
+    // mock _FAIL response
+    const response = {
+      type: "POST_IDP_NEXT_FAIL",
+      error: true,
+      payload: {
+        csrf_token: "csrf-token",
+        message: "error",
+      },
+    };
+    next = generator.next(response);
+    expect(next.value.PUT.action.type).toEqual("NEW_CSRF_TOKEN");
+    next = generator.next();
+    // mock _FAIL response is equal to _FAIL action
+    expect(response).toEqual(postRefFail("error"));
+    expect(next.value.PUT.action.type).toEqual("POST_IDP_NEXT_FAIL");
   });
 });


### PR DESCRIPTION
#### Description:
This PR adds error handling for the `/next` endpoint

**Summary:** 
1. Saga file has been cleaned up to improve legibility

2. **TEST**: improved legibility and added `_FAIL` response test

**Known limitation**:
- message `login.bad_ref` does not yet have a translation and triggers the generic error message 

---
###### MANUAL TEST: Error message renders as expected (when posting incorrect ref and at failing api call)
<img width="500" alt="Screenshot 2021-07-19 at 18 32 26" src="https://user-images.githubusercontent.com/30963614/126196134-9e2b1127-5707-4a49-b547-ff80dfe5ef2b.png"> <img width="500" alt="Screenshot 2021-07-19 at 18 32 31" src="https://user-images.githubusercontent.com/30963614/126196141-00b636de-ef7c-41a0-8998-2397b1215584.png">



---

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

