### PR TITLE
LOGIN: get new qr code in device 1 when code expired, hidden content on device 2

### DIFF
--- a/src/login/components/LoginApp/Login/UseOtherDevice1.tsx
+++ b/src/login/components/LoginApp/Login/UseOtherDevice1.tsx
@@ -2,6 +2,7 @@ import { fetchUseOtherDevice1, UseOtherDevice1ResponseWithQR } from "apis/eduidL
 import { TimeRemainingWrapper } from "components/TimeRemaining";
 import { useAppDispatch, useAppSelector } from "login/app_init/hooks";
 import ButtonPrimary from "login/components/Buttons/ButtonPrimary";
+import ButtonSecondary from "login/components/Buttons/ButtonSecondary";
 import loginSlice from "login/redux/slices/loginSlice";
 import React, { useEffect, useState } from "react";
 import { FormattedMessage } from "react-intl";
@@ -67,22 +68,21 @@ function RenderFatalError(props: { error: JSX.Element; handleNewQRCodeOnClick?: 
         {props.error}
       </div>
       <div className="buttons">
-        <ButtonPrimary
+        <ButtonSecondary
           type="submit"
           onClick={handleCancelButtonOnClick}
           id="response-code-cancel-button"
           className={"settings-button"}
         >
-          <FormattedMessage defaultMessage="Cancel" description="Login OtherDevice" />
-        </ButtonPrimary>
-
+          <FormattedMessage defaultMessage="Back to Login" description="Login OtherDevice" />
+        </ButtonSecondary>
         <ButtonPrimary
           type="submit"
           id="refresh-get-new-code"
           className={"settings-button"}
           onClick={props.handleNewQRCodeOnClick}
         >
-          <FormattedMessage defaultMessage="Refresh" description="Login OtherDevice" />
+          <FormattedMessage defaultMessage="Continue with New QR code" description="Login OtherDevice" />
         </ButtonPrimary>
       </div>
     </React.Fragment>
@@ -116,7 +116,6 @@ function RenderOtherDevice1(props: { data: UseOtherDevice1ResponseWithQR }): JSX
   function handleNewQRCodeOnClick() {
     // Get new code
     if (login_ref) {
-      // refresh state on page reload
       const _name = username ? username : undefined; // backend is picky and won't allow null
       dispatch(fetchUseOtherDevice1({ ref: login_ref, action: "FETCH", username: _name }));
       setIsExpired(false);
@@ -137,27 +136,38 @@ function RenderOtherDevice1(props: { data: UseOtherDevice1ResponseWithQR }): JSX
     return undefined;
   }
 
-  const expiredMessage = <FormattedMessage defaultMessage="The code has expired" description="Use another device #1" />;
+  const expiredMessage = (
+    <>
+      {/* <h3>
+        <FormattedMessage defaultMessage="The code has expired" description="Use another device #1" />
+      </h3> */}
+
+      <FormattedMessage
+        defaultMessage="Inloggningen avbröts, eller tog för lång tid av säkerhetsskäl finns det en tidsbegränsning"
+        description="Use another device #1"
+      />
+    </>
+  );
 
   return (
     <React.Fragment>
-      <ol className="listed-steps">
-        <li>
-          <FormattedMessage defaultMessage="Scan this QR-code with your other device" />
+      {!isExpired ? (
+        <ol className="listed-steps">
+          <li>
+            <FormattedMessage defaultMessage="Scan this QR-code with your other device" />
 
-          <figure>
-            <img className="qr-code" src={data.qr_img} />
-            <figcaption className="short-code">ID# {data.short_code}</figcaption>
-          </figure>
-        </li>
+            <figure>
+              <img className="qr-code" src={data.qr_img} />
+              <figcaption className="short-code">ID# {data.short_code}</figcaption>
+            </figure>
+          </li>
 
-        <li>
-          <FormattedMessage defaultMessage="Log in on the other device" />
-        </li>
+          <li>
+            <FormattedMessage defaultMessage="Log in on the other device" />
+          </li>
 
-        <li>
-          <FormattedMessage defaultMessage="Enter the response code shown on the other device in the form below" />
-          {!isExpired ? (
+          <li>
+            <FormattedMessage defaultMessage="Enter the response code shown on the other device in the form below" />
             <div className="expiration-info device1">
               <TimeRemainingWrapper
                 name="other-device-expires"
@@ -168,11 +178,7 @@ function RenderOtherDevice1(props: { data: UseOtherDevice1ResponseWithQR }): JSX
                 <ExpiresMeter expires_max={data.expires_max} />
               </TimeRemainingWrapper>
             </div>
-          ) : null}
 
-          {isExpired ? (
-            <RenderFatalError error={expiredMessage} handleNewQRCodeOnClick={handleNewQRCodeOnClick} />
-          ) : (
             <ResponseCodeForm
               extra_className="device1"
               submitDisabled={false}
@@ -181,10 +187,11 @@ function RenderOtherDevice1(props: { data: UseOtherDevice1ResponseWithQR }): JSX
               handleAbort={handleAbortButtonOnClick}
               handleSubmitCode={handleSubmitCode}
             />
-          )}
-        </li>
-      </ol>
-
+          </li>
+        </ol>
+      ) : (
+        <RenderFatalError error={expiredMessage} handleNewQRCodeOnClick={handleNewQRCodeOnClick} />
+      )}
       <DeveloperInfo {...data} />
     </React.Fragment>
   );

--- a/src/login/components/LoginApp/Login/UseOtherDevice1.tsx
+++ b/src/login/components/LoginApp/Login/UseOtherDevice1.tsx
@@ -74,7 +74,7 @@ function RenderFatalError(props: { error: JSX.Element; handleNewQRCodeOnClick?: 
           id="response-code-cancel-button"
           className={"settings-button"}
         >
-          <FormattedMessage defaultMessage="Back to Login" description="Login OtherDevice" />
+          <FormattedMessage defaultMessage="Cancel" description="Login OtherDevice" />
         </ButtonSecondary>
         <ButtonPrimary
           type="submit"
@@ -82,7 +82,7 @@ function RenderFatalError(props: { error: JSX.Element; handleNewQRCodeOnClick?: 
           className={"settings-button"}
           onClick={props.handleNewQRCodeOnClick}
         >
-          <FormattedMessage defaultMessage="Continue with New QR code" description="Login OtherDevice" />
+          <FormattedMessage defaultMessage="Retry with QR code" description="Login OtherDevice" />
         </ButtonPrimary>
       </div>
     </React.Fragment>
@@ -138,12 +138,8 @@ function RenderOtherDevice1(props: { data: UseOtherDevice1ResponseWithQR }): JSX
 
   const expiredMessage = (
     <>
-      {/* <h3>
-        <FormattedMessage defaultMessage="The code has expired" description="Use another device #1" />
-      </h3> */}
-
       <FormattedMessage
-        defaultMessage="Inloggningen avbröts, eller tog för lång tid av säkerhetsskäl finns det en tidsbegränsning"
+        defaultMessage="the login attempt was aborted or exceeded the allowed time limit for safety reasons please try again"
         description="Use another device #1"
       />
     </>

--- a/src/login/components/LoginApp/Login/UseOtherDevice1.tsx
+++ b/src/login/components/LoginApp/Login/UseOtherDevice1.tsx
@@ -163,7 +163,7 @@ function RenderOtherDevice1(props: { data: UseOtherDevice1ResponseWithQR }): JSX
           </li>
 
           <li>
-            <FormattedMessage defaultMessage="Enter the response code shown on the other device in the form below" />
+            <FormattedMessage defaultMessage="Enter the six digit response code shown on the other device in the form below" />
             <div className="expiration-info device1">
               <TimeRemainingWrapper
                 name="other-device-expires"

--- a/src/login/components/LoginApp/Login/UseOtherDevice1.tsx
+++ b/src/login/components/LoginApp/Login/UseOtherDevice1.tsx
@@ -110,7 +110,6 @@ function RenderOtherDevice1(props: { data: UseOtherDevice1ResponseWithQR }): JSX
     if (login_ref) {
       // Tell backend we're abandoning the request to login using another device
       dispatch(fetchUseOtherDevice1({ ref: login_ref, action: "ABORT" }));
-      setIsExpired(false);
     }
   }
 
@@ -120,6 +119,7 @@ function RenderOtherDevice1(props: { data: UseOtherDevice1ResponseWithQR }): JSX
       // refresh state on page reload
       const _name = username ? username : undefined; // backend is picky and won't allow null
       dispatch(fetchUseOtherDevice1({ ref: login_ref, action: "FETCH", username: _name }));
+      setIsExpired(false);
     }
   }
 
@@ -157,17 +157,18 @@ function RenderOtherDevice1(props: { data: UseOtherDevice1ResponseWithQR }): JSX
 
         <li>
           <FormattedMessage defaultMessage="Enter the response code shown on the other device in the form below" />
-
-          <div className="expiration-info device1">
-            <TimeRemainingWrapper
-              name="other-device-expires"
-              unique_id={data.display_id}
-              value={data.expires_in}
-              onReachZero={handleTimerReachZero}
-            >
-              <ExpiresMeter expires_max={data.expires_max} />
-            </TimeRemainingWrapper>
-          </div>
+          {!isExpired ? (
+            <div className="expiration-info device1">
+              <TimeRemainingWrapper
+                name="other-device-expires"
+                unique_id={data.display_id}
+                value={data.expires_in}
+                onReachZero={handleTimerReachZero}
+              >
+                <ExpiresMeter expires_max={data.expires_max} />
+              </TimeRemainingWrapper>
+            </div>
+          ) : null}
 
           {isExpired ? (
             <RenderFatalError error={expiredMessage} handleNewQRCodeOnClick={handleNewQRCodeOnClick} />

--- a/src/login/components/LoginApp/Login/UseOtherDevice1.tsx
+++ b/src/login/components/LoginApp/Login/UseOtherDevice1.tsx
@@ -139,7 +139,7 @@ function RenderOtherDevice1(props: { data: UseOtherDevice1ResponseWithQR }): JSX
   const expiredMessage = (
     <>
       <FormattedMessage
-        defaultMessage="the login attempt was aborted or exceeded the allowed time limit for safety reasons please try again"
+        defaultMessage="The login attempt was aborted or exceeded the time limit. Please try again."
         description="Use another device #1"
       />
     </>

--- a/src/login/components/LoginApp/Login/UseOtherDevice2.tsx
+++ b/src/login/components/LoginApp/Login/UseOtherDevice2.tsx
@@ -208,8 +208,6 @@ function RenderLoggedIn(props: { isExpired: boolean; data: UseOtherDevice2Respon
   }
 
   if (props.isExpired) {
-    // TODO: show this as a modal window, greying out all the other content?
-
     return (
       <p>
         <FormattedMessage

--- a/src/login/components/LoginApp/Login/UseOtherDevice2.tsx
+++ b/src/login/components/LoginApp/Login/UseOtherDevice2.tsx
@@ -223,7 +223,7 @@ function RenderLoggedIn(props: { isExpired: boolean; data: UseOtherDevice2Respon
       <div className="finished device2">
         <div className="response-code">
           <FormattedMessage
-            defaultMessage="Use the response code below to continue logging in on the other device"
+            defaultMessage="Use the response code below in the first device to continue logging in."
             description="Use another device, finished"
           />
         </div>

--- a/src/login/components/LoginApp/Login/UseOtherDevice2.tsx
+++ b/src/login/components/LoginApp/Login/UseOtherDevice2.tsx
@@ -223,7 +223,7 @@ function RenderLoggedIn(props: { isExpired: boolean; data: UseOtherDevice2Respon
       <div className="finished device2">
         <div className="response-code">
           <FormattedMessage
-            defaultMessage="Use the response code below in the first device to continue logging in."
+            defaultMessage="Use the response code below in the first device to continue logging in"
             description="Use another device, finished"
           />
         </div>

--- a/src/login/components/LoginApp/Login/UseOtherDevice2.tsx
+++ b/src/login/components/LoginApp/Login/UseOtherDevice2.tsx
@@ -200,12 +200,12 @@ function RenderLoggedIn(props: { isExpired: boolean; data: UseOtherDevice2Respon
     // TODO: show this as a modal window, greying out all the other content?
 
     return (
-      <div className="finished device2">
+      <p>
         <FormattedMessage
           defaultMessage="The code has expired, please close this browser window"
           description="Use another device, finished"
         />
-      </div>
+      </p>
     );
   }
 

--- a/src/login/components/LoginApp/Login/UseOtherDevice2.tsx
+++ b/src/login/components/LoginApp/Login/UseOtherDevice2.tsx
@@ -70,7 +70,7 @@ function RenderOtherDevice2(props: { data: LoginUseOtherDevice2Response }): JSX.
     return (
       <p>
         <FormattedMessage
-          defaultMessage="The code has expired, please close this browser window"
+          defaultMessage="The code has expired, please close this browser window."
           description="Use another device, finished"
         />
       </p>
@@ -213,7 +213,7 @@ function RenderLoggedIn(props: { isExpired: boolean; data: UseOtherDevice2Respon
     return (
       <p>
         <FormattedMessage
-          defaultMessage="The code has expired, please close this browser window"
+          defaultMessage="The code has expired, please close this browser window."
           description="Use another device, finished"
         />
       </p>

--- a/src/login/components/LoginApp/Login/UseOtherDevice2.tsx
+++ b/src/login/components/LoginApp/Login/UseOtherDevice2.tsx
@@ -67,18 +67,20 @@ function RenderOtherDevice2(props: { data: LoginUseOtherDevice2Response }): JSX.
   return (
     <React.Fragment>
       <ol className="listed-steps">
-        <li>
-          <InfoAboutOtherDevice data={data} />
+        {!timerIsZero ? (
+          <li>
+            <InfoAboutOtherDevice data={data} />
 
-          <TimeRemainingWrapper
-            name="other-device-expires"
-            unique_id={data.short_code}
-            value={data.expires_in}
-            onReachZero={handleTimerReachZero}
-          >
-            <ExpiresMeter expires_max={data.expires_max} />
-          </TimeRemainingWrapper>
-        </li>
+            <TimeRemainingWrapper
+              name="other-device-expires"
+              unique_id={data.short_code}
+              value={data.expires_in}
+              onReachZero={handleTimerReachZero}
+            >
+              <ExpiresMeter expires_max={data.expires_max} />
+            </TimeRemainingWrapper>
+          </li>
+        ) : null}
 
         {data.state === "IN_PROGRESS" ? (
           <li>
@@ -86,9 +88,7 @@ function RenderOtherDevice2(props: { data: LoginUseOtherDevice2Response }): JSX.
             <ProceedLoginButton disabled={timerIsZero} />
           </li>
         ) : data.state === "AUTHENTICATED" ? (
-          <li>
-            <RenderLoggedIn data={data} isExpired={timerIsZero} />
-          </li>
+          <RenderLoggedIn data={data} isExpired={timerIsZero} />
         ) : data !== undefined ? (
           <li>
             <FormattedMessage
@@ -210,51 +210,53 @@ function RenderLoggedIn(props: { isExpired: boolean; data: UseOtherDevice2Respon
   }
 
   return (
-    <div className="finished device2">
-      <div className="response-code">
-        <FormattedMessage
-          defaultMessage="Use the response code below to continue logging in on the other device"
-          description="Use another device, finished"
-        />
-      </div>
-      <div className="response-code text-small">
-        <FormattedMessage
-          defaultMessage="After using the code on the other device, please close this browser window."
-          description="Use another device, finished"
-        />
-      </div>
-      <div>
-        <ResponseCodeForm
-          extra_className="device2"
-          submitDisabled={true}
-          inputsDisabled={true}
-          code={props.data.response_code}
-          handleSubmitCode={handleSubmit}
-        />
+    <li>
+      <div className="finished device2">
+        <div className="response-code">
+          <FormattedMessage
+            defaultMessage="Use the response code below to continue logging in on the other device"
+            description="Use another device, finished"
+          />
+        </div>
+        <div className="response-code text-small">
+          <FormattedMessage
+            defaultMessage="After using the code on the other device, please close this browser window."
+            description="Use another device, finished"
+          />
+        </div>
+        <div>
+          <ResponseCodeForm
+            extra_className="device2"
+            submitDisabled={true}
+            inputsDisabled={true}
+            code={props.data.response_code}
+            handleSubmitCode={handleSubmit}
+          />
 
-        <div className="phishing-warning">
-          <span className="warning-symbol">
-            <FontAwesomeIcon icon={faExclamationCircle} />
-          </span>
-          <span className="text-small">
-            <FormattedMessage
-              defaultMessage="Don't share this code with anyone, as it might compromise your credentials."
-              description="Use another device, finished"
-            />
-          </span>
+          <div className="phishing-warning">
+            <span className="warning-symbol">
+              <FontAwesomeIcon icon={faExclamationCircle} />
+            </span>
+            <span className="text-small">
+              <FormattedMessage
+                defaultMessage="Don't share this code with anyone, as it might compromise your credentials."
+                description="Use another device, finished"
+              />
+            </span>
+          </div>
+        </div>
+        <div className="buttons device2">
+          <ButtonPrimary
+            type="submit"
+            onClick={handleOnClick}
+            id="proceed-other-device-button"
+            className={"settings-button"}
+          >
+            <FormattedMessage defaultMessage="Cancel" description="Use another device, finished" />
+          </ButtonPrimary>
         </div>
       </div>
-      <div className="buttons device2">
-        <ButtonPrimary
-          type="submit"
-          onClick={handleOnClick}
-          id="proceed-other-device-button"
-          className={"settings-button"}
-        >
-          <FormattedMessage defaultMessage="Cancel" description="Use another device, finished" />
-        </ButtonPrimary>
-      </div>
-    </div>
+    </li>
   );
 }
 

--- a/src/login/components/LoginApp/Login/UseOtherDevice2.tsx
+++ b/src/login/components/LoginApp/Login/UseOtherDevice2.tsx
@@ -64,23 +64,34 @@ function RenderOtherDevice2(props: { data: LoginUseOtherDevice2Response }): JSX.
     setTimerIsZero(true);
   }
 
+  if (timerIsZero) {
+    // TODO: show this as a modal window, greying out all the other content?
+
+    return (
+      <p>
+        <FormattedMessage
+          defaultMessage="The code has expired, please close this browser window"
+          description="Use another device, finished"
+        />
+      </p>
+    );
+  }
+
   return (
     <React.Fragment>
       <ol className="listed-steps">
-        {!timerIsZero ? (
-          <li>
-            <InfoAboutOtherDevice data={data} />
+        <li>
+          <InfoAboutOtherDevice data={data} />
 
-            <TimeRemainingWrapper
-              name="other-device-expires"
-              unique_id={data.short_code}
-              value={data.expires_in}
-              onReachZero={handleTimerReachZero}
-            >
-              <ExpiresMeter expires_max={data.expires_max} />
-            </TimeRemainingWrapper>
-          </li>
-        ) : null}
+          <TimeRemainingWrapper
+            name="other-device-expires"
+            unique_id={data.short_code}
+            value={data.expires_in}
+            onReachZero={handleTimerReachZero}
+          >
+            <ExpiresMeter expires_max={data.expires_max} />
+          </TimeRemainingWrapper>
+        </li>
 
         {data.state === "IN_PROGRESS" ? (
           <li>

--- a/src/login/styles/_Login.scss
+++ b/src/login/styles/_Login.scss
@@ -433,7 +433,7 @@ a.send-link.disabled {
   }
 
   p {
-    margin-left: -2.25em;
+    margin-left: -1.75em;
   }
 }
 

--- a/src/login/styles/_Login.scss
+++ b/src/login/styles/_Login.scss
@@ -46,6 +46,7 @@ a.send-link {
   &:hover {
     text-decoration: underline;
   }
+
   @media (max-width: $bp-sm) {
     margin: 1rem 0;
   }
@@ -241,9 +242,11 @@ a.send-link.disabled {
       }
     }
   }
+
   .flex-between {
     flex-direction: row;
     text-align: right;
+
     @media (max-width: $bp-md) {
       flex-direction: column;
       text-align: center;
@@ -427,6 +430,10 @@ a.send-link.disabled {
       font-family: "Akkurat";
       font-weight: bold;
     }
+  }
+
+  p {
+    margin-left: -2.25em;
   }
 }
 

--- a/src/login/styles/_inputs.scss
+++ b/src/login/styles/_inputs.scss
@@ -146,8 +146,8 @@ input:focus {
 }
 
 .input-validate-error {
-  font-size: 1rem;
-  color: $orange-highlight;
+  font-size: 1.25rem;
+  color: $black;
 }
 
 // login username-pw / reset-password set-new-password

--- a/src/login/translation/extractedMessages.json
+++ b/src/login/translation/extractedMessages.json
@@ -1,4 +1,8 @@
 {
+  "/8yhnq": {
+    "developer_comment": "Login OtherDevice",
+    "string": "Retry with QR code"
+  },
   "/ANjhk": {
     "developer_comment": "Header register",
     "string": "Register"
@@ -159,6 +163,10 @@
     "developer_comment": "Reset password copy password tooltip",
     "string": "Copied!"
   },
+  "I+NQu2": {
+    "developer_comment": "Use another device #1",
+    "string": "The login attempt was aborted or exceeded the time limit. Please try again."
+  },
   "InvalidStateError: The user attempted to register an authenticator that contains one of the credentials already registered with the relying party.": {
     "string": "You are attempting to register an authenticator that contains one of the credentials already registered with the relying party"
   },
@@ -209,10 +217,6 @@
   "PwI8gG": {
     "developer_comment": "Reset Password set new password success",
     "string": "Password has been updated."
-  },
-  "R0rN2Z": {
-    "developer_comment": "Use another device, finished",
-    "string": "The code has expired, please close this browser window"
   },
   "R3n7aY": {
     "developer_comment": "Use other device",
@@ -736,6 +740,10 @@
     "developer_comment": "Set new password (go back to eduID button)",
     "string": "go back"
   },
+  "hEOTTF": {
+    "developer_comment": "Use another device, finished",
+    "string": "The code has expired, please close this browser window."
+  },
   "hRXpVn": {
     "developer_comment": "Header logout",
     "string": "Log out"
@@ -1022,10 +1030,6 @@
   },
   "nins.wrong_length": {
     "string": "A national id number must have 12 digits"
-  },
-  "noNGvR": {
-    "developer_comment": "Use another device #1",
-    "string": "The code has expired"
   },
   "o2Jbwm": {
     "developer_comment": "Terms of use (common footer)",

--- a/src/login/translation/extractedMessages.json
+++ b/src/login/translation/extractedMessages.json
@@ -233,6 +233,9 @@
   "SecurityMsg.rm_webauthn": {
     "string": "Security key has been removed."
   },
+  "SgvXTp": {
+    "string": "Enter the six digit response code shown on the other device in the form below"
+  },
   "SuxgmQ": {
     "developer_comment": "ToU 2016-v1 paragraph 2 heading",
     "string": "SUNET judges unethical behaviour to be when someone:"
@@ -763,12 +766,13 @@
     "developer_comment": "Reset Password phone code sent (Input label)",
     "string": "Confirmation code"
   },
-  "j6UxLp": {
-    "string": "Enter the response code shown on the other device in the form below"
-  },
   "l+PAQr": {
     "developer_comment": "explanation text for letter proofing",
     "string": "For you registered at your current address"
+  },
+  "l2zA68": {
+    "developer_comment": "Use another device, finished",
+    "string": "Use the response code below in the first device to continue logging in."
   },
   "ladok.dropdown_placeholder": {
     "developer_comment": "Ladok account linking",
@@ -1347,10 +1351,6 @@
   "q4ENsq": {
     "developer_comment": "explanation text for letter proofing",
     "string": "Confirmation code"
-  },
-  "qHqnkz": {
-    "developer_comment": "Use another device, finished",
-    "string": "Use the response code below to continue logging in on the other device"
   },
   "qw1OJJ": {
     "developer_comment": "ToU second paragraph",


### PR DESCRIPTION
#### Description:
up on timer/code expired
device 1:  enable option to cancel or to retry and added a information message  
device 2:  all content(code inout, device information) to be hidden and showing code expired message

- code expired, device 1
<img width="1190" alt="Screenshot 2022-03-10 at 20 47 32" src="https://user-images.githubusercontent.com/44289056/157751165-f3b42379-0783-47d4-be8c-2aa741795741.png">

- code expired, device 2
<img width="1152" alt="Screenshot 2022-03-10 at 21 14 47" src="https://user-images.githubusercontent.com/44289056/157751191-de28b700-67b0-4a36-97b0-92b42509ae25.png">



#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
