### PR TITLE
Fix the swedish help text for frejaeID

### DIFF
--- a/src/login/translation/extractedMessages.json
+++ b/src/login/translation/extractedMessages.json
@@ -602,7 +602,7 @@
     "string": "No information for you found in Ladok with that institution."
   },
   "ladok.no-verified-nin": {
-    "string": "You need a verified Swedish national identity number to link your account with Ladok"
+    "string": "You need a verified Swedish national identity number to link your account with Ladok."
   },
   "letter.already-sent": {
     "string": "You have already been sent a verification letter"

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -355,7 +355,7 @@
     "string": "Tip: Use the app to find your nearest agent"
   },
   "eidas.initialize_proofing_help_text": {
-    "string": "To use this option you will need to first create a digital ID-card in the <a href=\"https://frejaeid.com/skaffa-freja-eid/\" target=\"_blank\">Freja eID</a> app."
+    "string": "To use this option you will need to first create a digital ID-card in the {skaffa_freja_eid_link} app."
   },
   "eidas.modal_title": {
     "string": "Use Freja eID+ and pass a local authorised agent"

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -355,7 +355,7 @@
     "string": "Tips: Du kan hitta närmsta ombud i appen"
   },
   "eidas.initialize_proofing_help_text": {
-    "string": "För att använda det här alternativet måste du först skaffa ett digitalt ID-kort i <a href=\"https://frejaeid.com/skaffa-freja-eid/\" target=\"_blank\">Freja eID</a> appen."
+    "string": "För att använda det här alternativet måste du först skaffa ett digitalt ID-kort i {skaffa_freja_eid_link} appen."
   },
   "eidas.modal_title": {
     "string": "Med Freja eID appen kan du skapa ett digitalt ID-kort"


### PR DESCRIPTION
#### Description:
<img width="1104" alt="Screenshot 2021-12-14 at 15 37 12" src="https://user-images.githubusercontent.com/44289056/146018844-4e6ccb43-0044-438a-a92c-e931e4e66701.png">


#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
