### PR TITLE
RESETPASSWORD: Redirect from url reset-password to reset-password/email

### DIFF
--- a/src/login/components/LoginApp/LoginApp.js
+++ b/src/login/components/LoginApp/LoginApp.js
@@ -1,7 +1,7 @@
 /* eslint-disable */
 import React, { Component, useEffect } from "react";
 import { useDispatch, useSelector } from "react-redux";
-import { Route, withRouter } from "react-router-dom";
+import { Route, withRouter, Redirect } from "react-router-dom";
 import Login from "./Login/Login";
 import { useLoginRef } from "../../redux/actions/postRefLoginActions";
 import ResetPasswordMain from "./ResetPassword/ResetPasswordMain";
@@ -15,6 +15,11 @@ import ResetPasswordSuccess from "./ResetPassword/ResetPasswordSuccess";
  const RenderResetPassword = (props) => {
    return (
      <>
+     <Route
+        exact
+        path="/reset-password/"
+        component={() => <Redirect to="/reset-password/email" />}
+      />
       <Route
         path={`/reset-password/email`}
         render={(props) => <ResetPasswordMain {...props} />}

--- a/src/login/components/LoginApp/ResetPassword/ResetPasswordMain.js
+++ b/src/login/components/LoginApp/ResetPassword/ResetPasswordMain.js
@@ -50,7 +50,7 @@ EmailForm = connect(() => ({
 function ResetPasswordMain(props){
   const dispatch = useDispatch();
   const url = document.location.href;
-  const loginRef = url.split("/email/").reverse()[0];
+  const loginRef = url.split("/email").reverse()[0];
 
   useEffect(()=>{
     clearCountdown();
@@ -64,7 +64,6 @@ function ResetPasswordMain(props){
       setLocalStorage(LOCAL_STORAGE_PERSISTED_EMAIL , email)
     }
   };
-
   return (
     <>
       <p className="heading">{props.translate("resetpw.heading-add-email")}</p>


### PR DESCRIPTION
#### Description:
This PR is to redirect all users from `/reset-password/` to `reset-password/email`
at this time the `/reset-password/` page is blank, this PR will redirect all users who write url "/reset-password/" to reset password main page (reset-password/email)

To Test this PR:
check if this url "https://html.eduid.docker/reset-password" redirect to "https://html.eduid.docker/reset-password/email"

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

