### PR TITLE
LOGIN: Addresses cosmetic design feedback on the login form 

### DIFF
--- a/src/login/components/Inputs/EmailInput.js
+++ b/src/login/components/Inputs/EmailInput.js
@@ -12,7 +12,6 @@ let EmailInput = ({ translate, required, autoFocus }) => (
     componentClass="input"
     type="email"
     name="email"
-    helpBlock={translate("emails.input_help_text")}
     autoFocus={autoFocus}
     ariaLabel={"enter your email address to login"}
     autoComplete="username"

--- a/src/login/components/LoginApp/Login/UsernamePw.js
+++ b/src/login/components/LoginApp/Login/UsernamePw.js
@@ -29,27 +29,30 @@ const RenderRegisterLink = ({ translate }) => {
 
 const RenderResetPasswordLink = ({ translate }) => {
   const loginRef = useSelector((state) => state.login.ref);
-  const request_in_progress = useSelector((state) => state.app.request_in_progress);
+  const request_in_progress = useSelector(
+    (state) => state.app.request_in_progress
+  );
   const dispatch = useDispatch();
   const history = useHistory();
-  
+
   const sendLink = (e) => {
     e.preventDefault();
-    const email = document.querySelector("input[name='email']") && 
+    const email =
+      document.querySelector("input[name='email']") &&
       document.querySelector("input[name='email']").value;
-    if(email){
-      if(emailPattern.test(email)){
+    if (email) {
+      if (emailPattern.test(email)) {
         dispatch(postEmailLink(email));
-        setLocalStorage(LOCAL_STORAGE_PERSISTED_EMAIL , email)
-      }else history.push(`/reset-password/email/${loginRef}`)
-    } else history.push(`/reset-password/email/${loginRef}`)
+        setLocalStorage(LOCAL_STORAGE_PERSISTED_EMAIL, email);
+      } else history.push(`/reset-password/email/${loginRef}`);
+    } else history.push(`/reset-password/email/${loginRef}`);
   };
-  
+
   return (
     <LinkRedirect
       id={"link-forgot-password"}
       to={"/"}
-      className={`send-link ${request_in_progress ? 'disabled' : ''}`}
+      className={`send-link ${request_in_progress ? "disabled" : ""}`}
       onClick={sendLink}
       text={translate("login.usernamePw.reset-password-link")}
     />
@@ -89,8 +92,8 @@ const UsernamePw = (props) => {
       </h2>
       <UsernamePwForm {...props} />
       <div className="button-pair">
-        <RenderResetPasswordLink {...props} />
         <UsernamePwFormButton {...props} />
+        <RenderResetPasswordLink {...props} />
       </div>
       <RenderRegisterLink {...props} />
     </div>

--- a/src/login/styles/_Login.scss
+++ b/src/login/styles/_Login.scss
@@ -164,6 +164,7 @@ a.send-link.disabled {
     margin-top: #{3 * $margin};
     display: flex;
     flex-direction: column;
+    align-items: flex-end;
   }
   .tou .tou-text {
     margin-top: #{2 * $margin};

--- a/src/login/translation/defaultMessages/errors.js
+++ b/src/login/translation/defaultMessages/errors.js
@@ -16,7 +16,7 @@ export const generalErrors = {
   ),
 
   required: (
-    <FormattedMessage id="required" defaultMessage={`Field cannot be empty`} />
+    <FormattedMessage id="required" defaultMessage={`*Field cannot be empty`} />
   ),
 
   "value not changed": (

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -334,7 +334,7 @@
   "phones.unconfirmed_number_not_primary": "An unconfirmed phone number cannot be set as primary",
   "phones.unknown_phone": "We have no record of the phone number you provided",
   "phones.verification-success": "Successfully verified phone number",
-  "placeholder.password": "enter a password",
+  "placeholder.password": "enter password",
   "profile.email_display_no_data": "no email added",
   "profile.email_display_title": "Email address",
   "profile.eppn_display_title": "eppn",

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -354,7 +354,7 @@
   "register.paragraph": "Once you have created an eduID you will be able to log in and connect it to your Swedish national identity number.",
   "register.sub-heading": "Register your email address to create your eduID.",
   "register.toLogin": "If you already have eduID you can log in",
-  "required": "Field cannot be empty",
+  "required": "*Field cannot be empty",
   "resend.button": "Send a new confirmation link",
   "resend.email-label": "Complete registration by clicking the link sent to:",
   "resend.link-sent": "A link has been sent to your email address.",

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -354,7 +354,7 @@
   "register.paragraph": "När du har skapat ditt eduID kan du logga in och koppla det till ditt svenska personnummer.",
   "register.sub-heading": "Registrera din e-postadress för att skapa ditt eduID.",
   "register.toLogin": "Om du redan har ett eduID kan du logga in",
-  "required": "Obligatorisk",
+  "required": "Fältet kan inte vara tomt",
   "resend.button": "Skicka ett nytt verifieringsmeddelande",
   "resend.email-label": "Slutför skapandet av eduID genom att klicka länken skickad till:",
   "resend.link-sent": "En länk har skickats till din e-postadress.",

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -334,7 +334,7 @@
   "phones.unconfirmed_number_not_primary": "Du kan inte sätta ett obekräftat telefonnummer som primärt nummer",
   "phones.unknown_phone": "Telefonumret du angav kan inte hittas",
   "phones.verification-success": "Telefonnummer har bekräftats",
-  "placeholder.password": "ange ett lösenord",
+  "placeholder.password": "ange lösenord",
   "profile.email_display_no_data": "ingen e-postadress sparad",
   "profile.email_display_title": "E-postadress",
   "profile.eppn_display_title": "eppn",

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -354,7 +354,7 @@
   "register.paragraph": "När du har skapat ditt eduID kan du logga in och koppla det till ditt svenska personnummer.",
   "register.sub-heading": "Registrera din e-postadress för att skapa ditt eduID.",
   "register.toLogin": "Om du redan har ett eduID kan du logga in",
-  "required": "Fältet kan inte vara tomt",
+  "required": "*Fältet kan inte vara tomt",
   "resend.button": "Skicka ett nytt verifieringsmeddelande",
   "resend.email-label": "Slutför skapandet av eduID genom att klicka länken skickad till:",
   "resend.link-sent": "En länk har skickats till din e-postadress.",

--- a/src/login/translation/messageIndex.js
+++ b/src/login/translation/messageIndex.js
@@ -31,7 +31,7 @@ export const formattedMessages = {
 export const unformattedMessages = defineMessages({
   "placeholder.password": {
     id: "placeholder.password",
-    defaultMessage: `enter a password`,
+    defaultMessage: `enter password`,
     description: "placeholder text for password input",
   },
   "pd.choose-language": {

--- a/src/login/translation/src/login/translation/defaultMessages/errors.json
+++ b/src/login/translation/src/login/translation/defaultMessages/errors.json
@@ -9,7 +9,7 @@
   },
   {
     "id": "required",
-    "defaultMessage": "Field cannot be empty"
+    "defaultMessage": "*Field cannot be empty"
   },
   {
     "id": "value not changed",

--- a/src/login/translation/src/login/translation/messageIndex.json
+++ b/src/login/translation/src/login/translation/messageIndex.json
@@ -2,7 +2,7 @@
   {
     "id": "placeholder.password",
     "description": "placeholder text for password input",
-    "defaultMessage": "enter a password"
+    "defaultMessage": "enter password"
   },
   {
     "id": "pd.choose-language",


### PR DESCRIPTION
#### Description:
This PR addresses some design-related feedback on the login form page.

**Summary:**
- Swaps position: Login button and "Forgot password" link  
- Changes the following text: pw placeholder, error text for required data, removed help text on the login form email address input
- Register here: right-aligned in both languages 

---
###### Login form (before feedback)
<img width="350" alt="Screenshot 2021-09-20 at 16 46 25" src="https://user-images.githubusercontent.com/30963614/134022636-78b80915-5ad3-4165-bc0e-3253183f7273.png"> <img width="350" alt="Screenshot 2021-09-20 at 16 54 32" src="https://user-images.githubusercontent.com/30963614/134024038-c77a494d-e997-428d-be69-7496b9843495.png">

###### Login form (after feedback)
<img width="350" alt="Screenshot 2021-09-20 at 16 43 19" src="https://user-images.githubusercontent.com/30963614/134022652-1345ffd3-1c61-4a1a-bd07-7d6674e3faec.png"> <img width="350" alt="Screenshot 2021-09-20 at 16 55 31" src="https://user-images.githubusercontent.com/30963614/134024178-d977aa08-00b1-4c6f-a858-183bf10fddf0.png">
---

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

