### PR TITLE
Add return for rendering help text

### DIFF
--- a/src/components/VerifyIdentity.tsx
+++ b/src/components/VerifyIdentity.tsx
@@ -72,7 +72,7 @@ class VerifyIdentity extends Component<VerifyIdentityProps> {
       const addedNin = this.props.nins[0];
 
       const buttonHelpText = (msg: string, disabled_if?: boolean) => {
-        <p className={"proofing-btn-help" + (disabled_if === true ? " disabled" : "")}>{translate(msg)}</p>;
+        return <p className={"proofing-btn-help" + (disabled_if === true ? " disabled" : "")}>{translate(msg)}</p>;
       };
 
       // proofing via letter requires the user to have added a NIN first


### PR DESCRIPTION
#### Description:

- issue

<img width="1426" alt="Screenshot 2021-12-10 at 15 39 34" src="https://user-images.githubusercontent.com/44289056/145591360-27d0208e-bdbd-4efc-8a38-ea1654aa0e08.png">

- fixed

<img width="1419" alt="Screenshot 2021-12-10 at 15 38 55" src="https://user-images.githubusercontent.com/44289056/145591212-a7b1b0e5-3497-4962-aabc-f0bfb9b83e65.png">

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
