### PR TITLE
Add span element around notification messages

### DIFF
--- a/src/components/Notifications.js
+++ b/src/components/Notifications.js
@@ -24,7 +24,7 @@ class Notifications extends Component {
           isOpen={true}
           toggle={this.props.handleRMNotification}
         >
-          {err_msg}
+          <span>{err_msg}</span>
         </Alert>
       );
     });
@@ -51,7 +51,7 @@ class Notifications extends Component {
             isOpen={true}
             toggle={this.props.handleRMNotification}
           >
-            {success_msg}
+            <span>{success_msg}</span>
           </Alert>
         );
       });


### PR DESCRIPTION
#### Description:

**issue** 
<img width="502" alt="Screenshot 2021-12-04 at 11 42 55" src="https://user-images.githubusercontent.com/44289056/144706659-79f64629-ff8b-4e03-b664-c5bb1e2d72cf.png">

**fixed**


<img width="504" alt="Screenshot 2021-12-04 at 11 42 01" src="https://user-images.githubusercontent.com/44289056/144706675-e7887b22-0596-49d4-b57b-4ef8b0dca45a.png">



#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
