### PR TITLE
RESETPASSWORD: Remove enter code link from extra security phone button loop

### DIFF
--- a/src/login/components/LoginApp/ResetPassword/ExtraSecurity.js
+++ b/src/login/components/LoginApp/ResetPassword/ExtraSecurity.js
@@ -39,12 +39,6 @@ const SecurityWithSMSButton = ({ extraSecurityPhone, translate, dispatch, histor
     dispatch(requestPhoneCode(phone));
   };
 
-  const toPhoneCodeForm = (phone)=>{
-    dispatch(selectedPhoneInfo(phone));
-    dispatch(eduidRMAllNotify());
-    history.push(`/reset-password/phone-code-sent/${emailCode}`);
-  };
-
   return (
     extraSecurityPhone.map(phone => {
       return (
@@ -58,9 +52,6 @@ const SecurityWithSMSButton = ({ extraSecurityPhone, translate, dispatch, histor
           {translate("resetpw.extra-phone_send_sms")(
             {phone: phone.number.replace(/^.{10}/g, '**********')})}
           </EduIDButton>
-          <p className="enter-phone-code">{translate("resetpw.received-sms")} 
-            <a onClick={()=>toPhoneCodeForm(phone)}>{translate("resetpw.enter-code")} </a> 
-          </p>
         </div>
       )
     })
@@ -100,6 +91,11 @@ function ExtraSecurity(props){
     }
   };
 
+  const toPhoneCodeForm = ()=>{
+    dispatch(eduidRMAllNotify());
+    history.push(`/reset-password/phone-code-sent/${emailCode}`);
+  };
+
   return (
     <ResetPasswordLayout
       heading={props.translate("resetpw.extra-security_heading")} 
@@ -118,13 +114,19 @@ function ExtraSecurity(props){
         /> : null
       }
       { !selected_option && extraSecurity && extraSecurity.phone_numbers.length > 0 ? 
-        <SecurityWithSMSButton 
-          extraSecurityPhone={extraSecurity.phone_numbers} 
-          translate={props.translate}
-          dispatch={dispatch}
-          history={history}
-          emailCode={emailCode}
-        /> : null
+        <>
+          <SecurityWithSMSButton 
+            extraSecurityPhone={extraSecurity.phone_numbers} 
+            translate={props.translate}
+            dispatch={dispatch}
+            history={history}
+            emailCode={emailCode}
+          /> 
+          <p className="enter-phone-code">{props.translate("resetpw.received-sms")} 
+            <a onClick={()=>toPhoneCodeForm()}>{props.translate("resetpw.enter-code")} </a> 
+          </p>
+        </>
+      : null
       }
     </ResetPasswordLayout>
   ) 

--- a/src/login/components/LoginApp/ResetPassword/ExtraSecurity.js
+++ b/src/login/components/LoginApp/ResetPassword/ExtraSecurity.js
@@ -5,7 +5,7 @@ import EduIDButton from "../../../../components/EduIDButton";
 import { useDispatch, useSelector } from "react-redux";
 import ResetPasswordLayout from "./ResetPasswordLayout";
 import PropTypes from "prop-types";
-import { requestPhoneCode, selectExtraSecurity, selectedPhoneInfo } from "../../../redux/actions/postResetPasswordActions";
+import { requestPhoneCode, selectExtraSecurity } from "../../../redux/actions/postResetPasswordActions";
 import ExtraSecurityToken from "../ResetPassword/ExtraSecurityToken";
 import { assertionFromAuthenticator } from "../../../app_utils/helperFunctions/authenticatorAssertion";
 import Splash from "../../../../containers/Splash";

--- a/src/login/components/LoginApp/ResetPassword/ExtraSecurity.js
+++ b/src/login/components/LoginApp/ResetPassword/ExtraSecurity.js
@@ -34,7 +34,7 @@ const SecurityKeyButton = ({
   ) : selected_option === "securityKey" ? <ExtraSecurityToken /> : null
 )};
 
-const SecurityWithSMSButton = ({ extraSecurityPhone, translate, dispatch, history, emailCode }) => {
+const SecurityWithSMSButton = ({ extraSecurityPhone, translate, dispatch }) => {
   const sendConfirmCode = (phone)=>{
     dispatch(requestPhoneCode(phone));
   };

--- a/src/login/redux/actions/postResetPasswordActions.js
+++ b/src/login/redux/actions/postResetPasswordActions.js
@@ -9,7 +9,6 @@ export const POST_RESET_PASSWORD_EXTRA_SECURITY_PHONE = "POST_RESET_PASSWORD_EXT
 export const POST_RESET_PASSWORD_EXTRA_SECURITY_PHONE_FAIL = "POST_RESET_PASSWORD_EXTRA_SECURITY_PHONE_FAIL";
 export const SAVE_PHONE_CODE = "SAVE_PHONE_CODE";
 export const SELECT_EXTRA_SECURITY_OPTION = "SELECT_EXTRA_SECURITY_OPTION";
-export const ADD_EXTRA_SECURITY_PHONE_INFO = "ADD_EXTRA_SECURITY_PHONE_INFO";
 
 export function postEmailLink(email) {
   return {
@@ -58,18 +57,6 @@ export function postLinkCodeFail(err) {
 export function requestPhoneCode(phone) {
   return {
     type: POST_RESET_PASSWORD_EXTRA_SECURITY_PHONE,
-    payload: {
-      phone: {
-        index: phone.index,
-        number: phone.number
-      }
-    }
-  };
-}
-
-export function selectedPhoneInfo(phone) {
-  return {
-    type: ADD_EXTRA_SECURITY_PHONE_INFO,
     payload: {
       phone: {
         index: phone.index,

--- a/src/login/redux/reducers/resetPasswordReducer.js
+++ b/src/login/redux/reducers/resetPasswordReducer.js
@@ -59,11 +59,6 @@ let resetPasswordReducer = (state = data, action) => {
         ...state,
         ...action.payload
       };
-    case postActions.ADD_EXTRA_SECURITY_PHONE_INFO:
-      return {
-        ...state,
-        ...action.payload
-      };
     default:
       return state;
   }

--- a/src/login/styles/_ResetPassword.scss
+++ b/src/login/styles/_ResetPassword.scss
@@ -73,7 +73,9 @@
       padding-left: 6px;
     }
   }
-  button#extra-security {
+  button#extra-security-key, 
+  #extra-security-freja,
+  #extra-security-phone {
     margin-bottom: 0.5rem;
   }
   p.decription-without-security{
@@ -99,9 +101,6 @@
         min-height: 1px;
         padding: 1.25rem;
       }
-    }
-    button#extra-security {
-      margin-bottom: 0.5rem;
     }
   }
 


### PR DESCRIPTION
#### Description:
This PR is to remove "enter code" link inside loop. API call to "/extra-security-phone/" for reset password phone_index is not needed. so now there will be only one link to enter phone code form below all individual phone number sms request buttons.

#### Summary:
- Removed unnecessary function for `selectedPhoneInfo`
- Moved link `toPhoneCodeForm` to outside of phone button loop
- Adjust styling for extra security buttons after added unique id for extra security buttons

---
- Before
<img width="1436" alt="Screenshot 2021-08-27 at 15 13 31" src="https://user-images.githubusercontent.com/44289056/131133682-c6714370-da71-43b7-a690-c35da41d923f.png">

- After
<img width="1436" alt="Screenshot 2021-08-27 at 15 13 51" src="https://user-images.githubusercontent.com/44289056/131133732-2aab279b-d716-4125-bab6-f1500f6a3309.png">


---



#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

