### PR TITLE
ADVANCEDSETTINGS: Change expression to "condition ? true : false" for platform auth button

### DIFF
--- a/src/components/Security.js
+++ b/src/components/Security.js
@@ -53,7 +53,6 @@ class Security extends Component {
   render() {
     let btnVerify = "";
     let date_success = "";
-    let platformAuthenticatorButton = "";
     let securitykey_table = "";
     // filter out password from data
     const tokens = this.props.credentials.filter(
@@ -88,17 +87,6 @@ class Security extends Component {
           </EduIDButton>
         );
       }
-      if(this.state.isPlatformAuthLoaded && this.state.isPlatformAuthenticatorAvailable){
-        platformAuthenticatorButton = (
-          <EduIDButton
-            id="security-webauthn-platform-button"
-            onClick={this.props.handleStartAskingDeviceWebauthnDescription}
-          >
-            {this.props.translate("security.add_webauthn_token_device")}
-          </EduIDButton>
-        );
-      }
-
 
       return (
         <tr key={index} className={`webauthn-token-holder ${cred.verified ? "verified" : ""}`} data-token={cred.key}>
@@ -169,7 +157,14 @@ class Security extends Component {
           <div id="register-webauthn-tokens-area" className="table-responsive">
             {securitykey_table}
             <div className="register-authn-buttons">
-            {platformAuthenticatorButton}
+            { this.state.isPlatformAuthenticatorAvailable ?
+              <EduIDButton
+                id="security-webauthn-platform-button"
+                onClick={this.props.handleStartAskingDeviceWebauthnDescription}
+              >
+                {this.props.translate("security.add_webauthn_token_device")}
+              </EduIDButton> : null
+            }
               <button
                 id="security-webauthn-button"
                 className={this.state.isPlatformAuthenticatorAvailable ? "second-option" : "btn-primary"}


### PR DESCRIPTION
#### Description:
I have tested with my mobile phone and I can still not rendering "platform auth button"
However, I see the security button has been changed to "secondary option" it means platform auth is available.
I changed from  "true && expression" to "condition ? true : false" same expression as className. 
"true && expression" cause the problem, skipping re-rendering of updated state.
and I moved button inside render for readability 

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

