### PR TITLE
NOTIFICATION: Fix issue with notification message covering content

### DIFF
--- a/src/login/styles/_Notifications.scss
+++ b/src/login/styles/_Notifications.scss
@@ -5,7 +5,6 @@
   flex-direction: column;
   color: transparent;
   background-color: transparent;
-  height: 3rem;
   margin-bottom: 0.75rem;
   width: 100%;
   z-index: 1;

--- a/src/login/styles/_base.scss
+++ b/src/login/styles/_base.scss
@@ -52,6 +52,7 @@ article {
   // this is added to prevent margin collapse (look for other solution if causing problems)
   display: flex;
   flex-direction: column;
+  padding-top: 2rem;
 }
 
 fieldset {

--- a/src/login/styles/_base.scss
+++ b/src/login/styles/_base.scss
@@ -52,6 +52,9 @@ article {
   // this is added to prevent margin collapse (look for other solution if causing problems)
   display: flex;
   flex-direction: column;
+}
+
+.horizontal-content-margin {
   padding-top: 2rem;
 }
 


### PR DESCRIPTION
#### Description:
This PR is to fix the issue with notification messages covering content on small size screens

#### Summary:
- Removed height: 3rem for notification-area
- Added padding-top: 2rem for horizontal-content-margin

 Please render any error and display at any page on small size screen to confirm that the fix solve this issue 

---
- Before 

![Screenshot 2021-09-13 at 11 58 06](https://user-images.githubusercontent.com/44289056/133064272-5f4b8fe5-08b4-4f40-a188-c84818cc83b9.png)

- After

![Screenshot 2021-09-13 at 11 58 13](https://user-images.githubusercontent.com/44289056/133064320-4c6f3453-ef2d-4574-b016-d8fa26c4841a.png)


---


#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

