### PR TITLE
ADVANCEDSETTINGS: Conditional display of adding security key button

### DIFF
--- a/src/components/Security.js
+++ b/src/components/Security.js
@@ -9,7 +9,10 @@ import "../login/styles/index.scss";
 class Security extends Component {
   constructor(props) {
     super(props);
-    this.state = { isAvailablePlatformAuthenticator: false };
+    this.state = { 
+      isAvailablePlatformAuthenticator: false,
+      className: "" 
+    };
   }
 
   componentDidMount(){
@@ -24,7 +27,8 @@ class Security extends Component {
             console.log("Supported."),
             this.setState(() => {
               return {
-                isAvailablePlatformAuthenticator: true
+                isAvailablePlatformAuthenticator: true,
+                className: "second-option"
               };
             });
           } else {
@@ -33,7 +37,8 @@ class Security extends Component {
             ),  
             this.setState(() => {
               return {
-                isAvailablePlatformAuthenticator: false
+                isAvailablePlatformAuthenticator: false,
+                className: "btn-primary"
               };
             });
           }
@@ -43,7 +48,8 @@ class Security extends Component {
       console.log("Not supported."),
       this.setState(() => {
         return {
-          isAvailablePlatformAuthenticator: false
+          isAvailablePlatformAuthenticator: false,
+          className: "btn-primary"
         };
       });
      }
@@ -169,13 +175,13 @@ class Security extends Component {
             {securitykey_table}
             <div className="register-authn-buttons">
              {platformAuthenticatorButton}
-              <EduIDButton
+              <button
                 id="security-webauthn-button"
-                className={!this.state.isAvailablePlatformAuthenticator ? " " : "second-option"}
+                className={this.state.className}
                 onClick={this.props.handleStartAskingKeyWebauthnDescription}
               >
                 {this.props.translate("security.add_webauthn_token_key")}
-              </EduIDButton>
+              </button>
             </div>
           </div>
         </div>

--- a/src/components/Security.js
+++ b/src/components/Security.js
@@ -171,7 +171,7 @@ class Security extends Component {
              {platformAuthenticatorButton}
               <EduIDButton
                 id="security-webauthn-button"
-                className="settings-button"
+                className={!this.state.isAvailablePlatformAuthenticator ? " " : "second-option"}
                 onClick={this.props.handleStartAskingKeyWebauthnDescription}
               >
                 {this.props.translate("security.add_webauthn_token_key")}

--- a/src/login/styles/_Security.scss
+++ b/src/login/styles/_Security.scss
@@ -1,9 +1,8 @@
 td .passwords {
-  background-color: white;
+  background-color: $white;
 }
 
 .register-authn-buttons {
-  padding-left: 0.3rem;
   margin: 1.5rem 0;
   button {
     margin: 0.5rem 0;
@@ -11,10 +10,17 @@ td .passwords {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    &#security-webauthn-button {
-      background-color:$white;
+    &.second-option {
+      background-color: $white;
       border: solid 1px $orange-highlight;
       color: $orange-highlight;
+      text-transform: uppercase;
     }
+  }
+}
+
+@media (max-width: 414px) {
+  button.btn {
+    justify-content: center;
   }
 }

--- a/src/login/styles/_Security.scss
+++ b/src/login/styles/_Security.scss
@@ -10,17 +10,18 @@ td .passwords {
     display: flex;
     justify-content: space-between;
     align-items: center;
+    text-transform: uppercase;
+    padding: 6px 12px;
     &.second-option {
       background-color: $white;
       border: solid 1px $orange-highlight;
       color: $orange-highlight;
-      text-transform: uppercase;
     }
   }
 }
 
 @media (max-width: 414px) {
-  button.btn {
+  #security-webauthn-button {
     justify-content: center;
   }
 }

--- a/src/tests/Security-test.js
+++ b/src/tests/Security-test.js
@@ -1027,7 +1027,7 @@ describe("Security Container", () => {
   it("Clicks WEBAUTHN", () => {
     expect(dispatch.mock.calls.length).toEqual(0);
     const wrapper = getWrapper();
-    wrapper.find("EduIDButton#security-webauthn-button").simulate("click");
+    wrapper.find("button#security-webauthn-button").simulate("click");
     expect(dispatch.mock.calls.length).toEqual(3);
     expect(dispatch.mock.calls[0][0].type).toEqual(
       notifyActions.RM_ALL_NOTIFICATION


### PR DESCRIPTION
#### Description:
This PR is to render two different "add security key" buttons, depending on if platform auth is available for the user or not. 

- If platform auth is available the security key will be displayed as the secondary option 

![Screenshot 2021-10-06 at 11 03 23](https://user-images.githubusercontent.com/44289056/136174938-8d330ae0-ca6c-4be6-a13f-cccebe2b6a56.png)


![Screenshot 2021-10-06 at 11 11 29](https://user-images.githubusercontent.com/44289056/136175126-d991777b-f717-4ad4-9b1c-43e35640283a.png)

- If platform auth is not available the security key will be displayed as the primary option 

![Screenshot 2021-10-06 at 11 03 05](https://user-images.githubusercontent.com/44289056/136175050-411316a2-57a8-4795-a3af-85a8fbb725ca.png)

![Screenshot 2021-10-06 at 11 12 06](https://user-images.githubusercontent.com/44289056/136175168-b657b081-01cb-46f0-bc73-a8e7b2f7f8c1.png)

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

