### PR TITLE
Carina ladok styling

### DIFF
--- a/src/components/Ladok.tsx
+++ b/src/components/Ladok.tsx
@@ -152,14 +152,14 @@ const LadokLinkStatus = (): JSX.Element => {
   return (
     <React.Fragment>
       {isLinked === true ? (
-        <fieldset className="flex-between">
+        <fieldset className="ladok-university flex-between">
           <label>
             <FormattedMessage
               defaultMessage="Your account is linked with Ladok information from"
               description="Ladok account linking"
             />
           </label>
-          <div className="text-large">{university_name}</div>
+          <div className="text-large ladok-university-name">{university_name}</div>
         </fieldset>
       ) : (
         <React.Fragment />

--- a/src/login/styles/_Ladok.scss
+++ b/src/login/styles/_Ladok.scss
@@ -56,9 +56,7 @@ select {
   height: 40px;
   margin-top: 3px;
 }
-option:hover {
-  background-color: yellow;
-}
+
 .heading-4 {
   //@extend h4;
   font-size: 1.5rem;
@@ -66,11 +64,22 @@ option:hover {
   margin-bottom: 1rem;
   font-weight: 700;
 }
-
+/* Possible utility-classes */
 .text-large {
   font-size: 1.25rem;
 }
-
+.ladok-university-name {
+  flex-grow: 1;
+  text-align: right;
+  white-space: nowrap;
+}
 strong {
-  font-weight: 600;
+  font-weight: bold;
+}
+
+@media (max-width: 768px) {
+  .ladok-university {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }

--- a/src/login/styles/_tables.scss
+++ b/src/login/styles/_tables.scss
@@ -50,6 +50,7 @@ table {
             font-family: "ProximaNova-Regular";
             font-weight: 700;
             padding: 0;
+            font-size: 0.75rem;
           }
         }
         .verified {


### PR DESCRIPTION
#### Description:

Made settings table status label size relative to document inst of parent (Ove test issue).
Made responsive edits to linked Ladok university.

<img width="224" alt="Skärmavbild 2021-12-10 kl  16 26 31" src="https://user-images.githubusercontent.com/79106074/145598808-2bb9d1aa-7e9b-46c5-90c4-4ea221f1844c.png">
<img width="403" alt="Skärmavbild 2021-12-10 kl  16 26 52" src="https://user-images.githubusercontent.com/79106074/145598829-1dc07249-c98e-49b1-9705-9f2a1f6baf43.png">

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
