### PR TITLE
RESETPASSWORD: Change link description text

### DIFF
--- a/src/login/components/LoginApp/ResetPassword/ResetPasswordSuccess.js
+++ b/src/login/components/LoginApp/ResetPassword/ResetPasswordSuccess.js
@@ -13,7 +13,7 @@ function ResetPasswordSuccess(props){
       <SuccessIconAnimation />
       <div id="reset-pass-display">
         <p>{props.translate("resetpw.set-new-password-success")}</p>
-        <a id="return-login" href={toHome}>{props.translate("resetpw.return-login")}</a> 
+        <a id="return-login" href={toHome}>{props.translate("resetpw.go-to-eduid")}</a> 
       </div>
     </>
   ) 

--- a/src/login/translation/defaultMessages/password.js
+++ b/src/login/translation/defaultMessages/password.js
@@ -387,5 +387,10 @@ export const resetPassword = {
       defaultMessage={`accept password`}
     />
   ),
-
+  "resetpw.go-to-eduid": (
+    <FormattedMessage
+      id="resetpw.go-to-eduid"
+      defaultMessage={`go to eduID`}
+    />
+  ),
 };

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -355,6 +355,7 @@
   "resetpw.extra-phone_send_sms": "Send sms to {phone}",
   "resetpw.extra-security_description": "Prove that your are the owner of the account.",
   "resetpw.extra-security_heading": "Extra security",
+  "resetpw.go-to-eduid": "go to eduID",
   "resetpw.heading-add-email": "Enter your email address registered to your account",
   "resetpw.invalid_user": "User has not completed signup",
   "resetpw.received-sms": "Already received sms? ",

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -355,6 +355,7 @@
   "resetpw.extra-phone_send_sms": "Skicka sms till {phone}",
   "resetpw.extra-security_description": "Bevisa att du är ägaren till kontot.",
   "resetpw.extra-security_heading": "Extra säkerhet",
+  "resetpw.go-to-eduid": "gå till eduID",
   "resetpw.heading-add-email": "Ange din e-postadress registrerad till ditt konto",
   "resetpw.invalid_user": "Användaren har inte slutfört registreringen",
   "resetpw.received-sms": "Redan fått sms? ",

--- a/src/login/translation/src/login/translation/defaultMessages/password.json
+++ b/src/login/translation/src/login/translation/defaultMessages/password.json
@@ -230,5 +230,9 @@
   {
     "id": "resetpw.accept-password",
     "defaultMessage": "accept password"
+  },
+  {
+    "id": "resetpw.go-to-eduid",
+    "defaultMessage": "go to eduID"
   }
 ]


### PR DESCRIPTION
#### Description:
This PR is to change link description text to `go to eduID` when finished reset password, to reflect the link routing
Previous text "return to Login" even though the link was to the "main page"

---
- in english
<img width="364" alt="Screenshot 2021-08-27 at 13 17 45" src="https://user-images.githubusercontent.com/44289056/131120102-7aa22eb2-3cfa-4a88-8e4a-1fc61855973e.png">

- in Swedish
<img width="366" alt="Screenshot 2021-08-27 at 13 17 37" src="https://user-images.githubusercontent.com/44289056/131120180-2179ed36-fac9-4585-9831-244f0c7eeb01.png">




--



#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

