### PR TITLE
RESETPASSWORD: Adjust description text for resending phone code/email link depending on if count down timer is active or not

### DIFF
--- a/src/login/components/LoginApp/ResetPassword/CountDownTimer.js
+++ b/src/login/components/LoginApp/ResetPassword/CountDownTimer.js
@@ -20,6 +20,7 @@ export const setLocalStorage = (key, val) => {
 
 export const countFiveMin = (key) => {
   const elementResendLink = document.querySelector(`#resend-${key}`);
+  const elementTextIn = document.getElementById("timer-in");
   const elementCountDownTime = document.getElementById(`count-down-time-${key}`);
   // Resend link button will be disabled
   elementResendLink !== null && elementResendLink.classList.remove('button-active');
@@ -40,10 +41,12 @@ export const countFiveMin = (key) => {
     // If the count down is over, resend-${key} will be active and timer will be display-none
       if (period < 0) {
         elementCountDownTime && elementCountDownTime.classList.add('display-none');
+        elementTextIn && elementTextIn.classList.add('display-none');
         elementResendLink && elementResendLink.classList.add('button-active');
         clearInterval(timer);  
       }else {
         elementResendLink && elementResendLink.classList.remove('button-active');
+        elementTextIn && elementTextIn.classList.remove('display-none');
         elementCountDownTime && elementCountDownTime.classList.remove('display-none');
       }
     }, 1000);

--- a/src/login/components/LoginApp/ResetPassword/EmailLinkSent.js
+++ b/src/login/components/LoginApp/ResetPassword/EmailLinkSent.js
@@ -42,6 +42,7 @@ function EmailLinkSent(props){
             <a id={"resend-email"} onClick={sendLink}> 
               {props.translate("resetpw.resend-link-button")} 
             </a>
+            <span id="timer-in" className="display-none">{props.translate("resetpw.resend-timer-in")} </span>
             <span id="count-down-time-email" />
           </p>
         </div>

--- a/src/login/components/LoginApp/ResetPassword/PhoneCodeSent.js
+++ b/src/login/components/LoginApp/ResetPassword/PhoneCodeSent.js
@@ -118,6 +118,7 @@ function PhoneCodeSent(props){
           <a id={"resend-phone"} onClick={resendPhoneCode}> 
             {props.translate("cm.resend_code")} 
           </a>
+          <span id="timer-in" className="display-none">{props.translate("resetpw.resend-timer-in")} </span>
           <span id="count-down-time-phone" />
         </div>
       </div>

--- a/src/login/styles/_ResetPassword.scss
+++ b/src/login/styles/_ResetPassword.scss
@@ -156,6 +156,11 @@
   span#count-down-time-phone {
     color: $gray;
   }
+  span#timer-in{
+    font-family: "Akkurat";
+    color: $gray;
+    font-size: 1rem;
+  }
 }
 
 a#resend-email, 

