### PR TITLE
RESETPASSWORD: Add missing status message when OTP has been sent

### DIFF
--- a/src/login/redux/sagas/resetpassword/postExtraSecurityPhoneSaga.js
+++ b/src/login/redux/sagas/resetpassword/postExtraSecurityPhoneSaga.js
@@ -2,7 +2,10 @@ import { put, call, select } from "redux-saga/effects";
 import { failRequest, putCsrfToken } from "../../../../sagas/common";
 import postRequest from "../postDataRequest";
 import resetPasswordSlice from "../../slices/resetPasswordSlice";
-import { eduidRMAllNotify } from "../../../../actions/Notifications";
+import {
+  eduidRMAllNotify,
+  eduidNotify,
+} from "../../../../actions/Notifications";
 import {
   LOCAL_STORAGE_PERSISTED_COUNT_RESEND_PHONE_CODE,
   countFiveMin,
@@ -34,6 +37,8 @@ export function* requestPhoneCodeForNewPassword() {
       }
       return;
     }
+    // Success message is showing in notification bar
+    yield put(eduidNotify(response.payload.message, "messages"));
     clearCountdown(LOCAL_STORAGE_PERSISTED_COUNT_RESEND_PHONE_CODE);
     setLocalStorage(
       LOCAL_STORAGE_PERSISTED_COUNT_RESEND_PHONE_CODE,

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -397,7 +397,7 @@
   "resetpw.return-login": "återgå till inloggningen",
   "resetpw.send-link": "Skicka länk till e-postadress",
   "resetpw.send-sms-failed": "Det gick inte att skicka telefonkoden",
-  "resetpw.send-sms-success": "En engångsverifieringskod har skickats till din telefon.",
+  "resetpw.send-sms-success": "En engångskod har skickats till din telefon.",
   "resetpw.set-new-password-description": "Ett säkert lösenord har genererats till dig. För att komma vidare behöver du kopiera det till Repetera ditt nya lösenord och klicka Acceptera lösenord.",
   "resetpw.set-new-password-heading": "Skapa ditt nya lösenord",
   "resetpw.set-new-password-success": "Lösenordet har uppdaterats",


### PR DESCRIPTION
#### Description:
Fixes #774
engångsverifieringskod -> engångskod

---

<img width="400" alt="Screenshot 2021-11-09 at 09 33 09" src="https://user-images.githubusercontent.com/44289056/140889715-ecc16ec0-0610-4e3c-9bda-6ae6ecf8e660.png">

---


#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
