### PR TITLE
RESETPASSWORD: Add  hover effect information to copy icon for new password

### DIFF
--- a/src/login/components/LoginApp/ResetPassword/SetNewPassword.js
+++ b/src/login/components/LoginApp/ResetPassword/SetNewPassword.js
@@ -101,6 +101,7 @@ function SetNewPassword(props){
     (state) => state.resetPassword.extra_security
   );
   const [password, setPassword] = useState(null);
+  const [toolTipText, setToolTipText] = useState("copy to clipboard");
   const ref = useRef(null);
 
   useEffect(()=>{
@@ -119,11 +120,13 @@ function SetNewPassword(props){
   const copyToClipboard = () => {
     ref.current.select();
     document.execCommand('copy');
+    setToolTipText("copied")
     document.getElementById("icon-copy").style.display = "none";
     document.getElementById("icon-check").style.display = "inline";
     setTimeout(()=> {
       document.getElementById("icon-copy").style.display = "inline";
       document.getElementById("icon-check").style.display = "none";
+      setToolTipText("copy to clipboard")
     }, 1000);
   };
 
@@ -157,6 +160,7 @@ function SetNewPassword(props){
         <button id="clipboard" className="icon copybutton" onClick={copyToClipboard}> 
           <FontAwesomeIcon id={"icon-copy"} icon={faCopy} />
           <FontAwesomeIcon id={"icon-check"} icon={faCheck} />
+          <span className="tool-tip-text" id="tool-tip">{toolTipText}</span>
         </button> 
       </div>
       <NewPasswordForm {...props} 

--- a/src/login/components/LoginApp/ResetPassword/SetNewPassword.js
+++ b/src/login/components/LoginApp/ResetPassword/SetNewPassword.js
@@ -101,7 +101,7 @@ function SetNewPassword(props){
     (state) => state.resetPassword.extra_security
   );
   const [password, setPassword] = useState(null);
-  const [toolTipText, setToolTipText] = useState("copy to clipboard");
+  const [toolTipText, setToolTipText] = useState("resetpw.copy-to-clipboard");
   const ref = useRef(null);
 
   useEffect(()=>{
@@ -120,13 +120,13 @@ function SetNewPassword(props){
   const copyToClipboard = () => {
     ref.current.select();
     document.execCommand('copy');
-    setToolTipText("copied")
+    setToolTipText("resetpw.copied-in-clipboard")
     document.getElementById("icon-copy").style.display = "none";
     document.getElementById("icon-check").style.display = "inline";
     setTimeout(()=> {
       document.getElementById("icon-copy").style.display = "inline";
       document.getElementById("icon-check").style.display = "none";
-      setToolTipText("copy to clipboard")
+      setToolTipText("resetpw.copy-to-clipboard")
     }, 1000);
   };
 
@@ -160,7 +160,7 @@ function SetNewPassword(props){
         <button id="clipboard" className="icon copybutton" onClick={copyToClipboard}> 
           <FontAwesomeIcon id={"icon-copy"} icon={faCopy} />
           <FontAwesomeIcon id={"icon-check"} icon={faCheck} />
-          <span className="tool-tip-text" id="tool-tip">{toolTipText}</span>
+          <div className="tool-tip-text" id="tool-tip">{props.translate(toolTipText)}</div>
         </button> 
       </div>
       <NewPasswordForm {...props} 

--- a/src/login/styles/_ResetPassword.scss
+++ b/src/login/styles/_ResetPassword.scss
@@ -198,12 +198,13 @@ a#resend-link {
   background-color: $orange-opaque;
   top: 2rem;
   right: 1rem;
+  box-shadow: none;
   #icon-check {
     display: none;
   }
   .tool-tip-text {
     visibility: hidden;
-    width: 120px;
+    width: 100px;
     background-color: $black;
     color: $white;
     font-size: 0.875rem;
@@ -213,7 +214,7 @@ a#resend-link {
     position: absolute;
     z-index: 1;
     bottom: 150%;
-    left: 30%;
+    left: 2rem;
     margin-left: -75px;
     opacity: 0;
     transition: opacity 0.3s;
@@ -223,7 +224,7 @@ a#resend-link {
     content: "";
     position: absolute;
     top: 100%;
-    left: 60%;
+    left: 3.5rem;
     margin-left: -5px;
     border-width: 5px;
     border-style: solid;

--- a/src/login/styles/_ResetPassword.scss
+++ b/src/login/styles/_ResetPassword.scss
@@ -201,6 +201,39 @@ a#resend-link {
   #icon-check {
     display: none;
   }
+  .tool-tip-text {
+    visibility: hidden;
+    width: 120px;
+    background-color: $black;
+    color: $white;
+    font-size: 0.875rem;
+    font-family: "ProximaNova-Regular", Arial, Helvetica, sans-serif;
+    border-radius: 4px;
+    padding: 6px;
+    position: absolute;
+    z-index: 1;
+    bottom: 150%;
+    left: 30%;
+    margin-left: -75px;
+    opacity: 0;
+    transition: opacity 0.3s;
+  }
+  
+ .tool-tip-text::after {
+    content: "";
+    position: absolute;
+    top: 100%;
+    left: 60%;
+    margin-left: -5px;
+    border-width: 5px;
+    border-style: solid;
+    border-color: $black transparent transparent transparent;
+  }
+  
+  &:hover .tool-tip-text {
+    visibility: visible;
+    opacity: 1;
+  }
 }
 
 .button-tooltip-container {
@@ -217,6 +250,15 @@ a#resend-link {
     font-size: 1rem;
     margin-left: -2px;
   }
+}
+
+.signature {
+  position: absolute;
+  right: 12px;
+  bottom: 12px;
+  
+  color: rgba(0,0,0,.07);
+  font-size: 10px;
 }
 
 @media (max-width: 568px) {

--- a/src/login/styles/_ResetPassword.scss
+++ b/src/login/styles/_ResetPassword.scss
@@ -253,15 +253,6 @@ a#resend-link {
   }
 }
 
-.signature {
-  position: absolute;
-  right: 12px;
-  bottom: 12px;
-  
-  color: rgba(0,0,0,.07);
-  font-size: 10px;
-}
-
 @media (max-width: 568px) {
   #reset-password-form, 
   #phone-code-form {

--- a/src/login/translation/defaultMessages/password.js
+++ b/src/login/translation/defaultMessages/password.js
@@ -456,4 +456,16 @@ export const resetPassword = {
       defaultMessage={`go back`}
     />
   ),
+  "resetpw.copy-to-clipboard": (
+    <FormattedMessage
+      id="resetpw.copy-to-clipboard"
+      defaultMessage={`Copy to clipboard`}
+    />
+  ),
+  "resetpw.copied-in-clipboard": (
+    <FormattedMessage
+      id="resetpw.copied-in-clipboard"
+      defaultMessage={`Copied!`}
+    />
+  ),
 };

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -353,6 +353,8 @@
   "resetpw.accept-password": "accept password",
   "resetpw.check-email-link": "Please check your email <b>{email}</b> to continue. \n Link is valid for 2 hours.",
   "resetpw.continue_reset_password": "Continue reset password",
+  "resetpw.copy-to-clipboard": "Copy to clipboard",
+  "resetpw.copied-in-clipboard": "Copied!",
   "resetpw.email-send-failure": "Error sending mail, please try again",
   "resetpw.email-throttled": "Reset password link already sent please try again later",
   "resetpw.enter-code": "enter code",

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -353,6 +353,8 @@
   "resetpw.accept-password": "acceptera lösenord",
   "resetpw.check-email-link": "Kontrollera din e-postadress <b>{email}</b> för att fortsätta. \n Länken är giltig i två timmar.",
   "resetpw.continue_reset_password": "Forsätt återställ lösenordet",
+  "resetpw.copy-to-clipboard": "Kopiera till urklipp",
+  "resetpw.copied-in-clipboard": "Kopierat!",
   "resetpw.email-send-failure": "Misslyckades att skicka e-post, vänligen försök igen",
   "resetpw.email-throttled": "Återställ lösenordslänken har redan skickats, försök igen senare",
   "resetpw.enter-code": "skriv in koden",

--- a/src/login/translation/src/login/translation/defaultMessages/password.json
+++ b/src/login/translation/src/login/translation/defaultMessages/password.json
@@ -274,5 +274,13 @@
   {
     "id": "resetpw.go-back",
     "defaultMessage": "go back"
+  },
+  {
+    "id": "resetpw.copy-to-clipboard",
+    "defaultMessage": "Copy to clipboard"
+  },
+  {
+    "id": "resetpw.copied-in-clipboard",
+    "defaultMessage": "Copied!"
   }
 ]


### PR DESCRIPTION
#### Description: 
To explain the function of the `Copy to clipboard` button/ icon, I have added tool tip with hover effect. 
When hovering the icon, the information `Copy to clipboard(eng) / Kopiera till urklipp(swe)` will display
When icon has been clicked, the information `Copied!(eng) / Kopierat!(swe)` will be displayed

---
- Hover effect (Desktop mode)
<img width="907" alt="Screenshot 2021-09-10 at 14 36 22" src="https://user-images.githubusercontent.com/44289056/132854603-4ed6e2cb-e71a-4247-9d00-390f540efc74.png">

- onClick
<img width="907" alt="Screenshot 2021-09-10 at 14 39 51" src="https://user-images.githubusercontent.com/44289056/132854661-2ae05255-5660-48c2-8802-1189da32179a.png">


- Hover effect (Mobile mode)
<img width="222" alt="Screenshot 2021-09-10 at 14 36 52" src="https://user-images.githubusercontent.com/44289056/132854705-ce858093-081d-4f8b-a5a4-5f92f374f0e2.png">

- onClick
<img width="222" alt="Screenshot 2021-09-10 at 14 39 32" src="https://user-images.githubusercontent.com/44289056/132854717-6d1ea252-0c28-493a-888b-235d3e37e56e.png">


---

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

