### PR TITLE
DASHBOARD: Alters DOM traversal to get value from security key input when adding new key

### DIFF
--- a/src/containers/Security.js
+++ b/src/containers/Security.js
@@ -12,7 +12,7 @@ import {
   startWebauthnRegistration,
   startAskWebauthnDescription,
   stopAskWebauthnDescription,
-  chooseAuthenticator
+  chooseAuthenticator,
 } from "actions/Security";
 import { eduidRMAllNotify } from "actions/Notifications";
 import i18n from "../login/translation/InjectIntl_HOC_factory";
@@ -25,60 +25,60 @@ const mapStateToProps = (state) => {
     redirect_to: state.security.location,
     deleted: state.security.deleted,
     webauthn_asking_description: state.security.webauthn_asking_description,
-    authenticator: state.security.webauthn_authenticator
+    authenticator: state.security.webauthn_authenticator,
   };
 };
 
 const mapDispatchToProps = (dispatch) => {
   return {
-    handleStartConfirmationPassword: function() {
+    handleStartConfirmationPassword: function () {
       dispatch(eduidRMAllNotify());
       dispatch(startConfirmationPassword());
     },
-    handleStopConfirmationPassword: function() {
+    handleStopConfirmationPassword: function () {
       dispatch(stopConfirmationPassword());
     },
     handleConfirmationPassword: () => {
       dispatch(confirmPasswordChange());
     },
-    handleStartConfirmationDeletion: function() {
+    handleStartConfirmationDeletion: function () {
       dispatch(eduidRMAllNotify());
       dispatch(startConfirmationDeletion());
     },
-    handleStopConfirmationDeletion: function() {
+    handleStopConfirmationDeletion: function () {
       dispatch(stopConfirmationDeletion());
     },
-    handleConfirmationDeletion: function() {
+    handleConfirmationDeletion: function () {
       dispatch(confirmDeletion());
     },
-    handleStartAskingKeyWebauthnDescription: function() {
+    handleStartAskingKeyWebauthnDescription: function () {
       dispatch(eduidRMAllNotify());
       dispatch(chooseAuthenticator("cross-platform"));
       dispatch(startAskWebauthnDescription());
     },
-    handleStartAskingDeviceWebauthnDescription: function() {
+    handleStartAskingDeviceWebauthnDescription: function () {
       dispatch(eduidRMAllNotify());
       dispatch(chooseAuthenticator("platform"));
       dispatch(startAskWebauthnDescription());
     },
-    handleStopAskingWebauthnDescription: function() {
+    handleStopAskingWebauthnDescription: function () {
       dispatch(stopAskWebauthnDescription());
     },
-    handleStartWebauthnRegistration: function() {
-      const description = document.getElementById(
-        "describeWebauthnTokenDialogControl"
-      ).children[1].value.trim();
+    handleStartWebauthnRegistration: function () {
+      const description = document
+        .getElementById("describeWebauthnTokenDialogControl")
+        .value.trim();
       dispatch(stopAskWebauthnDescription());
       dispatch(startWebauthnRegistration(description));
     },
-    handleRemoveWebauthnToken: function(e) {
+    handleRemoveWebauthnToken: function (e) {
       const token = e.target.closest(".webauthn-token-holder").dataset.token;
       dispatch(postRemoveWebauthnToken(token));
     },
-    handleVerifyWebauthnToken: function(e) {
+    handleVerifyWebauthnToken: function (e) {
       const token = e.target.closest(".webauthn-token-holder").dataset.token;
       dispatch(postVerifyWebauthnToken(token));
-    }
+    },
   };
 };
 


### PR DESCRIPTION
#### Description:
This PR addresses issue [683](https://github.com/SUNET/eduid-front/issues/683), where adding a security key has stopped working. In fact, the website crashes on OK button click because `description` variable in the `Container` is not pointing to the input value.

**Summary:**
1. DOM traversal shortened to pick up security name value

---  
###### Before and after clicking OK
<img width="350" alt="Screenshot 2021-09-07 at 14 32 19" src="https://user-images.githubusercontent.com/30963614/132346092-9da01314-1374-4e47-be68-c1a3431685f3.png"> <img width="350" alt="Screenshot 2021-09-07 at 14 32 30" src="https://user-images.githubusercontent.com/30963614/132346070-ea972904-e16c-4ccf-9638-cbc061acdcb7.png">
---

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

