### PR TITLE
CHANGEPASSWORD: Remove html tag from chpass.help-text

### DIFF
--- a/i18n/src/login/translation/messageIndex.json
+++ b/i18n/src/login/translation/messageIndex.json
@@ -44,6 +44,16 @@
     "defaultMessage": "<label>Tip: Choose a strong password</label>\n            <ul id=\"password-custom-help\">\n\t            <li>Use upper- and lowercase characters, but not at the beginning or end</li>\n\t            <li>Add digits somewhere, but not at the beginning or end</li>\n                <li>Add special characters, such as &#64; &#36; &#92; &#43; &#95; &#37;</li>\n\t            <li>Spaces are ignored</li>\n            </ul>"
   },
   {
+    "id": "chpass.help-text-newpass-label",
+    "description": "help text for custom password label",
+    "defaultMessage": "Tip: Choose a strong password"
+  },
+ {
+    "id": "chpass.help-text-newpass-tips",
+    "description": "help text for custom password tips",
+    "defaultMessage": "Use upper- and lowercase characters, but not at the beginning or end\n Add digits somewhere, but not at the beginning or end\n Add special characters, such as  @ $ \\u005c  + _ %\n Spaces are ignored"
+  },
+  {
     "id": "cm.lost_code",
     "description": "Lost code problem description",
     "defaultMessage": "Is the code not working?"

--- a/i18n/src/login/translation/messageIndex.json
+++ b/i18n/src/login/translation/messageIndex.json
@@ -39,11 +39,6 @@
     "description": "Help text for security key max length"
   },
   {
-    "id": "chpass.help-text-newpass",
-    "description": "help text for custom password",
-    "defaultMessage": "<label>Tip: Choose a strong password</label>\n            <ul id=\"password-custom-help\">\n\t            <li>Use upper- and lowercase characters, but not at the beginning or end</li>\n\t            <li>Add digits somewhere, but not at the beginning or end</li>\n                <li>Add special characters, such as &#64; &#36; &#92; &#43; &#95; &#37;</li>\n\t            <li>Spaces are ignored</li>\n            </ul>"
-  },
-  {
     "id": "chpass.help-text-newpass-label",
     "description": "help text for custom password label",
     "defaultMessage": "Tip: Choose a strong password"

--- a/src/components/ChangePasswordForm.js
+++ b/src/components/ChangePasswordForm.js
@@ -113,12 +113,19 @@ class ChangePasswordForm extends Component {
       );
 
       helpCustom = (
-        <div
-          className="password-format"
-          dangerouslySetInnerHTML={{
-            __html: this.props.translate("chpass.help-text-newpass"),
-          }}
-        />
+        <div className="password-format">
+          <label>
+            {this.props.translate("chpass.help-text-newpass-label")}
+          </label>
+          <ul id="password-custom-help">
+            {this.props
+              .translate("chpass.help-text-newpass-tips")
+              .split("\n")
+              .map((list, index) => {
+                return <li key={index}>{list}</li>;
+              })}
+          </ul>
+        </div>
       );
     } else {
       form = (

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -33,7 +33,6 @@
   "chpass.form_custom_password": "Enter new password",
   "chpass.form_custom_password_repeat": "Repeat new password",
   "chpass.help-text-general": "You can change your current password using this form. A strong password has been generated for you. You can accept the generated password by clicking \"Change password\" or you can opt to choose your own password using the checkbox.",
-  "chpass.help-text-newpass": "<label>Tip: Choose a strong password</label>\n            <ul id=\"password-custom-help\">\n\t            <li>Use upper- and lowercase characters, but not at the beginning or end</li>\n\t            <li>Add digits somewhere, but not at the beginning or end</li>\n                <li>Add special characters, such as &#64; &#36; &#92; &#43; &#95; &#37;</li>\n\t            <li>Spaces are ignored</li>\n            </ul>",
   "chpass.help-text-newpass-label": "Tip: Choose a strong password",
   "chpass.help-text-newpass-tips": "Use upper- and lowercase characters, but not at the beginning or end\n Add digits somewhere, but not at the beginning or end\n Add special characters, such as  @ $ \\u005c  + _ %\n Spaces are ignored",
   "chpass.low-password-entropy": "Please provide a stronger password",

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -34,6 +34,8 @@
   "chpass.form_custom_password_repeat": "Repeat new password",
   "chpass.help-text-general": "You can change your current password using this form. A strong password has been generated for you. You can accept the generated password by clicking \"Change password\" or you can opt to choose your own password using the checkbox.",
   "chpass.help-text-newpass": "<label>Tip: Choose a strong password</label>\n            <ul id=\"password-custom-help\">\n\t            <li>Use upper- and lowercase characters, but not at the beginning or end</li>\n\t            <li>Add digits somewhere, but not at the beginning or end</li>\n                <li>Add special characters, such as &#64; &#36; &#92; &#43; &#95; &#37;</li>\n\t            <li>Spaces are ignored</li>\n            </ul>",
+  "chpass.help-text-newpass-label": "Tip: Choose a strong password",
+  "chpass.help-text-newpass-tips": "Use upper- and lowercase characters, but not at the beginning or end\n Add digits somewhere, but not at the beginning or end\n Add special characters, such as  @ $ \\u005c  + _ %\n Spaces are ignored",
   "chpass.low-password-entropy": "Please provide a stronger password",
   "chpass.main_title": "Change your current password",
   "chpass.no_old_pw": "Please enter your old password",

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -34,6 +34,8 @@
   "chpass.form_custom_password_repeat": "Repetera ditt nya lösenord",
   "chpass.help-text-general": "Här kan du byta ditt lösenord. Ett säkert lösenord har genererats till dig. Du väljer att använda det genererade lösenordet genom att klicka \"Byt lösenord\". Vill du använda ett eget lösenord så gör du det genom att klicka i rutan för eget lösenord.",
   "chpass.help-text-newpass": "<label>Tänk på att välja ett säkert lösenord:</label>\n<ul>\n<li>Använd stora och små bokstäver (inte bara första bokstaven)</li>\n<li>Lägg till en eller flera siffror någonstans i mitten av lösenordet</li> \n<li>Använd specialtecken som &#64; &#36; &#92; &#43; &#95; &#37;</li>\n<li>Blanksteg (mellanslag) ignoreras</li>\n</ul>",
+  "chpass.help-text-newpass-label": "Tänk på att välja ett säkert lösenord",
+  "chpass.help-text-newpass-tips": "Använd stora och små bokstäver (inte bara första bokstaven)\n Lägg till en eller flera siffror någonstans i mitten av lösenordet\n Använd specialtecken som @ $ \\u005c  + _ %\n Blanksteg (mellanslag) ignoreras",
   "chpass.low-password-entropy": "Var god välj ett starkare lösenord",
   "chpass.main_title": "Byt ditt lösenord",
   "chpass.no_old_pw": "Skriv in ditt nuvarande lösenord",

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -33,7 +33,6 @@
   "chpass.form_custom_password": "Skriv ditt nya lösenord",
   "chpass.form_custom_password_repeat": "Repetera ditt nya lösenord",
   "chpass.help-text-general": "Här kan du byta ditt lösenord. Ett säkert lösenord har genererats till dig. Du väljer att använda det genererade lösenordet genom att klicka \"Byt lösenord\". Vill du använda ett eget lösenord så gör du det genom att klicka i rutan för eget lösenord.",
-  "chpass.help-text-newpass": "<label>Tänk på att välja ett säkert lösenord:</label>\n<ul>\n<li>Använd stora och små bokstäver (inte bara första bokstaven)</li>\n<li>Lägg till en eller flera siffror någonstans i mitten av lösenordet</li> \n<li>Använd specialtecken som &#64; &#36; &#92; &#43; &#95; &#37;</li>\n<li>Blanksteg (mellanslag) ignoreras</li>\n</ul>",
   "chpass.help-text-newpass-label": "Tänk på att välja ett säkert lösenord",
   "chpass.help-text-newpass-tips": "Använd stora och små bokstäver (inte bara första bokstaven)\n Lägg till en eller flera siffror någonstans i mitten av lösenordet\n Använd specialtecken som @ $ \\u005c  + _ %\n Blanksteg (mellanslag) ignoreras",
   "chpass.low-password-entropy": "Var god välj ett starkare lösenord",

--- a/src/login/translation/messageIndex.js
+++ b/src/login/translation/messageIndex.js
@@ -93,7 +93,9 @@ export const unformattedMessages = defineMessages({
     id: "chpass.help-text-newpass-tips",
     description: "help text for custom password tips",
     defaultMessage:
-      "Use upper- and lowercase characters, but not at the beginning or end\n Add digits somewhere, but not at the beginning or end\n Add special characters, such as  @ $ \\u005c  + _ %\n Spaces are ignored",
+      "Use upper- and lowercase characters, but not at the beginning or end\n" +
+      "Add digits somewhere, but not at the beginning or end\n" +
+      "Add special characters, such as  @ $ \\u005c  + _ %\n Spaces are ignored",
   },
   "cm.lost_code": {
     id: "cm.lost_code",

--- a/src/login/translation/messageIndex.js
+++ b/src/login/translation/messageIndex.js
@@ -84,17 +84,6 @@ export const unformattedMessages = defineMessages({
     defaultMessage: `here.`,
     description: "Placeholder for phone text input",
   },
-  "chpass.help-text-newpass": {
-    id: "chpass.help-text-newpass",
-    defaultMessage: `<label>Tip: Choose a strong password</label>
-            <ul id="password-custom-help">
-	            <li>Use upper- and lowercase characters, but not at the beginning or end</li>
-	            <li>Add digits somewhere, but not at the beginning or end</li>
-                <li>Add special characters, such as &#64; &#36; &#92; &#43; &#95; &#37;</li>
-	            <li>Spaces are ignored</li>
-            </ul>`,
-    description: "help text for custom password",
-  },
   "chpass.help-text-newpass-label": {
     id: "chpass.help-text-newpass-label",
     description: "help text for custom password label",

--- a/src/login/translation/messageIndex.js
+++ b/src/login/translation/messageIndex.js
@@ -95,6 +95,17 @@ export const unformattedMessages = defineMessages({
             </ul>`,
     description: "help text for custom password",
   },
+  "chpass.help-text-newpass-label": {
+    id: "chpass.help-text-newpass-label",
+    description: "help text for custom password label",
+    defaultMessage: "Tip: Choose a strong password",
+  },
+  "chpass.help-text-newpass-tips": {
+    id: "chpass.help-text-newpass-tips",
+    description: "help text for custom password tips",
+    defaultMessage:
+      "Use upper- and lowercase characters, but not at the beginning or end\n Add digits somewhere, but not at the beginning or end\n Add special characters, such as  @ $ \\u005c  + _ %\n Spaces are ignored",
+  },
   "cm.lost_code": {
     id: "cm.lost_code",
     defaultMessage: `Is the code not working?`,

--- a/src/login/translation/src/i18n-messages.json
+++ b/src/login/translation/src/i18n-messages.json
@@ -1566,11 +1566,6 @@
     "defaultMessage": "max 50 characters"
   },
   {
-    "id": "chpass.help-text-newpass",
-    "description": "help text for custom password",
-    "defaultMessage": "<label>Tip: Choose a strong password</label>\n            <ul id=\"password-custom-help\">\n\t            <li>Use upper- and lowercase characters, but not at the beginning or end</li>\n\t            <li>Add digits somewhere, but not at the beginning or end</li>\n                <li>Add special characters, such as &#64; &#36; &#92; &#43; &#95; &#37;</li>\n\t            <li>Spaces are ignored</li>\n            </ul>"
-  },
-  {
     "id": "chpass.help-text-newpass-label",
     "description": "help text for custom password label",
     "defaultMessage": "Tip: Choose a strong password"

--- a/src/login/translation/src/i18n-messages.json
+++ b/src/login/translation/src/i18n-messages.json
@@ -1571,6 +1571,16 @@
     "defaultMessage": "<label>Tip: Choose a strong password</label>\n            <ul id=\"password-custom-help\">\n\t            <li>Use upper- and lowercase characters, but not at the beginning or end</li>\n\t            <li>Add digits somewhere, but not at the beginning or end</li>\n                <li>Add special characters, such as &#64; &#36; &#92; &#43; &#95; &#37;</li>\n\t            <li>Spaces are ignored</li>\n            </ul>"
   },
   {
+    "id": "chpass.help-text-newpass-label",
+    "description": "help text for custom password label",
+    "defaultMessage": "Tip: Choose a strong password"
+  },
+ {
+    "id": "chpass.help-text-newpass-tips",
+    "description": "help text for custom password tips",
+    "defaultMessage": "Use upper- and lowercase characters, but not at the beginning or end\n Add digits somewhere, but not at the beginning or end\n Add special characters, such as  @ $ \\u005c  + _ %\n Spaces are ignored"
+  },
+  {
     "id": "cm.lost_code",
     "description": "Lost code problem description",
     "defaultMessage": "Is the code not working?"

--- a/src/login/translation/src/login/translation/messageIndex.json
+++ b/src/login/translation/src/login/translation/messageIndex.json
@@ -54,11 +54,6 @@
     "defaultMessage": "here."
   },
   {
-    "id": "chpass.help-text-newpass",
-    "description": "help text for custom password",
-    "defaultMessage": "<label>Tip: Choose a strong password</label>\n            <ul id=\"password-custom-help\">\n\t            <li>Use upper- and lowercase characters, but not at the beginning or end</li>\n\t            <li>Add digits somewhere, but not at the beginning or end</li>\n                <li>Add special characters, such as &#64; &#36; &#92; &#43; &#95; &#37;</li>\n\t            <li>Spaces are ignored</li>\n            </ul>"
-  },
-  {
     "id": "chpass.help-text-newpass-label",
     "description": "help text for custom password label",
     "defaultMessage": "Tip: Choose a strong password"

--- a/src/login/translation/src/login/translation/messageIndex.json
+++ b/src/login/translation/src/login/translation/messageIndex.json
@@ -59,6 +59,16 @@
     "defaultMessage": "<label>Tip: Choose a strong password</label>\n            <ul id=\"password-custom-help\">\n\t            <li>Use upper- and lowercase characters, but not at the beginning or end</li>\n\t            <li>Add digits somewhere, but not at the beginning or end</li>\n                <li>Add special characters, such as &#64; &#36; &#92; &#43; &#95; &#37;</li>\n\t            <li>Spaces are ignored</li>\n            </ul>"
   },
   {
+    "id": "chpass.help-text-newpass-label",
+    "description": "help text for custom password label",
+    "defaultMessage": "Tip: Choose a strong password"
+  },
+  {
+    "id": "chpass.help-text-newpass-tips",
+    "description": "help text for custom password tips",
+    "defaultMessage": "Use upper- and lowercase characters, but not at the beginning or end\n Add digits somewhere, but not at the beginning or end\n Add special characters, such as  @ $ \\\\  + _ %\n Spaces are ignored"
+  },
+  {
     "id": "cm.lost_code",
     "description": "Lost code problem description",
     "defaultMessage": "Is the code not working?"

--- a/src/login/translation/src/login/translation/messageIndex.json
+++ b/src/login/translation/src/login/translation/messageIndex.json
@@ -61,7 +61,7 @@
   {
     "id": "chpass.help-text-newpass-tips",
     "description": "help text for custom password tips",
-    "defaultMessage": "Use upper- and lowercase characters, but not at the beginning or end\n Add digits somewhere, but not at the beginning or end\n Add special characters, such as  @ $ \\\\  + _ %\n Spaces are ignored"
+    "defaultMessage": "Use upper- and lowercase characters, but not at the beginning or end\nAdd digits somewhere, but not at the beginning or end\nAdd special characters, such as  @ $ \\\\  + _ %\n Spaces are ignored"
   },
   {
     "id": "cm.lost_code",


### PR DESCRIPTION
#### Description:


---
- swe
<img width="606" alt="Screenshot 2021-11-11 at 11 05 50" src="https://user-images.githubusercontent.com/44289056/141279262-6172bda0-d356-49c3-a4ee-27aca1639721.png">

- eng
<img width="608" alt="Screenshot 2021-11-11 at 11 07 01" src="https://user-images.githubusercontent.com/44289056/141279356-13dca8d6-9d7a-41ce-99c9-0fafcfd18538.png">


--

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
