### PR TITLE
SIGNUP: Update styling for id  after latest change of uniq id

### DIFF
--- a/src/login/styles/_SignupMain.scss
+++ b/src/login/styles/_SignupMain.scss
@@ -11,7 +11,7 @@
   }
 }
 
-#email {
+#email-wrapper {
   flex: 1;
 }
 

--- a/src/login/styles/_base.scss
+++ b/src/login/styles/_base.scss
@@ -52,6 +52,9 @@ article {
   // this is added to prevent margin collapse (look for other solution if causing problems)
   display: flex;
   flex-direction: column;
+  .tagline {
+    padding-top: 0.625rem;
+  }
 }
 
 #content {

--- a/src/login/styles/_base.scss
+++ b/src/login/styles/_base.scss
@@ -52,9 +52,6 @@ article {
   // this is added to prevent margin collapse (look for other solution if causing problems)
   display: flex;
   flex-direction: column;
-  .tagline {
-    padding-top: 0.625rem;
-  }
 }
 
 #content {


### PR DESCRIPTION
#### Description:
Previous PR, changed id for element div id={email-wrapper}  but styling had not been updated on sign up. now input field size return to previous size.


 ---
- before fix

![Screenshot 2021-09-22 at 13 27 36](https://user-images.githubusercontent.com/44289056/134336044-fb87c81e-117e-4434-b055-4d41a89fcf71.png)

- after fix 
![Screenshot 2021-09-22 at 13 27 15](https://user-images.githubusercontent.com/44289056/134336080-0ed5e451-392f-4be6-a735-ecbf1c7b9a72.png)


---

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

