### PR TITLE
LOGIN: Removal of unnecessary saga call

### DIFF
--- a/src/login/components/LoginApp/Login/SecurityKeySelected.js
+++ b/src/login/components/LoginApp/Login/SecurityKeySelected.js
@@ -5,7 +5,6 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { faRedo, faTimes } from "@fortawesome/free-solid-svg-icons";
 import SecurityKeyGif from "../../../../../img/computer_animation.gif";
 import { addWebauthnAssertion } from "../../../redux/actions/addDataToStoreActions";
-import { postWebauthnFromAuthenticator } from "../../../redux/actions/postWebauthnFromAuthenticatorActions";
 import { eduidRMAllNotify } from "../../../../actions/Notifications";
 import InjectIntl from "../../../translation/InjectIntl_HOC_factory";
 
@@ -72,9 +71,7 @@ let SecurityKeySelected = ({ translate, setSelected }) => {
     } else {
       if (webauthn_assertion === null) {
         assertionFromAuthenticator(webauthn_challenge, dispatch, setSelected);
-      } else {
-        dispatch(postWebauthnFromAuthenticator(webauthn_assertion));
-      }
+      } 
     }
   }, [webauthn_challenge, webauthn_assertion, retryToggle]);
 

--- a/src/login/redux/sagas/rootSaga/loginSagas.js
+++ b/src/login/redux/sagas/rootSaga/loginSagas.js
@@ -9,8 +9,8 @@ import * as postUpdatedTouAcceptActions from "../../actions/postUpdatedTouAccept
 import { postUpdatedTouAcceptSaga } from "../login/postUpdatedTouAcceptSaga";
 import * as postRefForWebauthnChallengeActions from "../../actions/postRefForWebauthnChallengeActions";
 import { postRefForWebauthnChallengeSaga } from "../login/postRefForWebauthnChallengeSaga";
-import * as postWebauthnFromAuthenticatorActions from "../../actions/postWebauthnFromAuthenticatorActions";
 import { postWebauthnFromAuthenticatorSaga } from "../login/postWebauthnFromAuthenticatorSaga";
+import * as addDataToStoreActions from "../../actions/addDataToStoreActions";
 
 const loginSagas = [
   takeLatest(postRefLoginActions.POST_LOGIN_REF_TO_NEXT, postRefLoginSaga),
@@ -32,7 +32,7 @@ const loginSagas = [
     postRefLoginSaga
   ),
   takeLatest(
-    postWebauthnFromAuthenticatorActions.POST_WEBAUTHN_ASSERTION,
+    addDataToStoreActions.ADD_WEBAUTHN_ASSERTION_TO_STORE,
     postWebauthnFromAuthenticatorSaga
   ),
 ];


### PR DESCRIPTION
#### Description:
This PR is to fix POST IDP MFA AUTH FAIL on login with security key 

To test this PR
- comment out  `document.forms[0].submit();` in SubmitSamlResponse then try login authentication with security key

---
- before
<img width="795" alt="Screenshot 2021-09-24 at 13 49 23" src="https://user-images.githubusercontent.com/44289056/134670036-73618b06-f840-4636-b9d9-c8615c9ad3b7.png">

- after
<img width="795" alt="Screenshot 2021-09-24 at 13 47 21" src="https://user-images.githubusercontent.com/44289056/134670027-69aabbfc-ea1e-4583-8f4a-6a4fa1ad99cb.png">



---

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

