### PR TITLE
LOGIN: edit input field for response code

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11294,9 +11294,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "devOptional": true
     },
     "node_modules/minimist-options": {
@@ -25958,9 +25958,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
+      "integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
       "devOptional": true
     },
     "minimist-options": {

--- a/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
+++ b/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
@@ -118,7 +118,7 @@ interface CodeFieldProps {
   autoFocus?: boolean;
 }
 
-// helper-function to make for tidy code with one line per input field below
+// helper-component to make for tidy code with one line per input field in ShortCodeForm
 function CodeField({ num, value, disabled = false, fixed = false, autoFocus = undefined }: CodeFieldProps) {
   function handleKeyUp(event: React.KeyboardEvent<HTMLFormElement>) {
     const pressedKey = event.key;
@@ -157,9 +157,7 @@ function CodeField({ num, value, disabled = false, fixed = false, autoFocus = un
   }
 
   function onlyAllowedNumericalInput(e: React.KeyboardEvent<HTMLFormElement>) {
-    const charCode = typeof e.which == "undefined" ? e.keyCode : e.which;
-    const charStr = String.fromCharCode(charCode);
-    if (!charStr.match(/^[0-9]+$/)) e.preventDefault();
+    if (!isDigit(e.key)) e.preventDefault();
   }
 
   return (

--- a/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
+++ b/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
@@ -58,17 +58,19 @@ function ShortCodeForm(props: FormRenderProps<ResponseCodeValues> & ResponseCode
   return (
     <form onSubmit={props.handleSubmit} className="response-code-form">
       <div className="response-code-inputs">
-        {Array(9)
-          .fill("")
-          .map((_, index) => (
-            <CodeField
-              key={index}
-              num={index}
-              value=""
-              disabled={index === 0 || index === 1 || index === 5 ? true : false}
-              autoFocus={index === 2 && !props.inputsDisabled ? true : false}
-            />
-          ))}
+        <CodeField num={0} value="S" disabled={true} />
+        <CodeField num={1} value="K" disabled={true} />
+        <span className="nowrap-group">
+          <CodeField num={2} value="" disabled={props.inputsDisabled} autoFocus={!props.inputsDisabled} />
+          <CodeField num={3} value="" disabled={props.inputsDisabled} />
+          <CodeField num={4} value="" disabled={props.inputsDisabled} />
+        </span>
+        <CodeField num={5} value="-" disabled={true} fixed={true} />
+        <span className="nowrap-group">
+          <CodeField num={6} value="" disabled={props.inputsDisabled} />
+          <CodeField num={7} value="" disabled={props.inputsDisabled} />
+          <CodeField num={8} value="" disabled={props.inputsDisabled} />
+        </span>
       </div>
       {props.error && (
         <div role="alert" aria-invalid="true" tabIndex={0} className="input-validate-error">

--- a/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
+++ b/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
@@ -71,7 +71,7 @@ function ShortCodeForm(props: FormRenderProps<ResponseCodeValues> & ResponseCode
               num={index}
               value=""
               disabled={index === 0 || index === 1 || index === 5 ? true : false}
-              autoFocus={index === 2 ? true : false}
+              autoFocus={index === 2 && !props.inputsDisabled ? true : false}
             />
           ))}
       </div>

--- a/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
+++ b/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
@@ -131,12 +131,11 @@ interface CodeFieldProps {
   fixed?: boolean;
   autoFocus?: boolean;
   onFocus?: any;
+  onChange?: any;
 }
 
 // helper-function to make for tidy code with one line per input field below
 function CodeField({ num, value, onFocus, disabled = false, fixed = false, autoFocus = undefined }: CodeFieldProps) {
-  // TODO: Handle backspace, moving to the preceding field *after* clearing the contents of this one
-  // TODO: Add final-form validation to the form
   function handleKeyUp(event: React.KeyboardEvent<HTMLFormElement>) {
     const pressedKey = event.key;
     const form = event.currentTarget.form;
@@ -145,60 +144,31 @@ function CodeField({ num, value, onFocus, disabled = false, fixed = false, autoF
     switch (pressedKey) {
       case "Backspace":
       case "Delete": {
-        event.preventDefault();
         if (inputs[index].value) {
         } else {
           inputs[index - 1].focus();
-          // focusPrevInput();
         }
         break;
       }
       case "ArrowLeft": {
-        event.preventDefault();
         if (inputs[index - 1] !== undefined) {
           inputs[index - 1].focus();
         }
-
-        // focusPrevInput();
         break;
       }
       case "ArrowRight": {
-        event.preventDefault();
         if (inputs[index + 1] !== undefined) {
           inputs[index + 1].focus();
         }
-        // focusNextInput();
-
         break;
       }
       default: {
-        if (pressedKey.match(/(\w|\s)/g)) {
-          event.preventDefault();
+        if (index > -1 && index < inputs.length - 1) {
+          inputs[index + 1].focus();
         }
+        break;
       }
     }
-
-    // console.log("Key up: ", event.key.toLowerCase());
-    // if (event.key.toLowerCase() === "enter") {
-    //   event.preventDefault();
-    //   //dispatch(submit("usernamePwForm"));
-    // } else if (isDigit(event.key.toLowerCase())) {
-    //   // focus the next input field
-    //   const form = event.currentTarget.form;
-    //   // disabled inputs are placeholders, filter them out
-    //   const inputs = [...form].filter((input: { disabled?: boolean }) => !input.disabled);
-    //   const index = inputs.indexOf(event.currentTarget);
-    //   if (index < 0) {
-    //     // bail of the current input could not be found
-    //     return undefined;
-    //   }
-    //   const lastIndex = inputs.length - 1;
-    //   console.log(`Current index ${index} of ${lastIndex}`);
-    //   if (index > -1 && index < inputs.length - 1) {
-    //     console.log(`Advancing focus to index ${index + 1} of ${lastIndex}`);
-    //     inputs[index + 1].focus();
-    //   }
-    // }
   }
 
   return (

--- a/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
+++ b/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
@@ -156,7 +156,7 @@ function CodeField({ num, value, disabled = false, fixed = false, autoFocus = un
     }
   }
 
-  function onlyAllowedNumericalInput(e: React.KeyboardEvent<HTMLFormElement>) {
+  function handleCodeFieldInput(e: React.KeyboardEvent<HTMLFormElement>) {
     if (!isDigit(e.key)) e.preventDefault();
   }
 
@@ -173,7 +173,7 @@ function CodeField({ num, value, disabled = false, fixed = false, autoFocus = un
       autoFocus={autoFocus}
       onKeyUp={handleKeyUp}
       onFocus={(event: FocusEvent<HTMLInputElement>) => event.target.select()}
-      onKeyPress={onlyAllowedNumericalInput}
+      onKeyPress={handleCodeFieldInput}
     />
   );
 }

--- a/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
+++ b/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
@@ -75,19 +75,16 @@ function ShortCodeForm(props: FormRenderProps<ResponseCodeValues> & ResponseCode
   return (
     <form onSubmit={props.handleSubmit} className="response-code-form">
       <div className="response-code-inputs">
-        <CodeField num={0} value="S" disabled={true} />
-        <CodeField num={1} value="K" disabled={true} />
-        <span className="nowrap-group">
-          <CodeField num={2} value="" disabled={props.inputsDisabled} autoFocus={!props.inputsDisabled} />
-          <CodeField num={3} value="" disabled={props.inputsDisabled} />
-          <CodeField num={4} value="" disabled={props.inputsDisabled} />
-        </span>
-        <CodeField num={5} value="-" disabled={true} fixed={true} />
-        <span className="nowrap-group">
-          <CodeField num={6} value="" disabled={props.inputsDisabled} />
-          <CodeField num={7} value="" disabled={props.inputsDisabled} />
-          <CodeField num={8} value="" disabled={props.inputsDisabled} />
-        </span>
+        {Array(9)
+          .fill("")
+          .map((_, index) => (
+            <CodeField
+              num={index}
+              value=""
+              disabled={index === 0 || index === 1 || index === 5 ? true : false}
+              autoFocus={index === 2 ? true : false}
+            />
+          ))}
       </div>
       {props.error && (
         <div role="alert" aria-invalid="true" tabIndex={0} className="input-validate-error">

--- a/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
+++ b/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
@@ -157,7 +157,6 @@ function CodeField({ num, value, disabled = false, fixed = false, autoFocus = un
   }
 
   function onlyAllowedNumericalInput(e: React.KeyboardEvent<HTMLFormElement>) {
-    e = e || window.event;
     const charCode = typeof e.which == "undefined" ? e.keyCode : e.which;
     const charStr = String.fromCharCode(charCode);
     if (!charStr.match(/^[0-9]+$/)) e.preventDefault();

--- a/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
+++ b/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
@@ -156,7 +156,7 @@ function CodeField({ num, value, disabled = false, fixed = false, autoFocus = un
     }
   }
 
-  function handleCodeFieldInput(e: React.KeyboardEvent<HTMLFormElement>) {
+  function handleCodeFieldKeyPress(e: React.KeyboardEvent<HTMLFormElement>) {
     if (!isDigit(e.key)) e.preventDefault();
   }
 
@@ -173,7 +173,7 @@ function CodeField({ num, value, disabled = false, fixed = false, autoFocus = un
       autoFocus={autoFocus}
       onKeyUp={handleKeyUp}
       onFocus={(event: FocusEvent<HTMLInputElement>) => event.target.select()}
-      onKeyPress={handleCodeFieldInput}
+      onKeyPress={handleCodeFieldKeyPress}
     />
   );
 }

--- a/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
+++ b/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
@@ -49,15 +49,10 @@ export function ResponseCodeForm(props: ResponseCodeFormProps): JSX.Element {
 //type FixedFormRenderProps = Omit<FormRenderProps<ResponseCodeValues>, "handleSubmit">;
 
 function ShortCodeForm(props: FormRenderProps<ResponseCodeValues> & ResponseCodeFormProps) {
-  let emptyValues = false;
-
   // the code is formatted as SK123-456, ignore positions S, K and -
   const positions = [2, 3, 4, 6, 7, 8];
-  positions.forEach((pos) => {
-    if (!props.values.v[pos]) {
-      return (emptyValues = true);
-    }
-    return (emptyValues = false);
+  const validInputs = positions.filter((pos) => {
+    return props.values.v[pos] == undefined;
   });
 
   return (
@@ -100,7 +95,9 @@ function ShortCodeForm(props: FormRenderProps<ResponseCodeValues> & ResponseCode
               onClick={props.handleLogin}
               id="response-code-submit-button"
               className={"settings-button"}
-              disabled={props.submitDisabled || props.submitting || props.invalid || props.pristine || emptyValues}
+              disabled={
+                validInputs.length > 0 || props.submitDisabled || props.submitting || props.invalid || props.pristine
+              }
             >
               <FormattedMessage defaultMessage="Log in" description="Login OtherDevice" />
             </ButtonPrimary>
@@ -129,8 +126,7 @@ function CodeField({ num, value, disabled = false, fixed = false, autoFocus = un
     switch (pressedKey) {
       case "Backspace":
       case "Delete": {
-        if (inputs[index].value) {
-        } else {
+        if (inputs[index - 1] !== undefined) {
           inputs[index - 1].focus();
         }
         break;

--- a/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
+++ b/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
@@ -79,10 +79,12 @@ function ShortCodeForm(props: FormRenderProps<ResponseCodeValues> & ResponseCode
           .fill("")
           .map((_, index) => (
             <CodeField
+              key={index}
               num={index}
               value=""
               disabled={index === 0 || index === 1 || index === 5 ? true : false}
               autoFocus={index === 2 ? true : false}
+              onFocus={(e: any) => e.target.select()}
             />
           ))}
       </div>
@@ -128,34 +130,75 @@ interface CodeFieldProps {
   disabled?: boolean;
   fixed?: boolean;
   autoFocus?: boolean;
+  onFocus?: any;
 }
 
 // helper-function to make for tidy code with one line per input field below
-function CodeField({ num, value, disabled = false, fixed = false, autoFocus = undefined }: CodeFieldProps) {
+function CodeField({ num, value, onFocus, disabled = false, fixed = false, autoFocus = undefined }: CodeFieldProps) {
   // TODO: Handle backspace, moving to the preceding field *after* clearing the contents of this one
   // TODO: Add final-form validation to the form
   function handleKeyUp(event: React.KeyboardEvent<HTMLFormElement>) {
-    console.log("Key up: ", event.key.toLowerCase());
-    if (event.key.toLowerCase() === "enter") {
-      event.preventDefault();
-      //dispatch(submit("usernamePwForm"));
-    } else if (isDigit(event.key.toLowerCase())) {
-      // focus the next input field
-      const form = event.currentTarget.form;
-      // disabled inputs are placeholders, filter them out
-      const inputs = [...form].filter((input: { disabled?: boolean }) => !input.disabled);
-      const index = inputs.indexOf(event.currentTarget);
-      if (index < 0) {
-        // bail of the current input could not be found
-        return undefined;
+    const pressedKey = event.key;
+    const form = event.currentTarget.form;
+    const inputs = [...form].filter((input: { disabled?: boolean }) => !input.disabled);
+    const index = inputs.indexOf(event.currentTarget);
+    switch (pressedKey) {
+      case "Backspace":
+      case "Delete": {
+        event.preventDefault();
+        if (inputs[index].value) {
+        } else {
+          inputs[index - 1].focus();
+          // focusPrevInput();
+        }
+        break;
       }
-      const lastIndex = inputs.length - 1;
-      console.log(`Current index ${index} of ${lastIndex}`);
-      if (index > -1 && index < inputs.length - 1) {
-        console.log(`Advancing focus to index ${index + 1} of ${lastIndex}`);
-        inputs[index + 1].focus();
+      case "ArrowLeft": {
+        event.preventDefault();
+        if (inputs[index - 1] !== undefined) {
+          inputs[index - 1].focus();
+        }
+
+        // focusPrevInput();
+        break;
+      }
+      case "ArrowRight": {
+        event.preventDefault();
+        if (inputs[index + 1] !== undefined) {
+          inputs[index + 1].focus();
+        }
+        // focusNextInput();
+
+        break;
+      }
+      default: {
+        if (pressedKey.match(/(\w|\s)/g)) {
+          event.preventDefault();
+        }
       }
     }
+
+    // console.log("Key up: ", event.key.toLowerCase());
+    // if (event.key.toLowerCase() === "enter") {
+    //   event.preventDefault();
+    //   //dispatch(submit("usernamePwForm"));
+    // } else if (isDigit(event.key.toLowerCase())) {
+    //   // focus the next input field
+    //   const form = event.currentTarget.form;
+    //   // disabled inputs are placeholders, filter them out
+    //   const inputs = [...form].filter((input: { disabled?: boolean }) => !input.disabled);
+    //   const index = inputs.indexOf(event.currentTarget);
+    //   if (index < 0) {
+    //     // bail of the current input could not be found
+    //     return undefined;
+    //   }
+    //   const lastIndex = inputs.length - 1;
+    //   console.log(`Current index ${index} of ${lastIndex}`);
+    //   if (index > -1 && index < inputs.length - 1) {
+    //     console.log(`Advancing focus to index ${index + 1} of ${lastIndex}`);
+    //     inputs[index + 1].focus();
+    //   }
+    // }
   }
 
   return (
@@ -170,6 +213,7 @@ function CodeField({ num, value, disabled = false, fixed = false, autoFocus = un
       className={fixed === true ? "fixed" : null}
       autoFocus={autoFocus}
       onKeyUp={handleKeyUp}
+      onFocus={onFocus}
     />
   );
 }

--- a/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
+++ b/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
@@ -1,6 +1,6 @@
 import ButtonPrimary from "login/components/Buttons/ButtonPrimary";
 import ButtonSecondary from "login/components/Buttons/ButtonSecondary";
-import React from "react";
+import React, { FocusEvent } from "react";
 import { Field as FinalField, Form as FinalForm, FormRenderProps } from "react-final-form";
 import { FORM_ERROR } from "final-form";
 import { FormattedMessage } from "react-intl";
@@ -84,7 +84,6 @@ function ShortCodeForm(props: FormRenderProps<ResponseCodeValues> & ResponseCode
               value=""
               disabled={index === 0 || index === 1 || index === 5 ? true : false}
               autoFocus={index === 2 ? true : false}
-              onFocus={(e: any) => e.target.select()}
             />
           ))}
       </div>
@@ -130,12 +129,10 @@ interface CodeFieldProps {
   disabled?: boolean;
   fixed?: boolean;
   autoFocus?: boolean;
-  onFocus?: any;
-  onChange?: any;
 }
 
 // helper-function to make for tidy code with one line per input field below
-function CodeField({ num, value, onFocus, disabled = false, fixed = false, autoFocus = undefined }: CodeFieldProps) {
+function CodeField({ num, value, disabled = false, fixed = false, autoFocus = undefined }: CodeFieldProps) {
   function handleKeyUp(event: React.KeyboardEvent<HTMLFormElement>) {
     const pressedKey = event.key;
     const form = event.currentTarget.form;
@@ -183,7 +180,7 @@ function CodeField({ num, value, onFocus, disabled = false, fixed = false, autoF
       className={fixed === true ? "fixed" : null}
       autoFocus={autoFocus}
       onKeyUp={handleKeyUp}
-      onFocus={onFocus}
+      onFocus={(event: FocusEvent<HTMLInputElement>) => event.target.select()}
     />
   );
 }

--- a/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
+++ b/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
@@ -160,12 +160,21 @@ function CodeField({ num, value, disabled = false, fixed = false, autoFocus = un
         break;
       }
       default: {
-        if (index > -1 && index < inputs.length - 1) {
-          inputs[index + 1].focus();
+        if (isDigit(pressedKey)) {
+          if (index > -1 && index < inputs.length - 1) {
+            inputs[index + 1].focus();
+          }
         }
         break;
       }
     }
+  }
+
+  function onlyAllowedNumericalInput(e: React.KeyboardEvent<HTMLFormElement>) {
+    e = e || window.event;
+    const charCode = typeof e.which == "undefined" ? e.keyCode : e.which;
+    const charStr = String.fromCharCode(charCode);
+    if (!charStr.match(/^[0-9]+$/)) e.preventDefault();
   }
 
   return (
@@ -181,6 +190,7 @@ function CodeField({ num, value, disabled = false, fixed = false, autoFocus = un
       autoFocus={autoFocus}
       onKeyUp={handleKeyUp}
       onFocus={(event: FocusEvent<HTMLInputElement>) => event.target.select()}
+      onKeyPress={onlyAllowedNumericalInput}
     />
   );
 }

--- a/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
+++ b/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
@@ -147,7 +147,7 @@ function CodeField({ num, value, disabled = false, fixed = false, autoFocus = un
       }
       default: {
         if (isDigit(pressedKey)) {
-          if (index > -1 && index < inputs.length - 1) {
+          if (inputs[index + 1] !== undefined) {
             inputs[index + 1].focus();
           }
         }

--- a/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
+++ b/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
@@ -2,7 +2,6 @@ import ButtonPrimary from "login/components/Buttons/ButtonPrimary";
 import ButtonSecondary from "login/components/Buttons/ButtonSecondary";
 import React, { FocusEvent } from "react";
 import { Field as FinalField, Form as FinalForm, FormRenderProps } from "react-final-form";
-import { FORM_ERROR } from "final-form";
 import { FormattedMessage } from "react-intl";
 
 interface ResponseCodeFormProps {
@@ -41,37 +40,26 @@ export function ResponseCodeForm(props: ResponseCodeFormProps): JSX.Element {
               />
             );
           }}
-          validate={validate_code}
         />
       </div>
     </React.Fragment>
   );
 }
 
-function validate_code(values: ResponseCodeValues) {
-  const err: { [key: string]: string } = {};
+//type FixedFormRenderProps = Omit<FormRenderProps<ResponseCodeValues>, "handleSubmit">;
+
+function ShortCodeForm(props: FormRenderProps<ResponseCodeValues> & ResponseCodeFormProps) {
+  let emptyValues = false;
 
   // the code is formatted as SK123-456, ignore positions S, K and -
   const positions = [2, 3, 4, 6, 7, 8];
   positions.forEach((pos) => {
-    if (!values.v[pos] || !isDigit(values.v[pos])) {
-      // Record an (invisible) failure as long as one of the inputs doesn't contain a valid digit, to keep
-      // the submit button disabled until all fields hold a valid digit.
-      const name = `v[${pos}]`;
-      err[name] = "Not a digit";
+    if (!props.values.v[pos]) {
+      return (emptyValues = true);
     }
-    if (values.v[pos] && values.v[pos].length && !isDigit(values.v[pos])) {
-      // Set the form-wide error too. This is what is currently displayed, so only show error when there actually is
-      // a non-digit there, not for empty values.
-      err[FORM_ERROR] = "Not a digit";
-    }
+    return (emptyValues = false);
   });
-  return err;
-}
 
-//type FixedFormRenderProps = Omit<FormRenderProps<ResponseCodeValues>, "handleSubmit">;
-
-function ShortCodeForm(props: FormRenderProps<ResponseCodeValues> & ResponseCodeFormProps) {
   return (
     <form onSubmit={props.handleSubmit} className="response-code-form">
       <div className="response-code-inputs">
@@ -112,7 +100,7 @@ function ShortCodeForm(props: FormRenderProps<ResponseCodeValues> & ResponseCode
               onClick={props.handleLogin}
               id="response-code-submit-button"
               className={"settings-button"}
-              disabled={props.submitDisabled || props.submitting || props.invalid || props.pristine}
+              disabled={props.submitDisabled || props.submitting || props.invalid || props.pristine || emptyValues}
             >
               <FormattedMessage defaultMessage="Log in" description="Login OtherDevice" />
             </ButtonPrimary>

--- a/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
+++ b/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
@@ -125,21 +125,21 @@ function CodeField({ num, value, disabled = false, fixed = false, autoFocus = un
     const form = event.currentTarget.form;
     const inputs = [...form].filter((input: { disabled?: boolean }) => !input.disabled);
     const index = inputs.indexOf(event.currentTarget);
-    switch (pressedKey) {
-      case "Backspace":
-      case "Delete": {
+    switch (pressedKey.toLowerCase()) {
+      case "backspace":
+      case "delete": {
         if (inputs[index - 1] !== undefined) {
           inputs[index - 1].focus();
         }
         break;
       }
-      case "ArrowLeft": {
+      case "arrowleft": {
         if (inputs[index - 1] !== undefined) {
           inputs[index - 1].focus();
         }
         break;
       }
-      case "ArrowRight": {
+      case "arrowright": {
         if (inputs[index + 1] !== undefined) {
           inputs[index + 1].focus();
         }

--- a/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
+++ b/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
@@ -51,7 +51,7 @@ export function ResponseCodeForm(props: ResponseCodeFormProps): JSX.Element {
 function ShortCodeForm(props: FormRenderProps<ResponseCodeValues> & ResponseCodeFormProps) {
   // the code is formatted as SK123-456, ignore positions S, K and -
   const positions = [2, 3, 4, 6, 7, 8];
-  const validInputs = positions.filter((pos) => {
+  const invalidInputs = positions.filter((pos) => {
     return props.values.v[pos] == undefined;
   });
 
@@ -96,7 +96,7 @@ function ShortCodeForm(props: FormRenderProps<ResponseCodeValues> & ResponseCode
               id="response-code-submit-button"
               className={"settings-button"}
               disabled={
-                validInputs.length > 0 || props.submitDisabled || props.submitting || props.invalid || props.pristine
+                invalidInputs.length > 0 || props.submitDisabled || props.submitting || props.invalid || props.pristine
               }
             >
               <FormattedMessage defaultMessage="Log in" description="Login OtherDevice" />


### PR DESCRIPTION
#### Description:

add keyboard handling for response code (enable to control with arrow left, right and backspace)
only possible to filled with number
validation input (error message) removed since the input don't allow any other characters


#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
