### PR TITLE
RESETPASSWORD: Move the send link button for reset password form to allow longer email addresses

### DIFF
--- a/src/login/styles/_ResetPassword.scss
+++ b/src/login/styles/_ResetPassword.scss
@@ -37,9 +37,9 @@
 
 .return-login-link {
   font-size: 1rem;
-  margin-top: 0.5rem;
   display: flex;
   justify-content: flex-start;
+  padding-left: 6px;
 
   a:hover {
     color: $orange-highlight;
@@ -115,6 +115,7 @@
     margin-bottom: 0;
   }
   & #reset-password-button {
+    margin: 2rem 0 1rem 0;
     width: fit-content;
   }
 }

--- a/src/login/styles/_ResetPassword.scss
+++ b/src/login/styles/_ResetPassword.scss
@@ -110,14 +110,12 @@
   }
 
 #reset-password-form {
-  display: flex;
-  flex-direction: row;
   margin-top: 0;
   &.form-group {
     margin-bottom: 0;
   }
   & #reset-password-button {
-    margin: 1.6rem 0 0 1rem;
+    width: fit-content;
   }
 }
 


### PR DESCRIPTION
#### Description:
This PR moves the send button for reset password input for email, instead of having the button at the same row as the input, it is now below the input field to allow display of long email address 


---
- desktop 1200px
<img width="600" alt="Screenshot 2021-09-06 at 10 36 13" src="https://user-images.githubusercontent.com/44289056/132187533-ee2af917-c6ca-4cc2-8750-67cd3819b8d2.png">

- mobile 360px
<img width="300" alt="Screenshot 2021-09-06 at 10 35 21" src="https://user-images.githubusercontent.com/44289056/132187583-06753e90-bbe3-498a-94bb-b898a28115af.png">


---


#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

