### PR TITLE
LOGIN: Moves first call to /mfa_auth from onload to onClick 

### DIFF
--- a/src/login/components/LoginApp/Login/MultiFactorAuth.js
+++ b/src/login/components/LoginApp/Login/MultiFactorAuth.js
@@ -1,16 +1,10 @@
-import React, { useEffect } from "react";
-import { useDispatch } from "react-redux";
-import { postRefForWebauthnChallenge } from "../../../redux/actions/postRefForWebauthnChallengeActions";
+import React from "react";
 import SecurityKey from "./SecurityKey";
 import FrejaeID from "./FrejaeID";
 import PropTypes from "prop-types";
 import InjectIntl from "../../../translation/InjectIntl_HOC_factory";
 
 let MultiFactorAuth = (props) => {
-  const dispatch = useDispatch();
-  useEffect(() => {
-    dispatch(postRefForWebauthnChallenge());
-  }, []);
   const { translate } = props;
   return (
     <div className="mfa">

--- a/src/login/components/LoginApp/Login/SecurityKey.js
+++ b/src/login/components/LoginApp/Login/SecurityKey.js
@@ -1,16 +1,22 @@
 import React, { Fragment, useState } from "react";
+import { useDispatch } from "react-redux";
 import ButtonPrimary from "../../Buttons/ButtonPrimary";
 import PropTypes from "prop-types";
 import SecurityKeySelected from "./SecurityKeySelected";
+import { postRefForWebauthnChallenge } from "../../../redux/actions/postRefForWebauthnChallengeActions";
 import InjectIntl from "../../../translation/InjectIntl_HOC_factory";
 
 let SecurityKeyUnselected = ({ translate, setSelected }) => {
+  const dispatch = useDispatch();
   return (
     <Fragment>
       <p className="heading">{translate("login.mfa.primary-option.title")}</p>
       <ButtonPrimary
         type="submit"
-        onClick={() => setSelected(true)}
+        onClick={() => {
+          dispatch(postRefForWebauthnChallenge());
+          setSelected(true);
+        }}
         id="mfa-security-key"
       >
         {translate("login.mfa.primary-option.button")}

--- a/src/login/components/LoginApp/Login/SecurityKeySelected.js
+++ b/src/login/components/LoginApp/Login/SecurityKeySelected.js
@@ -44,19 +44,22 @@ let SecurityKeySelected = ({ translate, setSelected }) => {
   const webauthn_challenge = useSelector(
     (state) => state.login.mfa.webauthn_challenge
   );
-
   useEffect(() => {
     async function securityKeyAssertion() {
-      const webauthnAssertion = await navigator.credentials
-        .get(webauthn_challenge)
-        .then()
-        .catch((error) => {
-          console.log("Problem getting MFA credentials:", error);
-        });
-      dispatch(postWebauthnFromAuthenticator(webauthnAssertion));
+      if (webauthn_challenge !== null) {
+        const webauthnAssertion = await navigator.credentials
+          .get(webauthn_challenge)
+          .then()
+          .catch((error) => {
+            console.log("Problem getting MFA credentials:", error);
+          });
+        if (webauthnAssertion !== undefined) {
+          dispatch(postWebauthnFromAuthenticator(webauthnAssertion));
+        }
+      }
     }
     securityKeyAssertion();
-  }, [retryToggle]);
+  }, [webauthn_challenge, retryToggle]);
 
   return (
     <Fragment>

--- a/src/login/redux/sagas/login/postRefForWebauthnChallengeSaga.js
+++ b/src/login/redux/sagas/login/postRefForWebauthnChallengeSaga.js
@@ -13,8 +13,8 @@ export function* postRefForWebauthnChallengeSaga() {
       csrf_token: state.config.csrf_token,
     };
     const encodedWebauthnChallenge = yield call(postRequest, url, dataToSend);
-    const decodedWebauthnChallenge = yield put(
-      mfaDecodeMiddleware(encodedWebauthnChallenge)
+    const decodedWebauthnChallenge = mfaDecodeMiddleware(
+      encodedWebauthnChallenge
     );
     yield put(putCsrfToken(decodedWebauthnChallenge));
     yield put(decodedWebauthnChallenge);


### PR DESCRIPTION
#### Description:
This PR removes the api call to `/mfa_auth` on load and fires it when a user clicks the 'security key' button. This allows users who have problems with Freja to return to the mfa page and use a security key instead.

**Summary:**

1. ` <SecurityKey/>`: `postRefForWebauthnChallenge()` dispatched on button click

2. `<SecurityKeySelected/>`: additions to `securityKeyAssertion()` func:
     - function now has minor error handling for when `webauthn_challenge` is `null` and  `webauthnAssertion` is `undefined`
     - function re-runs when `webauthn_challenge` is updated 

3. `<MultiFactorAuth/>`: API call removed 

**Known limitations:**
- there are some duplicated in api calls to /next 
- error messages not yet fully checked


#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

