### PR TITLE
SIGNUP:  Fix unknown message id in reset password button

### DIFF
--- a/src/login/translation/defaultMessages/password.js
+++ b/src/login/translation/defaultMessages/password.js
@@ -202,6 +202,14 @@ export const changePassword = {
       defaultMessage={`Password`}
     />
   ),
+
+  // links to reset password from sign up
+  "used.reset-password": (
+    <FormattedMessage
+      id="used.reset-password"
+      defaultMessage={`Reset your password`}
+    />
+  ),
 };
 
 export const resetPassword = {

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -449,7 +449,7 @@
   "u2f.push-the-button": "Tryck på knappen på din U2F-säkerhetsnyckel",
   "unexpected-problem": "Ett okänt fel inträffade. Var god försök igen och kontakta supporten om felet kvarstår.",
   "unexpected-success": "Klart",
-  "used.email-in-use": "E-postadressen används redan",
+  "used.email-in-use": "Ett eduID konto använder redan {email}",
   "used.email-label": "Om detta är ditt eduID, kan du återställa lösenord för att kunna logga in igen.",
   "used.forgot-password": "Glömt ditt lösenord?",
   "used.reset-password": "Återställ lösenord",

--- a/src/login/translation/src/login/translation/defaultMessages/password.json
+++ b/src/login/translation/src/login/translation/defaultMessages/password.json
@@ -116,6 +116,10 @@
     "defaultMessage": "Password"
   },
   {
+    "id": "used.reset-password",
+    "defaultMessage": "Reset your password"
+  },
+  {
     "id": "resetpw.heading-add-email",
     "defaultMessage": "Enter your email address registered to your account"
   },


### PR DESCRIPTION
#### Description:
This PR is to fix an issue in staging, there is a missing translation of the text, it is for reset password button.
I adjusted the text  `used.email-in-use` to `An eduID is already using {email}` in English and `Ett eduID konto använder redan {email}` in Swedish, and added value to Swedish text for displaying email address

#### Summary:
- Added used.reset-password in password.js
- Adjusted Swedish text E-postadressen används redan -> Ett eduID konto använder redan {email}

---




- in English (before)
<img width="250" alt="Screenshot 2021-09-01 at 09 03 03" src="https://user-images.githubusercontent.com/44289056/131626929-49364386-09e8-4c43-afc6-92e69ec3d020.png">

- in English (after)
<img width="250" alt="Screenshot 2021-09-01 at 08 49 33" src="https://user-images.githubusercontent.com/44289056/131625859-7fdf1a0a-4aa8-4e2f-8dd6-98f0dc1219a7.png">

- in Swedish (before)

<img width="250" alt="Screenshot 2021-09-01 at 09 33 00" src="https://user-images.githubusercontent.com/44289056/131631021-4ba9362e-9dda-40a0-bc78-51dca347ab2e.png">


- in Swedish (after)
<img width="250" alt="Screenshot 2021-09-01 at 08 49 41" src="https://user-images.githubusercontent.com/44289056/131630405-5bfb329f-5c33-4f42-a2c7-7bb788b25811.png">

---

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

