### PR TITLE
IDENTITY: Correct confirming Identity by letter results in status message

### DIFF
--- a/i18n/src/login/translation/defaultMessages/userProfile.json
+++ b/i18n/src/login/translation/defaultMessages/userProfile.json
@@ -193,7 +193,7 @@
   },
   {
     "id": "letter.saved-unconfirmed",
-    "defaultMessage": "A letter is on it's way to your house"
+    "defaultMessage": "A letter with confirmation code has been sent."
   },
   {
     "id": "letter.wrong-code",

--- a/src/login/translation/defaultMessages/userProfile.js
+++ b/src/login/translation/defaultMessages/userProfile.js
@@ -334,7 +334,7 @@ export const userVetting = {
   "letter.saved-unconfirmed": (
     <FormattedMessage
       id="letter.saved-unconfirmed"
-      defaultMessage={`A letter is on it's way to your house`}
+      defaultMessage={`A letter with confirmation code has been sent.`}
     />
   ),
 

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -174,7 +174,7 @@
   "letter.no_state_found": "No state found",
   "letter.placeholder": "Letter confirmation code",
   "letter.resend_code": "Send code",
-  "letter.saved-unconfirmed": "A letter is on it's way to your house",
+  "letter.saved-unconfirmed": "A letter with confirmation code has been sent.",
   "letter.verification_success": "Successfully verified national id number",
   "letter.verify_title": "Add the code you have received by post",
   "letter.wrong-code": "Incorrect verification code",

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -174,7 +174,7 @@
   "letter.no_state_found": "Ingen pågående bekräftning hittades",
   "letter.placeholder": "Bekräftelsekod",
   "letter.resend_code": "Skicka bekräftelsekoden igen",
-  "letter.saved-unconfirmed": "Overifierat personnummer sparat",
+  "letter.saved-unconfirmed": "Ett brev med bekräftelsekod har skickats.",
   "letter.verification_success": "Personnumret är bekräftat",
   "letter.verify_title": "Skriv in koden du fått hemskickad",
   "letter.wrong-code": "Den bekräftelsekod du angett stämmer inte. Var god försök igen",

--- a/src/login/translation/src/login/translation/defaultMessages/userProfile.json
+++ b/src/login/translation/src/login/translation/defaultMessages/userProfile.json
@@ -201,7 +201,7 @@
   },
   {
     "id": "letter.saved-unconfirmed",
-    "defaultMessage": "A letter is on it's way to your house"
+    "defaultMessage": "A letter with confirmation code has been sent."
   },
   {
     "id": "letter.wrong-code",


### PR DESCRIPTION
#### Description:
Fixes #755

A letter is on it's way to your house -> A letter with confirmation code has been sent.
Overifierat personnummer sparat  -> Ett brev med bekräftelsekod har skickats.

---

- Swedish
<img width="633" alt="Screenshot 2021-10-18 at 09 02 01" src="https://user-images.githubusercontent.com/44289056/137684143-e93df7bf-3106-4ed5-9492-dc5db0d8edc3.png">

- English
<img width="633" alt="Screenshot 2021-10-18 at 09 02 14" src="https://user-images.githubusercontent.com/44289056/137684164-f664b232-6a40-4f4a-88d9-9751564f4622.png">

---

#### For reviewer:
- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes

