### PR TITLE
LOGIN: with other device styling fixes 

### DIFF
--- a/src/login/components/Inputs/CustomInput.tsx
+++ b/src/login/components/Inputs/CustomInput.tsx
@@ -100,6 +100,7 @@ const InputElement = (props: CustomInputProps): JSX.Element => {
       placeholder={props.placeholder}
       valid={input.value !== "" && valid}
       aria-required={input.required}
+      invalid={props.invalid}
       {...input}
     />
   );

--- a/src/login/components/LoginApp/Login/UseOtherDevice2.tsx
+++ b/src/login/components/LoginApp/Login/UseOtherDevice2.tsx
@@ -223,25 +223,26 @@ function RenderLoggedIn(props: { isExpired: boolean; data: UseOtherDevice2Respon
           description="Use another device, finished"
         />
       </div>
+      <div>
+        <ResponseCodeForm
+          extra_className="device2"
+          submitDisabled={true}
+          inputsDisabled={true}
+          code={props.data.response_code}
+          handleSubmitCode={handleSubmit}
+        />
 
-      <ResponseCodeForm
-        extra_className="device2"
-        submitDisabled={true}
-        inputsDisabled={true}
-        code={props.data.response_code}
-        handleSubmitCode={handleSubmit}
-      />
-
-      <div className="phishing-warning">
-        <span className="warning-symbol">
-          <FontAwesomeIcon icon={faExclamationCircle} />
-        </span>
-        <span className="text-small">
-          <FormattedMessage
-            defaultMessage="Don't share this code with anyone, as it might compromise your credentials."
-            description="Use another device, finished"
-          />
-        </span>
+        <div className="phishing-warning">
+          <span className="warning-symbol">
+            <FontAwesomeIcon icon={faExclamationCircle} />
+          </span>
+          <span className="text-small">
+            <FormattedMessage
+              defaultMessage="Don't share this code with anyone, as it might compromise your credentials."
+              description="Use another device, finished"
+            />
+          </span>
+        </div>
       </div>
       <div className="buttons device2">
         <ButtonPrimary

--- a/src/login/components/LoginApp/Login/UsernamePw.tsx
+++ b/src/login/components/LoginApp/Login/UsernamePw.tsx
@@ -51,8 +51,8 @@ export default function UsernamePw() {
                 <RenderResetPasswordLink />
 
                 <div className="button-pair">
-                  <UsernamePwAnotherDeviceButton />
                   <UsernamePwSubmitButton {...formProps} />
+                  <UsernamePwAnotherDeviceButton />
                 </div>
               </div>
               <RenderRegisterLink />

--- a/src/login/components/LoginApp/Login/UsernamePw.tsx
+++ b/src/login/components/LoginApp/Login/UsernamePw.tsx
@@ -138,8 +138,8 @@ function UsernamePwAnotherDeviceButton(): JSX.Element | null {
   }
 
   return (
-    <ButtonSecondary type="submit" onClick={handleOnClick} id="login-other-device-button" className="secondary">
+    <ButtonPrimary type="submit" onClick={handleOnClick} id="login-other-device-button" className="primary">
       <FormattedMessage defaultMessage="Log in using another device" description="Login UsernamePw" />
-    </ButtonSecondary>
+    </ButtonPrimary>
   );
 }

--- a/src/login/components/LoginApp/Login/UsernamePw.tsx
+++ b/src/login/components/LoginApp/Login/UsernamePw.tsx
@@ -47,14 +47,17 @@ export default function UsernamePw() {
               <EmailInput name="email" autoFocus={true} required={true} />
               <PasswordInput name="current-password" />
 
-              <div className="button-pair">
-                <UsernamePwSubmitButton {...formProps} />
-                <UsernamePwAnotherDeviceButton />
+              <div className="flex-between">
+                <div className="button-pair">
+                  <UsernamePwSubmitButton {...formProps} />
+                  <UsernamePwAnotherDeviceButton />
+                </div>
+
+                <div>
+                  <RenderResetPasswordLink />
+                  <RenderRegisterLink />
+                </div>
               </div>
-
-              <RenderResetPasswordLink />
-
-              <RenderRegisterLink />
             </form>
           );
         }}
@@ -68,7 +71,7 @@ function RenderRegisterLink(): JSX.Element {
   return (
     <p className="secondary-link text-small">
       <FormattedMessage defaultMessage="Don't have eduID? " description="Login front page" />
-      &nbsp;
+      &nbsp;&nbsp;
       <Link href={toSignup} text={<FormattedMessage defaultMessage=" Register" description="Login front page" />} />
     </p>
   );

--- a/src/login/components/LoginApp/Login/UsernamePw.tsx
+++ b/src/login/components/LoginApp/Login/UsernamePw.tsx
@@ -7,7 +7,6 @@ import { FormattedMessage } from "react-intl";
 import { useHistory } from "react-router-dom";
 import { emailPattern } from "../../../app_utils/validation/regexPatterns";
 import ButtonPrimary from "../../Buttons/ButtonPrimary";
-import ButtonSecondary from "../../Buttons/ButtonSecondary";
 import Link from "../../Links/Link";
 import LinkRedirect from "../../Links/LinkRedirect";
 import { setLocalStorage } from "../ResetPassword/CountDownTimer";
@@ -16,6 +15,8 @@ import { Form as FinalForm, FormRenderProps } from "react-final-form";
 import EmailInput from "login/components/Inputs/EmailInput";
 import PasswordInput from "login/components/Inputs/PasswordInput";
 import { callUsernamePasswordSaga } from "login/redux/sagas/login/postUsernamePasswordSaga";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faQrcode } from "@fortawesome/free-solid-svg-icons";
 
 interface UsernamePwFormData {
   email?: string;
@@ -140,7 +141,8 @@ function UsernamePwAnotherDeviceButton(): JSX.Element | null {
   }
 
   return (
-    <ButtonPrimary type="submit" onClick={handleOnClick} id="login-other-device-button" className="primary">
+    <ButtonPrimary type="submit" onClick={handleOnClick} id="login-other-device-button">
+      <FontAwesomeIcon icon={faQrcode} />
       <FormattedMessage defaultMessage="Log in using another device" description="Login UsernamePw" />
     </ButtonPrimary>
   );

--- a/src/login/components/LoginApp/Login/UsernamePw.tsx
+++ b/src/login/components/LoginApp/Login/UsernamePw.tsx
@@ -46,12 +46,14 @@ export default function UsernamePw() {
               <EmailInput name="email" autoFocus={true} required={true} />
               <PasswordInput name="current-password" />
 
-              <RenderResetPasswordLink />
-              <div className="button-pair">
-                <UsernamePwAnotherDeviceButton />
-                <UsernamePwSubmitButton {...formProps} />
-              </div>
+              <div className="button-wrapper">
+                <RenderResetPasswordLink />
 
+                <div className="button-pair">
+                  <UsernamePwAnotherDeviceButton />
+                  <UsernamePwSubmitButton {...formProps} />
+                </div>
+              </div>
               <RenderRegisterLink />
             </form>
           );

--- a/src/login/components/LoginApp/Login/UsernamePw.tsx
+++ b/src/login/components/LoginApp/Login/UsernamePw.tsx
@@ -47,14 +47,13 @@ export default function UsernamePw() {
               <EmailInput name="email" autoFocus={true} required={true} />
               <PasswordInput name="current-password" />
 
-              <div className="button-wrapper">
-                <RenderResetPasswordLink />
-
-                <div className="button-pair">
-                  <UsernamePwSubmitButton {...formProps} />
-                  <UsernamePwAnotherDeviceButton />
-                </div>
+              <div className="button-pair">
+                <UsernamePwSubmitButton {...formProps} />
+                <UsernamePwAnotherDeviceButton />
               </div>
+
+              <RenderResetPasswordLink />
+
               <RenderRegisterLink />
             </form>
           );

--- a/src/login/styles/_Login.scss
+++ b/src/login/styles/_Login.scss
@@ -213,14 +213,25 @@ a.send-link.disabled {
 }
 
 // TODO: make .button-pair and .buttons same
-.username-pw .button-pair {
-  padding-top: 0.75rem;
+.username-pw {
+  .button-wrapper {
+    display: flex;
+    justify-content: space-between;
 
-  @media (max-width: $bp-xs) {
-    flex-direction: column-reverse;
+    .button-pair {
+      //padding-top: 0.75rem;
 
-    button:nth-child(n + 2) {
-      margin-bottom: 0.5rem;
+      // @media (max-width: $bp-xs) {
+      flex-direction: column-reverse;
+      align-items: flex-end;
+
+      button:nth-child(n + 2) {
+        margin-bottom: 0.5rem;
+      }
+      //}
+    }
+    @media (max-width: $bp-xs) {
+      flex-direction: column-reverse;
     }
   }
 }

--- a/src/login/styles/_Login.scss
+++ b/src/login/styles/_Login.scss
@@ -40,19 +40,14 @@
 }
 
 a.send-link {
-  width: fit-content;
-  align-self: center;
-  text-align: center;
-  padding: 0.5rem 0;
+  margin: 0.5rem 0;
+  display: inline-block;
 
   &:hover {
     text-decoration: underline;
   }
-
-  @media (max-width: $bp-xs) {
-    border-top: 1px solid $close;
-    margin-top: 0.5rem;
-    padding: 1.5rem 3rem 1rem;
+  @media (max-width: $bp-sm) {
+    margin: 1rem 0;
   }
 }
 
@@ -221,8 +216,10 @@ a.send-link.disabled {
 .username-pw {
   .button-pair {
     flex-direction: column;
-    justify-content: center;
+    justify-content: flex-start;
+    align-items: center;
     margin: 0.5rem 0;
+    width: 100%;
 
     button {
       svg {
@@ -233,12 +230,23 @@ a.send-link.disabled {
 
     @media (min-width: $bp-xs) {
       flex-direction: row;
+      width: auto;
 
       button {
         min-width: 100px;
-        margin-left: 8px;
-        margin-right: 8px;
+
+        &:nth-child(n + 2) {
+          margin-left: 1rem;
+        }
       }
+    }
+  }
+  .flex-between {
+    flex-direction: row;
+    text-align: right;
+    @media (max-width: $bp-md) {
+      flex-direction: column;
+      text-align: center;
     }
   }
 }
@@ -252,7 +260,6 @@ a.send-link.disabled {
 
   .buttons {
     display: flex;
-    justify-content: center;
     column-gap: 1rem;
     margin: 1em 0;
 

--- a/src/login/styles/_Login.scss
+++ b/src/login/styles/_Login.scss
@@ -286,7 +286,6 @@ a.send-link.disabled {
       display: flex;
       flex-direction: row;
       flex-wrap: wrap;
-      margin-bottom: 0.5rem;
 
       input[type="text"] {
         display: inline-block;
@@ -313,7 +312,7 @@ a.send-link.disabled {
     &.device2 .response-code-inputs {
       background-color: $white;
       width: fit-content;
-      padding: 0.5rem 1rem;
+      padding: 1rem;
 
       input {
         border-bottom: none;
@@ -365,12 +364,17 @@ a.send-link.disabled {
     flex-direction: column;
     row-gap: 1rem;
 
+    .response-code-form {
+      background: $white;
+    }
+
     .phishing-warning {
       display: flex;
       align-items: center;
-      row-gap: 1rem;
       font-size: 1rem;
       color: $dark-orange;
+      background: $white;
+      padding: 0 1rem 1.5rem;
 
       .warning-symbol {
         padding-right: 0.5rem;

--- a/src/login/styles/_Login.scss
+++ b/src/login/styles/_Login.scss
@@ -31,7 +31,7 @@
   }
 
   .secondary-link {
-    align-self: flex-end;
+    align-self: center;
 
     a:hover {
       text-decoration: underline;
@@ -41,15 +41,18 @@
 
 a.send-link {
   width: fit-content;
+  align-self: center;
+  text-align: center;
+  padding: 0.5rem 0;
 
   &:hover {
     text-decoration: underline;
   }
 
   @media (max-width: $bp-xs) {
-    align-self: center;
     border-top: 1px solid $close;
-    padding: 1.5rem 3rem 0;
+    margin-top: 0.5rem;
+    padding: 1.5rem 3rem 1rem;
   }
 }
 
@@ -191,11 +194,6 @@ a.send-link.disabled {
     }
   }
 
-  .username-pw .secondary-link {
-    margin-top: #{1 * $margin};
-    align-self: center;
-  }
-
   .tou .tou-text {
     margin-top: #{2 * $margin};
   }
@@ -221,31 +219,26 @@ a.send-link.disabled {
 
 // TODO: make .button-pair and .buttons same
 .username-pw {
-  .button-wrapper {
-    display: flex;
-    justify-content: space-between;
+  .button-pair {
+    flex-direction: column;
+    justify-content: center;
+    margin: 0.5rem 0;
 
-    .button-pair {
-      flex-direction: column;
-      align-items: flex-end;
-
-      button {
-        min-width: 125px;
-
-        &:nth-child(n + 2) {
-          margin-bottom: 2rem;
-        }
-
-        svg {
-          transform: rotate(0);
-          margin-right: 8px;
-        }
+    button {
+      svg {
+        transform: rotate(0);
+        margin-right: 8px;
       }
     }
 
-    @media (max-width: $bp-xs) {
-      flex-direction: column-reverse;
-      padding-top: 0.5rem;
+    @media (min-width: $bp-xs) {
+      flex-direction: row;
+
+      button {
+        min-width: 100px;
+        margin-left: 8px;
+        margin-right: 8px;
+      }
     }
   }
 }
@@ -259,16 +252,17 @@ a.send-link.disabled {
 
   .buttons {
     display: flex;
+    justify-content: center;
     column-gap: 1rem;
     margin: 1em 0;
+
+    button {
+      min-width: 100px;
+    }
 
     @media (max-width: $bp-xs) {
       flex-direction: column-reverse;
       margin-left: -2.25rem;
-
-      // &:not(.device2) {
-      //   margin-left: -2.25rem;
-      // }
 
       button:nth-child(n + 2) {
         margin-bottom: 0.5rem;

--- a/src/login/styles/_Login.scss
+++ b/src/login/styles/_Login.scss
@@ -26,7 +26,7 @@
     }
 
     button {
-      margin: 0.25rem 0 #{2 * $margin};
+      margin: 0.25rem 0 #{1 * $margin};
     }
   }
 
@@ -226,14 +226,14 @@ a.send-link.disabled {
     justify-content: space-between;
 
     .button-pair {
-      flex-direction: column-reverse;
+      flex-direction: column;
       align-items: flex-end;
 
       button {
         min-width: 125px;
 
         &:nth-child(n + 2) {
-          margin-bottom: 1rem;
+          margin-bottom: 2rem;
         }
 
         svg {

--- a/src/login/styles/_Login.scss
+++ b/src/login/styles/_Login.scss
@@ -32,6 +32,10 @@
 
   .secondary-link {
     align-self: flex-end;
+
+    a:hover {
+      text-decoration: underline;
+    }
   }
 }
 
@@ -41,6 +45,7 @@ a.send-link {
   &:hover {
     text-decoration: underline;
   }
+
   @media (max-width: $bp-xs) {
     align-self: center;
     border-top: 1px solid $close;
@@ -230,12 +235,14 @@ a.send-link.disabled {
         &:nth-child(n + 2) {
           margin-bottom: 1rem;
         }
+
         svg {
           transform: rotate(0);
           margin-right: 8px;
         }
       }
     }
+
     @media (max-width: $bp-xs) {
       flex-direction: column-reverse;
       padding-top: 0.5rem;

--- a/src/login/translation/extractedMessages.json
+++ b/src/login/translation/extractedMessages.json
@@ -26,16 +26,20 @@
   "4WguDO": {
     "string": "Developer info, not shown in production:"
   },
-  "5ajfFQ": {
-    "developer_comment": "Login UsernamePw",
-    "string": "Log in using another device"
-  },
   "5l4hxp": {
     "string": "Log in on another device"
+  },
+  "5lHsOL": {
+    "developer_comment": "Login front page",
+    "string": "Register"
   },
   "6t9/LE": {
     "developer_comment": "ToU second paragraph",
     "string": "attempts to disrupt or destroy computer-based information"
+  },
+  "891gyK": {
+    "developer_comment": "Login UsernamePw",
+    "string": "Other device"
   },
   "8P/lJJ": {
     "developer_comment": "ToU paragraph 1 heading",
@@ -253,10 +257,6 @@
   "VmITR8": {
     "developer_comment": "Ladok account linking",
     "string": "Data from Ladok might give you access to more services. Some higher education institutions allow eduID to fetch data from Ladok."
-  },
-  "Vz/80o": {
-    "developer_comment": "Login front page",
-    "string": "Register here."
   },
   "YxJ0EU": {
     "developer_comment": "Login OtherDevice",


### PR DESCRIPTION
#### Description:


- login on other device button changed to primary 
- add background color for error message to integrate with code
- added email input field invalid- line that  will be red when user gets an error
- removed checkmark icon in password input 

<img width="1419" alt="Screenshot 2022-02-23 at 10 39 29" src="https://user-images.githubusercontent.com/44289056/155294429-f897f754-587a-4d87-908f-00c7b77bc09e.png">


<img width="1416" alt="Screenshot 2022-02-23 at 10 39 51" src="https://user-images.githubusercontent.com/44289056/155294430-550af362-16db-4bef-92d3-5e5807716d17.png">

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
