### PR TITLE
add a button to abort logins, calling the new /abort login endpoint

### DIFF
--- a/src/apis/eduidLogin.ts
+++ b/src/apis/eduidLogin.ts
@@ -7,6 +7,35 @@ import { LoginAppDispatch, LoginRootState } from "login/app_init/initStore";
 import { KeyValues, makeRequest, RequestThunkAPI } from "./common";
 
 /*********************************************************************************************************************/
+export interface LoginAbortRequest {
+  ref: string;
+}
+
+export interface LoginAbortResponse {
+  finished: boolean;
+}
+
+
+/**
+ * @public
+ * @function fetchAbort
+ * @desc     Request the backend to abort the current login request.
+ */
+export const fetchAbort = createAsyncThunk<
+  LoginAbortResponse, // return type
+  LoginAbortRequest, // args type
+  { dispatch: LoginAppDispatch; state: LoginRootState }
+>("login/api/fetchAbort", async (args, thunkAPI) => {
+  const body: KeyValues = {
+    ref: args.ref,
+  };
+
+  return makeLoginRequest<LoginAbortResponse>(thunkAPI, "abort", body)
+    .then((response) => response.payload)
+    .catch((err) => thunkAPI.rejectWithValue(err));
+});
+
+/*********************************************************************************************************************/
 
 export type LoginUseOtherDevice1Request = UseOtherDevice1Fetch | UseOtherDevice1Abort | UseOtherDevice1SubmitCode;
 export type LoginUseOtherDevice1Response = UseOtherDevice1ResponseWithQR | UseOtherDevice1ResponseWithoutQR;

--- a/src/login/components/LoginApp/Login/LoginAbortButton.tsx
+++ b/src/login/components/LoginApp/Login/LoginAbortButton.tsx
@@ -1,0 +1,22 @@
+import { useAppDispatch, useAppSelector } from "login/app_init/hooks";
+import React from "react";
+import { FormattedMessage } from "react-intl";
+import { fetchAbort } from "apis/eduidLogin";
+import EduIDButton from "components/EduIDButton";
+
+export function LoginAbortButton(): JSX.Element {
+  const loginRef = useAppSelector((state) => state.login.ref);
+  const dispatch = useAppDispatch();
+
+  async function handleOnClick() {
+    if (loginRef) {
+      dispatch(fetchAbort({ ref: loginRef }));
+    }
+  }
+
+  return (
+    <EduIDButton buttonstyle="secondary" type="submit" onClick={handleOnClick} id="login-abort-button">
+      <FormattedMessage defaultMessage="Abort" description="Login button" />
+    </EduIDButton>
+  );
+}

--- a/src/login/components/LoginApp/Login/UsernamePw.tsx
+++ b/src/login/components/LoginApp/Login/UsernamePw.tsx
@@ -20,6 +20,7 @@ import TextInput from "components/EduIDTextInput";
 import EduIDButton from "components/EduIDButton";
 import { forgetThisDevice } from "./NewDevice";
 import { LoginAtServiceInfo } from "./LoginAtServiceInfo";
+import { LoginAbortButton } from "./LoginAbortButton";
 
 interface UsernamePwFormData {
   email?: string;
@@ -56,6 +57,7 @@ export default function UsernamePw() {
 
               <div className="flex-between">
                 <div className="button-pair">
+                  <LoginAbortButton />
                   <UsernamePwSubmitButton {...formProps} />
                   <UsernamePwAnotherDeviceButton />
                 </div>

--- a/src/login/redux/slices/loginSlice.ts
+++ b/src/login/redux/slices/loginSlice.ts
@@ -1,6 +1,7 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import {
   fetchNewDevice,
+  fetchAbort,
   fetchNext,
   fetchUseOtherDevice1,
   fetchUseOtherDevice2,
@@ -149,6 +150,12 @@ export const loginSlice = createSlice({
       })
       .addCase(fetchUseOtherDevice2.rejected, (state) => {
         state.other_device2 = undefined;
+      })
+      .addCase(fetchAbort.fulfilled, (state, action) => {
+        if (action.payload.finished) {
+          // Trigger fetching of /next on successful abort
+          state.next_page = undefined;
+        }
       })
       .addCase(fetchNext.pending, (state) => {
         state.fetching_next = true;


### PR DESCRIPTION
#### Description:

Add a button to abort logins, returning the user to the SP. This is useful for example when choosing to change password, getting sent to the IdP and then changing one's mind.

![image](https://user-images.githubusercontent.com/166095/163989583-87c7dfa4-4886-4e58-9884-7627c9c7a6ca.png)


#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
