### PR TITLE
Remove html <b/> for without extra security heading

### DIFF
--- a/src/login/components/LoginApp/ResetPassword/ResetPasswordLayout.js
+++ b/src/login/components/LoginApp/ResetPassword/ResetPasswordLayout.js
@@ -19,7 +19,8 @@ const ResetPasswordLayout = (props) => {
         <p>{props.description}</p>
         {props.children}
         <p className="decription-without-security">
-          {props.linkInfoHeading}
+          <strong>{props.linkInfoHeading}</strong>
+          <br />
           {props.linkInfoText}
           <a id="continue-without-security" onClick={() => continueSetPassword()}>
             {" "}

--- a/src/login/translation/defaultMessages/password.js
+++ b/src/login/translation/defaultMessages/password.js
@@ -179,7 +179,7 @@ export const resetPassword = {
   "resetpw.without_extra_security_heading": (
     <FormattedMessage
       id="resetpw.without_extra_security_heading"
-      defaultMessage={`<b>Continue without extra security option </b> `}
+      defaultMessage={`Continue without extra security option`}
     />
   ),
   "resetpw.without_extra_security": (

--- a/src/login/translation/extractedMessages.json
+++ b/src/login/translation/extractedMessages.json
@@ -1319,7 +1319,7 @@
     "string": "Your account will require confirmation after the password has been reset."
   },
   "resetpw.without_extra_security_heading": {
-    "string": "<b>Continue without extra security option </b>"
+    "string": "Continue without extra security option"
   },
   "runtime_error.generic.description": {
     "string": "The issue has been reported to the team."

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -1319,7 +1319,7 @@
     "string": "Your account will require confirmation after the password has been reset."
   },
   "resetpw.without_extra_security_heading": {
-    "string": "<b>Continue without extra security option </b>"
+    "string": "Continue without extra security option"
   },
   "runtime_error.generic.description": {
     "string": "The issue has been reported to the team."

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -1319,7 +1319,7 @@
     "string": "Ditt konto kommer att behöva verifieras efter att lösenordet har återställts."
   },
   "resetpw.without_extra_security_heading": {
-    "string": "<b>Forsätt utan extra säkerhetsalternativ </b>"
+    "string": "Forsätt utan extra säkerhetsalternativ"
   },
   "runtime_error.generic.description": {
     "string": "Problemet har rapporterats till teamet."


### PR DESCRIPTION
#### Description:
<img width="400" alt="Screenshot 2021-12-13 at 11 45 43" src="https://user-images.githubusercontent.com/44289056/145798706-2af9a611-cb9f-4c2f-b01d-d7fd58cdc54d.png">

<img width="400" alt="Screenshot 2021-12-13 at 11 44 49" src="https://user-images.githubusercontent.com/44289056/145798755-c179d977-ece1-47f7-bf24-49191b9d5348.png">



#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
