### PR TITLE
LOGIN: Adds checkmark when valid input on autofill

### DIFF
--- a/src/login/components/Inputs/PasswordInput.js
+++ b/src/login/components/Inputs/PasswordInput.js
@@ -60,7 +60,7 @@ let PasswordInput = ({ translate }) => {
       autoComplete="current-password"
       required="true"
       label={translate("login.usernamePw.password-input")}
-      placeholder={"enter a password"}
+      placeholder={translate("placeholder.password")}
       helpBlock={""}
     />
   );

--- a/src/login/components/Inputs/PasswordInput.js
+++ b/src/login/components/Inputs/PasswordInput.js
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
 import { Field } from "redux-form";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faCheck } from "@fortawesome/free-solid-svg-icons";
 import CustomInput from "./CustomInput";
 import Input from "reactstrap/lib/Input";
 import InjectIntl from "../../translation/InjectIntl_HOC_factory";
@@ -42,6 +44,11 @@ export let PasswordInputElement = (props) => {
         aria-required={props.required}
         {...input}
       />
+      {props.valid ? (
+        <div className="checkmark ">
+          <FontAwesomeIcon icon={faCheck} />
+        </div>
+      ) : null}
       {inputType === "password" ? (
         <RenderShowButton {...props} setInputType={setInputType} />
       ) : inputType === "text" ? (

--- a/src/login/components/LoginApp/Login/FrejaeID.js
+++ b/src/login/components/LoginApp/Login/FrejaeID.js
@@ -13,7 +13,7 @@ let FrejaeID = ({ translate }) => {
     ? frejaUrlDomain
     : frejaUrlDomain.concat("/");
   return (
-    <div className="secondary">
+    <div className="secondary" tabIndex="0">
       <div className="option">
         <p className="heading">
           {translate("login.mfa.secondary-option.title")}

--- a/src/login/components/LoginApp/Login/MultiFactorAuth.js
+++ b/src/login/components/LoginApp/Login/MultiFactorAuth.js
@@ -15,7 +15,7 @@ let MultiFactorAuth = (props) => {
   return (
     <div className="mfa">
       <h2 className="heading">{translate("login.mfa.h2-heading")}</h2>
-      <p>{translate("login.mfa.paragraph")}</p>
+      <p tabIndex="0">{translate("login.mfa.paragraph")}</p>
       <div className="options">
         <SecurityKey {...props} />
         <FrejaeID {...props} />

--- a/src/login/components/LoginApp/Login/SecurityKey.js
+++ b/src/login/components/LoginApp/Login/SecurityKey.js
@@ -36,7 +36,7 @@ let SecurityKey = (props) => {
   const { translate } = props;
   const [selected, setSelected] = useState(false);
   return (
-    <div className="primary">
+    <div className="primary" tabIndex="0">
       <div className="option">
         {selected ? (
           <SecurityKeySelected setSelected={setSelected} {...props} />

--- a/src/login/components/LoginApp/Login/UsernamePw.js
+++ b/src/login/components/LoginApp/Login/UsernamePw.js
@@ -24,24 +24,24 @@ const RenderRegisterLink = ({ translate }) => {
 
 const RenderResetPasswordLink = ({ translate }) => {
   const loginRef = useSelector((state) => state.login.ref);
-  return(
+  return (
     <LinkRedirect
       id={"link-forgot-password"}
       className={""}
       to={`/reset-password/email/${loginRef}`}
       text={translate("login.usernamePw.reset-password-link")}
-  />
-)};
+    />
+  );
+};
 
 let UsernamePwFormButton = ({ invalid, dispatch, translate }) => {
-  const errorMessage = useSelector((state) => state.notifications.errors);
   const loading = useSelector((state) => state.app.loading_data);
   return (
     <ButtonPrimary
       type="submit"
       onClick={() => dispatch(submit("usernamePwForm"))}
-      disabled={errorMessage.length !== 0 || invalid || loading}
-      aria-disabled={errorMessage.length !== 0 || invalid || loading}
+      disabled={invalid || loading}
+      aria-disabled={invalid || loading}
       id="login-form-button"
       className={"settings-button"}
     >

--- a/src/login/styles/_inputs.scss
+++ b/src/login/styles/_inputs.scss
@@ -132,13 +132,14 @@ input:focus {
 // login username-pw / reset-password set-new-password
 .password-input {
   display: flex;
+  position: relative;
+  .is-valid {
+    background-image: none;
+  }
+  .checkmark,
   .show-hide-button {
-    color: $black;
-    font-size: 1rem;
     position: absolute;
-    right: 1rem;
     background: transparent;
-    height: 3rem;
     border-radius: 0;
     padding: 0;
     margin: 0;
@@ -146,8 +147,23 @@ input:focus {
     border: none;
     cursor: pointer;
   }
+  .show-hide-button {
+    right: 1rem;
+    color: $black;
+    font-size: 1rem;
+  }
   .is-valid ~ .show-hide-button {
     right: 3rem;
+  }
+  .checkmark {
+    color: #28a745;
+    right: 0.625rem;
+    align-self: center;
+    svg {
+      height: 1.5rem;
+      width: 1.5rem;
+      transform: rotate(0);
+    }
   }
 }
 
@@ -165,4 +181,3 @@ input:focus {
     font-size: 1rem;
   }
 }
-

--- a/src/login/styles/_inputs.scss
+++ b/src/login/styles/_inputs.scss
@@ -133,7 +133,7 @@ input:focus {
 .password-input {
   display: flex;
   position: relative;
-  .is-valid {
+  input[name="current-password"].is-valid {
     background-image: none;
   }
   .checkmark,

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -320,6 +320,7 @@
   "phones.unconfirmed_number_not_primary": "An unconfirmed phone number cannot be set as primary",
   "phones.unknown_phone": "We have no record of the phone number you provided",
   "phones.verification-success": "Successfully verified phone number",
+  "placeholder.password": "enter a password",
   "profile.email_display_no_data": "no email added",
   "profile.email_display_title": "Email address",
   "profile.eppn_display_title": "eppn",

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -320,6 +320,7 @@
   "phones.unconfirmed_number_not_primary": "Du kan inte sätta ett obekräftat telefonnummer som primärt nummer",
   "phones.unknown_phone": "Telefonumret du angav kan inte hittas",
   "phones.verification-success": "Telefonnummer har bekräftats",
+  "placeholder.password": "ange ett lösenord",
   "profile.email_display_no_data": "ingen e-postadress sparad",
   "profile.email_display_title": "E-postadress",
   "profile.eppn_display_title": "eppn",

--- a/src/login/translation/messageIndex.js
+++ b/src/login/translation/messageIndex.js
@@ -2,7 +2,7 @@ import { defineMessages } from "react-intl";
 
 // import content from other files
 import { generalErrors, specificErrors } from "./defaultMessages/errors";
-import { login, tou} from "./defaultMessages/login";
+import { login, tou } from "./defaultMessages/login";
 import { generalInstructions } from "./defaultMessages/instructions";
 import { changePassword, resetPassword } from "./defaultMessages/password";
 import { register } from "./defaultMessages/register";
@@ -29,6 +29,11 @@ export const formattedMessages = {
 };
 
 export const unformattedMessages = defineMessages({
+  "placeholder.password": {
+    id: "placeholder.password",
+    defaultMessage: `enter a password`,
+    description: "placeholder text for password input",
+  },
   "pd.choose-language": {
     id: "pd.choose-language",
     defaultMessage: `Choose language`,

--- a/src/login/translation/src/login/translation/messageIndex.json
+++ b/src/login/translation/src/login/translation/messageIndex.json
@@ -1,5 +1,10 @@
 [
   {
+    "id": "placeholder.password",
+    "description": "placeholder text for password input",
+    "defaultMessage": "enter a password"
+  },
+  {
     "id": "pd.choose-language",
     "defaultMessage": "Choose language"
   },


### PR DESCRIPTION
#### Description:
This PR adds the green chcekmark back in to valid inputs when they are autofilled.

**Summary:**

- Added to `<PasswordInput/>`:
    - Fontawesome checkmark icon to input
    - styling of icon to render next to show/hide button

> **NOTE** this change only applies to `<Form>` that imports `<PasswordInput />` and with `name="current-password"` (only password input in the UsernameAndPwForm). All previous code is intact.

---
###### No checkmark before confirmed validity
<img width="300" alt="Screenshot 2021-08-09 at 18 30 24" src="https://user-images.githubusercontent.com/30963614/128743175-7fff53e2-0dfc-4c4f-bf73-dc1f14a2e0f2.png"> 

###### Checkmark after confirmed validity with and without autofill
<img width="300" alt="Screenshot 2021-08-09 at 18 30 33" src="https://user-images.githubusercontent.com/30963614/128743188-ceeb10f7-4650-4ee2-ad64-bcd62f0a5b57.png"> <img width="300" alt="Screenshot 2021-08-09 at 18 30 55" src="https://user-images.githubusercontent.com/30963614/128743195-5f183321-6e59-4b5c-b117-80c6a660fc2c.png">


---

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

