### PR TITLE
RESETPASSWORD: Prevent browser suggested password in "repeat new password" field

### DIFF
--- a/src/login/components/Inputs/CustomInput.js
+++ b/src/login/components/Inputs/CustomInput.js
@@ -127,7 +127,7 @@ const customInput = (props) => {
           valid={valid}
           invalid={invalid}
         />
-      ) : input.name.includes("password") ? (
+      ) : input.name === "current-password" ? (
         <InputToggleShowHide
           {...props}
           name={input.name}

--- a/src/login/components/Inputs/ResetInputToggleShowHide.js
+++ b/src/login/components/Inputs/ResetInputToggleShowHide.js
@@ -1,0 +1,82 @@
+import React, { useState } from "react";
+import Input from "reactstrap/lib/Input";
+import InjectIntl from "../../translation/InjectIntl_HOC_factory";
+import PropTypes from "prop-types";
+
+let RenderHideButton = ({ setInputType, translate }) => (
+  <button
+    aria-label="hide password"
+    className="show-hide-button"
+    onClick={() => setInputType("password")}
+  >
+    <div className="button-text-container">
+      {translate("nin_hide_last_four_digits")}
+    </div>
+  </button>
+);
+
+let RenderShowButton = ({ setInputType, translate }) => (
+  <button
+    aria-label="show password"
+    className="show-hide-button"
+    onClick={() => setInputType("text")}
+  >
+    {translate("nin_show_last_four_digits")}
+  </button>
+);
+
+let ResetInputToggleShowHide = (props) => {
+  const {
+    input,
+    name,
+    disabled,
+    placeholder,
+    valid,
+    invalid,
+    autoComplete,
+    autoFocus,
+    ariaLabel,
+    required
+  } = props;
+  const [inputType, setInputType] = useState("password");
+
+  return (
+    <div className="password-input">
+      <Input
+        type={inputType}
+        disabled={disabled}
+        placeholder={placeholder}
+        id={name}
+        name={name}
+        valid={valid}
+        invalid={invalid}
+        autoComplete={autoComplete}
+        autoFocus={autoFocus}
+        aria-label={ariaLabel}
+        aria-required={required}
+        required={required}
+        {...input}
+      />
+      {inputType === "password" ? (
+        <RenderShowButton {...props} setInputType={setInputType} />
+      ) : inputType === "text" ? (
+        <RenderHideButton {...props} setInputType={setInputType} />
+      ) : null}
+    </div>
+  );
+};
+
+ResetInputToggleShowHide.propTypes = {
+  input: PropTypes.object,
+  name: PropTypes.string.isRequired,
+  disable: PropTypes.bool,
+  placeholder: PropTypes.string,
+  valid: PropTypes.bool,
+  invalid: PropTypes.bool,
+  autoComplete: PropTypes.string,
+  autoFocus: PropTypes.bool,
+  ariaLabel: PropTypes.string,
+  required: PropTypes.bool,
+};
+
+export default InjectIntl(ResetInputToggleShowHide);

--- a/src/login/components/LoginApp/ResetPassword/SetNewPassword.js
+++ b/src/login/components/LoginApp/ResetPassword/SetNewPassword.js
@@ -38,7 +38,7 @@ const validateNewPassword = (values, props) => {
 let NewPasswordForm = (props) => {
   const history = useHistory();
   return (
-    <Form autoComplete="on" id="new-password-form" role="form" aria-label="new-password form" onSubmit={props.clickSetNewPassword} >
+    <Form id="new-password-form" role="form" aria-label="new-password form" onSubmit={props.clickSetNewPassword} >
       <Field
         id="new-password"
         type="password"
@@ -47,7 +47,6 @@ let NewPasswordForm = (props) => {
         required={true}
         label={props.translate("chpass.form_custom_password_repeat")}
         placeholder="xxxx xxxx xxxx"
-        autoComplete={"new-password"} 
       />
       <div className="new-password-button-container">
       { props.extra_security && Object.keys(props.extra_security).length > 0 &&
@@ -159,6 +158,7 @@ function SetNewPassword(props){
           ref={ref}
           defaultValue={password && password}
           readOnly={true}
+          autoComplete="new-password"
         />
         <button id="clipboard" className="icon copybutton" onClick={copyToClipboard}> 
           <FontAwesomeIcon id={"icon-copy"} icon={faCopy} />

--- a/src/login/components/LoginApp/ResetPassword/SetNewPassword.js
+++ b/src/login/components/LoginApp/ResetPassword/SetNewPassword.js
@@ -41,7 +41,7 @@ let NewPasswordForm = (props) => {
     <Form id="new-password-form" role="form" aria-label="new-password form" onSubmit={props.clickSetNewPassword} >
       <Field
         id="new-password"
-        type="password"
+        type="text"
         name="new-password"
         component={CustomInput}
         required={true}


### PR DESCRIPTION
#### Description:
on click input "repeat new password", browser asking if the user want to use a suggested password from browser.

- change type from password to text
- move "autoComplete=new password" from repeat password input to new password


PS. this PR will remove the "show/hide" function for "repeat new password" input field DS.

---
- before (safari)


<img width="1077" alt="Screenshot 2021-09-17 at 09 03 51" src="https://user-images.githubusercontent.com/44289056/133774122-e665128b-bec3-4da5-950e-e2740e10805c.png">
- before (fire fox)
<img width="920" alt="Screenshot 2021-09-17 at 13 06 15" src="https://user-images.githubusercontent.com/44289056/133773085-1713dee4-09bb-4d7a-95be-55b7ed3a9e1a.png">
-before(chrome)
<img width="616" alt="Screenshot 2021-09-17 at 13 06 01" src="https://user-images.githubusercontent.com/44289056/133773057-043b5c91-42fb-46fc-8a6c-8174f7362a5c.png">

- after
<img width="914" alt="Screenshot 2021-09-17 at 13 05 14" src="https://user-images.githubusercontent.com/44289056/133773209-462dff56-8db9-4a22-80af-7243f6781b4d.png">




---

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

