### PR TITLE
DASHBOARDNAV: Inative settings link highlighting  when click advanced settings 

### DIFF
--- a/src/components/DashboardNav.js
+++ b/src/components/DashboardNav.js
@@ -62,7 +62,7 @@ function DashboardNav(props) {
         </NavLink>
         <NavLink 
           className={tipsAtSettings && active ?  `nav-settings ${selectedLanguage}`: null} 
-          activeClassName="active" to={`/profile/settings/`}
+          exact activeClassName="active" to={`/profile/settings/`}
         >
           <li>
             {props.translate("dashboard_nav.settings")}
@@ -71,7 +71,7 @@ function DashboardNav(props) {
         </NavLink>
         <NavLink
           className={tipsAtSettings && active ?  `nav-advanced-settings ${selectedLanguage}`: null} 
-          activeClassName="active"
+          exact activeClassName="active"
           to={`/profile/settings/advanced-settings`}
         >
           <li>{props.translate("dashboard_nav.advanced-settings")}</li>


### PR DESCRIPTION
#### Description:
Fixes #674 

---
<img width="798" alt="Screenshot 2021-09-22 at 11 50 32" src="https://user-images.githubusercontent.com/44289056/134322294-b37711e5-6287-4b73-976e-15ecdcca018a.png">


---

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

