### PR TITLE
Fix empty modal header - phone code, email code

### DIFF
--- a/src/components/Emails.js
+++ b/src/components/Emails.js
@@ -77,6 +77,15 @@ function Emails(props) {
     description: "Placeholder for email code input",
   });
 
+  const title = intl.formatMessage(
+    {
+      id: "emails.confirm_title",
+      defaultMessage: "Click the link or enter the code sent to {email} here",
+      description: "Title for email code input",
+    },
+    { email: props.confirming }
+  );
+
   return (
     <div className="emailsview-form-container">
       <div className="intro">
@@ -102,9 +111,10 @@ function Emails(props) {
       <ConfirmModal
         modalId="emailConfirmDialog"
         id="emailConfirmDialogControl"
-        title={translate("emails.confirm_title", {
-          email: props.confirming,
-        })}
+        // title={translate("emails.confirm_title", {
+        //   email: props.confirming,
+        // })}
+        title={title}
         resendLabel={translate("cm.enter_code")}
         resendHelp={translate("cm.lost_code")}
         resendText={translate("cm.resend_code")}

--- a/src/components/Mobile.js
+++ b/src/components/Mobile.js
@@ -95,6 +95,15 @@ function Mobile(props) {
     description: "placeholder text for phone code input",
   });
 
+  const title = intl.formatMessage(
+    {
+      id: "mobile.confirm_title",
+      defaultMessage: "Enter the code sent to {phone}",
+      description: "Title for phone code input",
+    },
+    { phone: props.confirming }
+  );
+
   return (
     <div className="phoneview-form-container" id="phone">
       <div className="intro">
@@ -118,9 +127,7 @@ function Mobile(props) {
       <ConfirmModal
         modalId="phoneConfirmDialog"
         id="phoneConfirmDialogControl"
-        title={translate("mobile.confirm_title", {
-          phone: props.confirming,
-        })}
+        title={title}
         resendLabel={translate("cm.enter_code")}
         resendHelp={translate("cm.lost_code")}
         resendText={translate("cm.resend_code")}

--- a/src/login/translation/defaultMessages/userProfile.js
+++ b/src/login/translation/defaultMessages/userProfile.js
@@ -721,11 +721,7 @@ export const userData = {
   "mobile.button_add": <FormattedMessage id="mobile.button_add" defaultMessage={`Add`} />,
 
   "mobile.confirm_title": (values) => (
-    <FormattedMessage
-      id="mobile.confirm_title"
-      defaultMessage={`Enter the code sent to <b>{phone}</b>`}
-      values={values}
-    />
+    <FormattedMessage id="mobile.confirm_title" defaultMessage={`Enter the code sent to {phone}`} values={values} />
   ),
 
   /* ----- PERSONAL DATA------- */

--- a/src/login/translation/extractedMessages.json
+++ b/src/login/translation/extractedMessages.json
@@ -817,7 +817,7 @@
     "string": "Phone confirmation code"
   },
   "mobile.confirm_title": {
-    "string": "Enter the code sent to <b>{phone}</b>"
+    "string": "Enter the code sent to {phone}"
   },
   "mobile.mobile": {
     "string": "mobile"

--- a/src/login/translation/languages/en.json
+++ b/src/login/translation/languages/en.json
@@ -811,7 +811,7 @@
     "string": "Phone confirmation code"
   },
   "mobile.confirm_title": {
-    "string": "Enter the code sent to <b>{phone}</b>"
+    "string": "Enter the code sent to {phone}"
   },
   "mobile.mobile": {
     "string": "mobile"

--- a/src/login/translation/languages/sv.json
+++ b/src/login/translation/languages/sv.json
@@ -811,7 +811,7 @@
     "string": "Bekräftelsekod"
   },
   "mobile.confirm_title": {
-    "string": "Skriv in koden som skickats till <b>{phone}</b>"
+    "string": "Skriv in koden som skickats till {phone}"
   },
   "mobile.mobile": {
     "string": "Telefon"


### PR DESCRIPTION
#### Description:
- Issue
<img width="463" alt="Screenshot 2021-12-15 at 11 11 41" src="https://user-images.githubusercontent.com/44289056/146167325-4272f6cd-e99a-4508-af6a-2cb9b7ea0e97.png">
<img width="463" alt="Screenshot 2021-12-15 at 11 11 49" src="https://user-images.githubusercontent.com/44289056/146167335-5c069638-c2a0-433c-b8cf-f8e6b220e6fe.png">

- Fixed
<img width="474" alt="Screenshot 2021-12-15 at 11 04 09" src="https://user-images.githubusercontent.com/44289056/146166884-3d6449a1-8d2e-4559-b1af-ba4f5cb0a82f.png">

<img width="546" alt="Screenshot 2021-12-15 at 10 41 11" src="https://user-images.githubusercontent.com/44289056/146166903-99f35576-77ff-409e-ad75-b97a882d91bf.png">

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
