### PR TITLE
SIGNUP: make available to register new account after registering an incorrect email 

### DIFF
--- a/src/actions/Captcha.js
+++ b/src/actions/Captcha.js
@@ -1,8 +1,8 @@
 export const CAPTCHA_VERIFICATION = "CAPTCHA_VERIFICATION";
-
 export const POST_SIGNUP_TRYCAPTCHA = "POST_SIGNUP_TRYCAPTCHA";
 export const POST_SIGNUP_TRYCAPTCHA_SUCCESS = "POST_SIGNUP_TRYCAPTCHA_SUCCESS";
 export const POST_SIGNUP_TRYCAPTCHA_FAIL = "POST_SIGNUP_TRYCAPTCHA_FAIL";
+export const IS_CAPTCHA_AVAILABLE = "IS_CAPTHA_AVAILABLE";
 
 export function verifyCaptcha(response) {
   return {
@@ -28,6 +28,15 @@ export function postCaptchaFail(err) {
     error: true,
     payload: {
       message: err,
+      disabledButton: false
+    }
+  };
+}
+
+export function makeCapthaButtonAvailable() {
+  return {
+    type: IS_CAPTCHA_AVAILABLE,
+    payload: {
       disabledButton: false
     }
   };

--- a/src/containers/Email.js
+++ b/src/containers/Email.js
@@ -1,6 +1,8 @@
 import { connect } from "react-redux";
 import RegisterEmail from "../login/components/RegisterEmail/RegisterEmail";
 import * as actions from "actions/Email";
+import { makeCapthaButtonAvailable } from "actions/Captcha";
+import { eduidRMAllNotify } from "actions/Notifications";
 import i18n from "../login/translation/InjectIntl_HOC_factory";
 import { history } from "components/SignupMain";
 
@@ -28,6 +30,10 @@ const mapDispatchToProps = (dispatch) => {
       e.preventDefault();
       dispatch(actions.acceptTOU());
       history.push(BASE_PATH + "/trycaptcha");
+      // remove remained notification message
+      dispatch(eduidRMAllNotify());
+      // to make captch button active
+      dispatch(makeCapthaButtonAvailable());
     },
     handleReject: (e) => {
       e.preventDefault();

--- a/src/reducers/Captcha.js
+++ b/src/reducers/Captcha.js
@@ -23,6 +23,11 @@ let captchaReducer = (state = captchaData, action) => {
         ...state,
         disabledButton: false
       };
+    case actions.IS_CAPTCHA_AVAILABLE:
+      return {
+        ...state,
+        disabledButton: false
+      };
     default:
       return state;
   }


### PR DESCRIPTION
#### Description:
This PR is to fix an issue with reregistration of new accounts, if the user is adding an incorrect email adress and notices this in the final stage "email sent", if the user is returning to "register page" using the browser "previous" button, the "captcha" function didn't allow a new email adress to be register.

#### Summary:
- Added function `makeCapthaButtonAvailable()` to activate button onclick accept TOU
- Added dispatch remove notification onclick accept TOU

**To test follow this steps:**
1.  Register a new user 
2.  Use the "previous " button in browser twice to be abele to change email adress
3. Change the email and try register 
4. "captcha" should work and a email should be sent to the "new email adress" 

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
