### PR TITLE
RESETPASSWORD: disable send email link when request is being progressed

### DIFF
--- a/src/login/components/App/App_reducer.js
+++ b/src/login/components/App/App_reducer.js
@@ -4,6 +4,7 @@ import * as loadingDataActions from "../../redux/actions/loadingDataActions";
 const appData = {
   is_loaded: false,
   loading_data: false,
+  request_in_progress: false,
 };
 
 let appReducer = (state = appData, action) => {
@@ -22,6 +23,16 @@ let appReducer = (state = appData, action) => {
       return {
         ...state,
         loading_data: false,
+      };
+    case loadingDataActions.REQUEST_IN_PROGRESS:
+      return {
+        ...state,
+        request_in_progress: true,
+      };
+    case loadingDataActions.REQUEST_COMPLETED:
+      return {
+        ...state,
+        request_in_progress: false,
       };
     default:
       return state;

--- a/src/login/components/LoginApp/Login/UsernamePw.js
+++ b/src/login/components/LoginApp/Login/UsernamePw.js
@@ -29,6 +29,7 @@ const RenderRegisterLink = ({ translate }) => {
 
 const RenderResetPasswordLink = ({ translate }) => {
   const loginRef = useSelector((state) => state.login.ref);
+  const request_in_progress = useSelector((state) => state.app.request_in_progress);
   const dispatch = useDispatch();
   const history = useHistory();
   
@@ -43,11 +44,12 @@ const RenderResetPasswordLink = ({ translate }) => {
       }else history.push(`/reset-password/email/${loginRef}`)
     } else history.push(`/reset-password/email/${loginRef}`)
   };
-
+  
   return (
     <LinkRedirect
       id={"link-forgot-password"}
       to={"/"}
+      className={`send-link ${request_in_progress ? 'disabled' : ''}`}
       onClick={sendLink}
       text={translate("login.usernamePw.reset-password-link")}
     />

--- a/src/login/components/LoginApp/ResetPassword/ResetPasswordMain.js
+++ b/src/login/components/LoginApp/ResetPassword/ResetPasswordMain.js
@@ -1,6 +1,6 @@
 import React, { useEffect }  from "react";
 import InjectIntl from "../../../translation/InjectIntl_HOC_factory";
-import { useDispatch, connect } from 'react-redux';
+import {  useSelector, useDispatch, connect } from 'react-redux';
 import { postEmailLink } from "../../../redux/actions/postResetPasswordActions";
 import { Field, reduxForm } from "redux-form";
 import Form from "reactstrap/lib/Form";
@@ -29,7 +29,7 @@ let EmailForm = (props) => (
     <EduIDButton
       className="settings-button"
       id="reset-password-button"
-      disabled={props.invalid}
+      disabled={props.invalid || props.request_in_progress }
       onClick={props.sendLink}
     >
       {props.translate("resetpw.send-link")}
@@ -51,6 +51,7 @@ function ResetPasswordMain(props){
   const dispatch = useDispatch();
   const url = document.location.href;
   const loginRef = url.split("/email/").reverse()[0];
+  const request_in_progress = useSelector(state => state.app.request_in_progress);
 
   useEffect(()=>{
     clearCountdown();
@@ -64,11 +65,10 @@ function ResetPasswordMain(props){
       setLocalStorage(LOCAL_STORAGE_PERSISTED_EMAIL , email)
     }
   };
-
   return (
     <>
       <p className="heading">{props.translate("resetpw.heading-add-email")}</p>
-      <EmailForm sendLink={sendLink} {...props} />
+      <EmailForm sendLink={sendLink} {...props} request_in_progress={request_in_progress}/>
       <div className={loginRef ? `return-login-link` : `return-login-link disabled`}>
         <a id="return-login" href={`/login/password/${loginRef}`}>
           {props.translate("resetpw.return-login")}

--- a/src/login/redux/actions/loadingDataActions.js
+++ b/src/login/redux/actions/loadingDataActions.js
@@ -1,5 +1,7 @@
 export const LOAD_DATA_REQUEST = "LOAD_DATA_REQUEST";
 export const LOAD_DATA_COMPLETE = "LOAD_DATA_COMPLETE";
+export const REQUEST_IN_PROGRESS = "REQUEST_IN_PROGRESS";
+export const REQUEST_COMPLETED = "REQUEST_COMPLETED";
 
 export const loadingData = () => ({
   type: LOAD_DATA_REQUEST,
@@ -9,3 +11,10 @@ export const loadingDataComplete = () => ({
   type: LOAD_DATA_COMPLETE,
 });
 
+export const requestInProgress = () => ({
+  type: REQUEST_IN_PROGRESS,
+});
+
+export const requestCompleted = () => ({
+  type: REQUEST_COMPLETED,
+});

--- a/src/login/redux/sagas/resetpassword/postResetPasswordSaga.js
+++ b/src/login/redux/sagas/resetpassword/postResetPasswordSaga.js
@@ -7,6 +7,10 @@ import postRequest from "../postDataRequest";
 import { postEmailLinkFail } from "../../actions/postResetPasswordActions";
 import { history } from "../../../components/App/App";
 import { countDownStart, clearCountdown } from "../../../components/LoginApp/ResetPassword/CountDownTimer";
+import {
+  requestInProgress,
+  requestCompleted,
+} from "../../actions/loadingDataActions";
 
 export function* postEmailLink() {
   const state = yield select(state => state);
@@ -16,6 +20,7 @@ export function* postEmailLink() {
     csrf_token: state.config.csrf_token
   };
   try {
+    yield put(requestInProgress());
     const resp = yield call(postRequest, url, data);
     yield put(putCsrfToken(resp));
     yield put(resp);
@@ -26,5 +31,8 @@ export function* postEmailLink() {
       }
   } catch (error) {
     yield* failRequest(error, postEmailLinkFail(error));
+  }
+  finally {
+    yield put(requestCompleted());
   }
 }

--- a/src/login/styles/_Login.scss
+++ b/src/login/styles/_Login.scss
@@ -31,7 +31,7 @@
   }
 }
 
-#link-forgot-password {
+a.send-link {
   text-decoration: underline;
   &:hover {
     text-decoration: none;

--- a/src/login/styles/_Login.scss
+++ b/src/login/styles/_Login.scss
@@ -38,6 +38,14 @@ a.send-link {
   }
 }
 
+a.send-link.disabled {
+  color: $gray;
+  text-decoration: none;
+  &:hover {
+    cursor: not-allowed;
+  }
+}
+
 // terms of use
 .tou {
   .tou-text {

--- a/src/tests/ResetPassword-test.js
+++ b/src/tests/ResetPassword-test.js
@@ -13,6 +13,9 @@ const messages = require("../login/translation/messageIndex");
 addLocaleData("react-intl/locale-data/en");
 
 const baseState = {
+  app: {
+    request_in_progress: false,
+  },
   resetPassword: {
     email_address: ""
   },
@@ -39,7 +42,7 @@ function getFakeState(newState) {
   return Object.assign(baseState, newState)
 }
 
-describe("ResetPasswordMain Component, renders", () => {
+describe("renders", () => {
   const fakeState = getFakeState();
   function setupComponent() {
     const history = createMemoryHistory();

--- a/src/tests/sagas/postResetPasswordSaga-test.js
+++ b/src/tests/sagas/postResetPasswordSaga-test.js
@@ -17,6 +17,8 @@ const fakeState = {
 describe(`API call to "/" behaves as expected on _SUCCESS`, () => {
   const generator = postEmailLink();
   let next = generator.next();
+  next = generator.next(fakeState);
+  expect(next.value.PUT.action.type).toEqual("REQUEST_IN_PROGRESS");
   it("saga posts the expected data", () => {
     const data = {
       email: fakeState.resetPassword.email_address,
@@ -40,11 +42,19 @@ describe(`API call to "/" behaves as expected on _SUCCESS`, () => {
   next = generator.next();
   expect(next.value.PUT.action.type).toEqual("POST_RESET_PASSWORD_SUCCESS");
   });
+  it("done after 'REQUEST_COMPLETED'", () => {
+    next = generator.next();
+    expect(next.value.PUT.action.type).toEqual("REQUEST_COMPLETED");
+    const done = generator.next().done;
+    expect(done).toEqual(true);
+  });
 });
 
 describe(`first API call to "/" behaves as expected on _FAIL`, () => {
   const generator = postEmailLink();
   let next = generator.next();
+  next = generator.next(fakeState);
+  expect(next.value.PUT.action.type).toEqual("REQUEST_IN_PROGRESS");
   it("saga posts unexpected data", () => {
     const data = {
       email: "not found user",
@@ -69,7 +79,9 @@ describe(`first API call to "/" behaves as expected on _FAIL`, () => {
     expect(next.value.PUT.action.type).toEqual("POST_RESET_PASSWORD_FAIL");
     expect(failResponse).toEqual(postEmailLinkFail("error"));
   });
-  it("done after 'POST_RESET_PASSWORD_FAIL'", () => {
+  it("done after 'REQUEST_COMPLETED'", () => {
+    next = generator.next();
+    expect(next.value.PUT.action.type).toEqual("REQUEST_COMPLETED");
     const done = generator.next().done;
     expect(done).toEqual(true);
   });


### PR DESCRIPTION
#### Description:
This PR is to prevent the user to click multiple times on the send link.
so I have disabled the button when `request_in_progress` state is true 
when `request_in_progress` state is false (request is completed), the button will be active again for the user.

---
- **LOGIN PAGE** `forgot your password` link will deactivate when request is being progressed
<img width="819" alt="Screenshot 2021-09-08 at 09 57 25" src="https://user-images.githubusercontent.com/44289056/132469777-e9338046-ff02-4d35-bc36-bed39900c4c4.png">

- **RESET-PASSWORD PAGE** ` send email button` will deactivate when request is being progressed
<img width="1432" alt="Screenshot 2021-09-08 at 09 46 03" src="https://user-images.githubusercontent.com/44289056/132469891-c3cd7a51-df6e-48d7-8b50-8fe71caa9a2d.png">



---

**To test this PR**, add delay function in `postResetPasswordSaga.js` to show that the button is disabled 
```
**const delay = (ms) => new Promise(res => setTimeout(res, ms))**
export function* postEmailLink() {
 ...
  try {
    yield put(requestInProgress());
    **yield delay(10000);** 
```

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

