### PR TITLE
Remove span tag from modal header styling

### DIFF
--- a/src/login/styles/_modals.scss
+++ b/src/login/styles/_modals.scss
@@ -22,9 +22,7 @@
     display: flex;
     justify-content: flex-end;
   }
-  & span {
-    padding: 0 2.25rem 1.5rem 2.25rem;
-  }
+  padding: 0 0 1.5rem 2.25rem;
 }
 
 h5.modal-title {


### PR DESCRIPTION
#### Description:

- before
<img width="505" alt="Screenshot 2021-12-10 at 14 47 02" src="https://user-images.githubusercontent.com/44289056/145583745-5bb19134-8c57-4905-b70b-01617f79a6b4.png">

- after
<img width="511" alt="Screenshot 2021-12-10 at 14 46 29" src="https://user-images.githubusercontent.com/44289056/145583725-0d9c2d3e-1154-443f-9b51-cbe073b944f1.png">


#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