--- a/src/login/styles/_ResetPassword.scss
+++ b/src/login/styles/_ResetPassword.scss
@@ -148,7 +148,6 @@
 }
 
 .timer {
-  display: flex;
   .display-none {
     display: none;
   }

--- a/src/login/translation/defaultMessages/password.js
+++ b/src/login/translation/defaultMessages/password.js
@@ -283,7 +283,7 @@ export const resetPassword = {
   "resetpw.resend-link-button": (
     <FormattedMessage
       id="resetpw.resend-link-button"
-      defaultMessage={`resend link in`}
+      defaultMessage={`resend link`}
     /> 
   ),
   "resetpw.extra-security_heading": (

--- a/src/login/translation/defaultMessages/password.js
+++ b/src/login/translation/defaultMessages/password.js
@@ -286,6 +286,12 @@ export const resetPassword = {
       defaultMessage={`resend link`}
     /> 
   ),
+  "resetpw.resend-timer-in": (
+    <FormattedMessage
+      id="resetpw.resend-timer-in"
+      defaultMessage={`in`}
+    /> 
+  ),
   "resetpw.extra-security_heading": (
     <FormattedMessage
       id="resetpw.extra-security_heading"

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -382,7 +382,7 @@
   "resetpw.pw-reset-fail": "Reset password failed, please try again",
   "resetpw.received-sms": "Already received sms? ",
   "resetpw.resend-link": "If you didn’t receive the email? Check your junk email, \n or",
-  "resetpw.resend-link-button": "resend link in",
+  "resetpw.resend-link-button": "resend link",
   "resetpw.reset-pw-initialized": "Reset password link has been sent to your email.",
   "resetpw.return-login": "return to Login",
   "resetpw.send-link": "send link to email",

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -383,6 +383,7 @@
   "resetpw.received-sms": "Already received sms? ",
   "resetpw.resend-link": "If you didn’t receive the email? Check your junk email, \n or",
   "resetpw.resend-link-button": "resend link",
+  "resetpw.resend-timer-in": "in",
   "resetpw.reset-pw-initialized": "Reset password link has been sent to your email.",
   "resetpw.return-login": "return to Login",
   "resetpw.send-link": "send link to email",

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -383,6 +383,7 @@
   "resetpw.received-sms": "Redan fått sms? ",
   "resetpw.resend-link": "Om du inte fick e-postmeddelandet? Kontrollera skräppost, \n eller",
   "resetpw.resend-link-button": "skicka länk igen",
+  "resetpw.resend-timer-in": "om",
   "resetpw.reset-pw-initialized": "Återställningslänken har skickats till din epost.",
   "resetpw.return-login": "återgå till inloggningen",
   "resetpw.send-link": "Skicka länk till e-postadress",

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -382,7 +382,7 @@
   "resetpw.pw-reset-fail": "Återställning av lösenordet misslyckades, vänligen försök igen",
   "resetpw.received-sms": "Redan fått sms? ",
   "resetpw.resend-link": "Om du inte fick e-postmeddelandet? Kontrollera skräppost, \n eller",
-  "resetpw.resend-link-button": "skicka länk igen om",
+  "resetpw.resend-link-button": "skicka länk igen",
   "resetpw.reset-pw-initialized": "Återställningslänken har skickats till din epost.",
   "resetpw.return-login": "återgå till inloggningen",
   "resetpw.send-link": "Skicka länk till e-postadress",

--- a/src/login/translation/src/login/translation/defaultMessages/password.json
+++ b/src/login/translation/src/login/translation/defaultMessages/password.json
@@ -165,7 +165,7 @@
   },
   {
     "id": "resetpw.resend-link-button",
-    "defaultMessage": "resend link in"
+    "defaultMessage": "resend link"
   },
   {
     "id": "resetpw.extra-security_heading",
@@ -193,7 +193,7 @@
   },
   {
     "id": "resetpw.state-not-found",
-    "defaultMessage": "Could not continue the reset password process. Please try again."
+    "defaultMessage": "Could not continue the reset password process. Please try again"
   },
   {
     "id": "resetpw.expired-email-code",

--- a/src/login/translation/src/login/translation/defaultMessages/password.json
+++ b/src/login/translation/src/login/translation/defaultMessages/password.json
@@ -168,6 +168,10 @@
     "defaultMessage": "resend link"
   },
   {
+    "id": "resetpw.resend-timer-in",
+    "defaultMessage": "in"
+  },
+  {
     "id": "resetpw.extra-security_heading",
     "defaultMessage": "Select an extra security option"
   },


### PR DESCRIPTION
#### Description:
depending on if the count down timer for "resend phone code"/"resend email link" is active or not the description text has been adjusted

- English: when not active - when timer is active
    resend link - resend link **in XX:YY**
- Swedish 
    skicka länk igen - Skicka länk igen **om XX:YY**
---
- email link 
<img width="370" alt="Screenshot 2021-09-16 at 15 12 22" src="https://user-images.githubusercontent.com/44289056/133620010-2bb73d18-67bd-4261-a2ad-b72d6dd04636.png">

![Screenshot 2021-09-16 at 15 25 07](https://user-images.githubusercontent.com/44289056/133620465-ecefd440-772c-465a-a835-9c52180a5a84.png)




-phone code
<img width="370" alt="Screenshot 2021-09-16 at 15 15 25" src="https://user-images.githubusercontent.com/44289056/133620119-91e3062f-49c9-4cbd-8322-a989612efe5d.png">
<img width="370" alt="Screenshot 2021-09-16 at 15 18 45" src="https://user-images.githubusercontent.com/44289056/133620133-0fba1288-176f-492b-870d-d51d12554c41.png">


---



#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

