### PR TITLE
Add correct path to /personaldata for currently active page

### DIFF
--- a/src/components/DashboardNav.tsx
+++ b/src/components/DashboardNav.tsx
@@ -84,7 +84,7 @@ function DashboardNav(): JSX.Element {
             {getTipsAtIdentity()}
           </li>
         </NavLink>
-        <NavLink className={settingsClass} exact activeClassName="active" to={`/profile/settings/`}>
+        <NavLink className={settingsClass} exact activeClassName="active" to={`/profile/settings/personaldata`}>
           <li>
             {translate("dashboard_nav.settings")}
             {tipsAtSettings}


### PR DESCRIPTION
#### Description:
found a missing path which caused the currently active page indication to be inactive
now sorted so user always can see what page they are in

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
