### PR TITLE
Adjust error msg styling

### DIFF
--- a/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
+++ b/src/login/components/LoginApp/Login/ResponseCodeForm.tsx
@@ -79,11 +79,7 @@ function ShortCodeForm(props: FormRenderProps<ResponseCodeValues> & ResponseCode
         <CodeField num={7} disabled={props.inputsDisabled} />
         <CodeField num={8} disabled={props.inputsDisabled} />
       </div>
-      {props.error && (
-        <div role="alert" aria-invalid="true" tabIndex={0} className="input-validate-error">
-          {props.error}
-        </div>
-      )}
+      {props.error && <p>{props.error}</p>}
 
       {props.handleAbort || props.handleLogin ? (
         <div className={`buttons ${props.extra_className}`}>

--- a/src/login/components/LoginApp/Login/UseOtherDevice1.tsx
+++ b/src/login/components/LoginApp/Login/UseOtherDevice1.tsx
@@ -72,9 +72,7 @@ function RenderFatalError(props: { error: JSX.Element; handleNewQRCodeOnClick?: 
 
   return (
     <React.Fragment>
-      <div role="alert" aria-invalid="true" tabIndex={0} className="input-validate-error">
-        {props.error}
-      </div>
+      <p>{props.error}</p>
       <div className="buttons">
         <EduIDButton
           buttonstyle="secondary"

--- a/src/login/styles/_inputs.scss
+++ b/src/login/styles/_inputs.scss
@@ -130,8 +130,8 @@ input:focus {
 }
 
 .input-validate-error {
-  font-size: 1.25rem;
-  color: $black;
+  font-size: 1rem;
+  color: $dark-orange;
 }
 
 // login username-pw / reset-password set-new-password


### PR DESCRIPTION
#### Description:

changed input error message color to dark orange and reduce font size 
changed html tag <div> to <p> for login with other device error messages

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
