### PR TITLE
RESETPASSWORD: Add a "go back" button to extra security

### DIFF
--- a/src/login/components/LoginApp/ResetPassword/ExtraSecurity.js
+++ b/src/login/components/LoginApp/ResetPassword/ExtraSecurity.js
@@ -11,6 +11,7 @@ import { assertionFromAuthenticator } from "../../../app_utils/helperFunctions/a
 import Splash from "../../../../containers/Splash";
 import { eduidRMAllNotify, eduidNotify } from "../../../../actions/Notifications";
 import { saveLinkCode } from "./../../../redux/actions/postResetPasswordActions";
+import { cancelWebauthnAssertion } from "../../../redux/actions/getWebauthnAssertionActions";
 
 const SecurityKeyButton = ({ 
   selected_option,
@@ -82,6 +83,7 @@ function ExtraSecurity(props){
 
   useEffect(()=>{
     dispatch(selectExtraSecurity(null));
+    dispatch(cancelWebauthnAssertion ());
     if(extra_security !== undefined){
       if(Object.keys(extra_security).length > 0){
         setExtraSecurity(extra_security);

--- a/src/login/components/LoginApp/ResetPassword/PhoneCodeSent.js
+++ b/src/login/components/LoginApp/ResetPassword/PhoneCodeSent.js
@@ -60,6 +60,10 @@ let PhoneCodeForm = (props) => (
   })(PhoneCodeForm);
   
   PhoneCodeForm = connect(() => ({
+    enableReinitialize: true,
+    initialValues: {
+      phone: ""
+    },
     touchOnChange: true,
     destroyOnUnmount: false,
   }))(PhoneCodeForm);

--- a/src/login/components/LoginApp/ResetPassword/SetNewPassword.js
+++ b/src/login/components/LoginApp/ResetPassword/SetNewPassword.js
@@ -15,11 +15,12 @@ import {
   setNewPasswordExtraSecurityExternalMfa  
 } from "../../../redux/actions/postResetNewPasswordActions";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faCheck, faCopy } from "@fortawesome/free-solid-svg-icons";
+import { faCheck, faCopy, faArrowLeft } from "@fortawesome/free-solid-svg-icons";
 import { useHistory } from 'react-router-dom';
 import { emptyStringPattern } from "../../../app_utils/validation/regexPatterns";
 import PropTypes from "prop-types";
 import Splash from "../../../../containers/Splash";
+import ButtonSecondary from "../../Buttons/ButtonSecondary";
 
 const validateNewPassword = (values, props) => {
   const newPassword = "new-password";
@@ -33,7 +34,8 @@ const validateNewPassword = (values, props) => {
   return errors;
 };
 
-let NewPasswordForm = (props) =>{
+let NewPasswordForm = (props) => {
+  const history = useHistory();
   return (
     <Form autoComplete="on" id="new-password-form" role="form" aria-label="new-password form" onSubmit={props.clickSetNewPassword} >
       <Field
@@ -45,6 +47,17 @@ let NewPasswordForm = (props) =>{
         label={props.translate("chpass.form_custom_password_repeat")}
         placeholder="xxxx xxxx xxxx"
       />
+      <div className="new-password-button-container">
+      { props.extra_security && Object.keys(props.extra_security).length > 0 &&
+        <ButtonSecondary
+          className="secondary"
+          id="go-back-button"
+          onClick={() => history.push(`/reset-password/extra-security/${props.emailCode}`)}
+        >
+          <FontAwesomeIcon icon={faArrowLeft} />
+          <span>go back</span>
+        </ButtonSecondary>
+      }
       <EduIDButton
         className="settings-button"
         id="new-password-button"
@@ -52,6 +65,7 @@ let NewPasswordForm = (props) =>{
       >
         {props.translate("resetpw.accept-password")}
       </EduIDButton>
+      </div>
     </Form>
   ) 
 }
@@ -75,6 +89,9 @@ function SetNewPassword(props){
   );
   const selected_option = useSelector(
     (state) => state.resetPassword.selected_option
+  );
+  const extra_security = useSelector(
+    (state) => state.resetPassword.extra_security
   );
   const [password, setPassword] = useState(null);
   const ref = useRef(null);
@@ -138,6 +155,8 @@ function SetNewPassword(props){
       <NewPasswordForm {...props} 
         suggested_password={suggested_password}
         clickSetNewPassword={clickSetNewPassword}
+        emailCode={emailCode}
+        extra_security={extra_security}
       />
     </>
   ) 

--- a/src/login/components/LoginApp/ResetPassword/SetNewPassword.js
+++ b/src/login/components/LoginApp/ResetPassword/SetNewPassword.js
@@ -46,6 +46,7 @@ let NewPasswordForm = (props) => {
         required={true}
         label={props.translate("chpass.form_custom_password_repeat")}
         placeholder="xxxx xxxx xxxx"
+        autoComplete={"new-password"} 
       />
       <div className="new-password-button-container">
       { props.extra_security && Object.keys(props.extra_security).length > 0 &&
@@ -147,7 +148,6 @@ function SetNewPassword(props){
           ref={ref}
           defaultValue={password && password}
           readOnly={true}
-          autoComplete={"new-password"} 
         />
         <button id="clipboard" className="icon copybutton" onClick={copyToClipboard}> 
           <FontAwesomeIcon id={"icon-copy"} icon={faCopy} />

--- a/src/login/components/LoginApp/ResetPassword/SetNewPassword.js
+++ b/src/login/components/LoginApp/ResetPassword/SetNewPassword.js
@@ -78,6 +78,10 @@ NewPasswordForm = reduxForm({
 })(NewPasswordForm);
 
 NewPasswordForm = connect(() => ({
+  enableReinitialize: true,
+  initialValues: {
+    "new-password": ""
+  },
   destroyOnUnmount: false,
   touchOnChange: true,
   validate: validateNewPassword
@@ -102,6 +106,7 @@ function SetNewPassword(props){
   useEffect(()=>{
     setPassword(suggested_password);
     dispatch(saveLinkCode(emailCode));
+
   },[suggested_password, dispatch]);
 
   // Change path to extra-security without selected option on reload

--- a/src/login/components/LoginApp/ResetPassword/SetNewPassword.js
+++ b/src/login/components/LoginApp/ResetPassword/SetNewPassword.js
@@ -52,10 +52,12 @@ let NewPasswordForm = (props) => {
         <ButtonSecondary
           className="secondary"
           id="go-back-button"
-          onClick={() => history.push(`/reset-password/extra-security/${props.emailCode}`)}
+          onClick={() => 
+            history.push(`/reset-password/extra-security/${props.emailCode}`)
+          }
         >
           <FontAwesomeIcon icon={faArrowLeft} />
-          <span>go back</span>
+          {props.translate("resetpw.go-back")}
         </ButtonSecondary>
       }
       <EduIDButton

--- a/src/login/styles/_ResetPassword.scss
+++ b/src/login/styles/_ResetPassword.scss
@@ -122,10 +122,27 @@
 }
 
 #new-password-form {
-  & button.settings-button{
-    width: fit-content;
-    margin-bottom: 1rem;
+  .new-password-button-container{
+    display: flex;
+    justify-content: space-between;
+    & button.btn.btn-secondary{
+      margin-top: 1rem;
+      color: $orange-highlight;
+      border: none;
+      border: solid 2px $orange-highlight;
+      text-transform: uppercase;
+      background-color: $white;
+      svg {
+        transform: rotate(0deg);
+        padding-right: 3px;
+      }
+    }
+    & button.settings-button{
+      width: fit-content;
+      margin-bottom: 1rem;
+    }
   }
+
   .form-control[readonly] {
     background-color: $white;
   }

--- a/src/login/styles/_ResetPassword.scss
+++ b/src/login/styles/_ResetPassword.scss
@@ -138,7 +138,6 @@
       }
     }
     & button.settings-button{
-      width: fit-content;
       margin-bottom: 1rem;
     }
   }
@@ -229,6 +228,16 @@ a#resend-link {
       #save-phone-button {
       width: 100%;
       margin-left: 0;
+    }
+  }
+}
+
+@media (max-width: 414px) {
+  .new-password-button-container {
+    flex-direction: column-reverse;
+    #go-back-button{
+      margin-top: 0.5rem;
+      margin-left: 0px;
     }
   }
 }

--- a/src/login/styles/_ResetPassword.scss
+++ b/src/login/styles/_ResetPassword.scss
@@ -233,9 +233,10 @@ a#resend-link {
 }
 
 @media (max-width: 414px) {
-  .new-password-button-container {
+  #new-password-form .new-password-button-container {
     flex-direction: column-reverse;
-    #go-back-button{
+    margin-top: 1rem;
+    button#go-back-button{
       margin-top: 0.5rem;
       margin-left: 0px;
     }

--- a/src/login/styles/_buttons.scss
+++ b/src/login/styles/_buttons.scss
@@ -261,7 +261,8 @@ button.icon {
   a.modal-button.ok-button,
   button.btn-secondary,
   #security-webauthn-button,
-  #connect-orcid-button {
+  #connect-orcid-button,
+  #new-password-button {
     width: 100%;
   }
   button.btn.btn-link,

--- a/src/login/translation/defaultMessages/password.js
+++ b/src/login/translation/defaultMessages/password.js
@@ -450,4 +450,10 @@ export const resetPassword = {
       defaultMessage={`External MFA failed.`}
     />
   ),
+  "resetpw.go-back": (
+    <FormattedMessage
+      id="resetpw.go-back"
+      defaultMessage={`go back`}
+    />
+  ),
 };

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -358,6 +358,7 @@
   "resetpw.external-mfa-fail": "External MFA failed",
   "resetpw.fido-token-fail": "There was a problem using your security key for resetting password",
   "resetpw.go-to-eduid": "go to eduID",
+  "resetpw.go-back": "go back",
   "resetpw.heading-add-email": "Enter your email address registered to your account",
   "resetpw.invalid_user": "User has not completed signup",
   "resetpw.invalid_session": "Invalid session, please try again",

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -358,6 +358,7 @@
   "resetpw.external-mfa-fail": "Externt MFA misslyckades",
   "resetpw.fido-token-fail": "Det uppstod ett problem med din säkerhetsnyckel för återställning av lösenordet",
   "resetpw.go-to-eduid": "gå till eduID",
+  "resetpw.go-back": "gå tillbaka",
   "resetpw.heading-add-email": "Ange din e-postadress registrerad till ditt konto",
   "resetpw.invalid_user": "Användaren har inte slutfört registreringen",
   "resetpw.invalid_session": "Ogiltig session, var god försök igen.",

--- a/src/login/translation/src/login/translation/defaultMessages/password.json
+++ b/src/login/translation/src/login/translation/defaultMessages/password.json
@@ -270,5 +270,9 @@
   {
     "id": "resetpw.external-mfa-fail",
     "defaultMessage": "External MFA failed."
+  },
+  {
+    "id": "resetpw.go-back",
+    "defaultMessage": "go back"
   }
 ]


### PR DESCRIPTION
#### Description:
This PR is to add a "go back" button for user who has an extra security.
the button will make it possible for the user to go back to the page where they can select another option of the "extra security"
And if the user fails to set a new password they are able to return to the extra security page


---
<img width="532" alt="Screenshot 2021-09-09 at 11 05 22" src="https://user-images.githubusercontent.com/44289056/132662683-66624a76-c958-44de-810f-c1e3c2b640a9.png">

---


#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

