### PR TITLE
RESETPASSWORD: Change link to new reset password url

### DIFF
--- a/src/components/EmailInUse.js
+++ b/src/components/EmailInUse.js
@@ -16,7 +16,7 @@ class EmailInUse extends Component {
             <p>{this.props.translate("used.email-label")}</p>
           </div>
 
-          <a href={this.props.reset_url}>
+          <a href={this.props.reset_password_link}>
             <EduIDButton className="settings-button">
               {this.props.translate("used.reset-password")}
             </EduIDButton>

--- a/src/containers/EmailInUse.js
+++ b/src/containers/EmailInUse.js
@@ -6,7 +6,7 @@ import EmailInUse from "components/EmailInUse";
 const mapStateToProps = (state) => {
   return {
     email: state.email.email,
-    reset_url: state.config.reset_passwd_url
+    reset_password_link: state.config.reset_password_link
   };
 };
 


### PR DESCRIPTION
#### Description:
When user is attempting to signup using an email address that is already in use, there is an option to go to reset password. the button used the old url.
This PR is to change the old url to new reset password url from config ("https://html.eduid.docker/reset-password/")

---

<img width="296" alt="Screenshot 2021-09-10 at 15 56 54" src="https://user-images.githubusercontent.com/44289056/132864870-4bb269ce-527d-43dc-b970-a7c38b42f908.png">

---



#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

