### PR TITLE
Fix  faulty styling for personal data

### DIFF
--- a/src/login/styles/_PersonalData.scss
+++ b/src/login/styles/_PersonalData.scss
@@ -23,7 +23,7 @@
       &:disabled,
       &.disabled {
         opacity: 0.5;
-        background: #f4f4f4;
+        background: $light-gray;
       }
     }
   }
@@ -97,7 +97,7 @@
 
   .form-control,
   input {
-    background-color: #f4f4f4;
+    background-color: $light-gray;
   }
 
   .form-group {

--- a/src/login/styles/_PersonalData.scss
+++ b/src/login/styles/_PersonalData.scss
@@ -40,6 +40,7 @@
   .name-inputs {
     .hint {
       margin-top: 1rem;
+      font-size: 1rem;
     }
 
     .icon-text {
@@ -68,10 +69,6 @@
 .personal-data-info {
   display: flex;
   flex-wrap: wrap;
-}
-
-.hint {
-  font-size: 1rem;
 }
 
 #personaldataview-form {

--- a/src/login/styles/_PersonalData.scss
+++ b/src/login/styles/_PersonalData.scss
@@ -74,16 +74,6 @@
   font-size: 1rem;
 }
 
-.input-pair {
-  display: flex;
-  flex: 1;
-  flex-wrap: wrap;
-
-  @media (max-width: 568px) {
-    flex-direction: column;
-  }
-}
-
 #personaldataview-form {
   margin-top: 0;
 

--- a/src/login/styles/_inputs.scss
+++ b/src/login/styles/_inputs.scss
@@ -33,6 +33,9 @@ input[type="radio"] {
   //  background-color: $white;
   background-color: transparent;
   border-radius: 50%;
+
+  /* to prevent overwrite from input padding, this ensures that the radio button remains round */
+  padding: 0;
 }
 
 /* appearance for checked radiobutton */


### PR DESCRIPTION
#### Description:
- issue
<img width="1144" alt="Screenshot 2022-01-24 at 15 27 42" src="https://user-images.githubusercontent.com/44289056/150801623-4d9fdcfb-0223-4759-9bc2-181268dbe851.png">


- fixed
<img width="1153" alt="Screenshot 2022-01-24 at 15 28 11" src="https://user-images.githubusercontent.com/44289056/150801588-c95ce8ad-03d4-4d3e-88f8-86a0968e6c43.png">

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
