### PR TITLE
Frontend buttons wrapper

### DIFF
--- a/src/components/ChangePasswordForm.tsx
+++ b/src/components/ChangePasswordForm.tsx
@@ -79,7 +79,10 @@ function ChangePasswordForm(props: ChangePasswordFormProps) {
                 </EduIDButton>
               </ButtonGroup>
             </div>
-            <div id="chpass-form" className="tabpane flex-buttons">
+            <div id="chpass-form" className="tabpane buttons">
+              <EduIDButton buttonstyle="secondary" onClick={handleCancel}>
+                {translate("cm.cancel")}
+              </EduIDButton>
               <EduIDButton
                 type="submit"
                 id="chpass-button"
@@ -88,9 +91,6 @@ function ChangePasswordForm(props: ChangePasswordFormProps) {
                 onClick={formProps.handleSubmit}
               >
                 {translate("chpass.button_save_password")}
-              </EduIDButton>
-              <EduIDButton buttonstyle="secondary" onClick={handleCancel}>
-                {translate("cm.cancel")}
               </EduIDButton>
             </div>
           </React.Fragment>

--- a/src/components/Emails.tsx
+++ b/src/components/Emails.tsx
@@ -152,7 +152,7 @@ function Emails() {
                     validate={validateEmailsInForm}
                     autoFocus
                   />
-                  <div className="flex-buttons">
+                  <div className="buttons">
                     <EduIDButton id="cancel-adding-email" buttonstyle="secondary" onClick={handleCancel}>
                       <FormattedMessage defaultMessage="Cancel" description="Emails button cancel" />
                     </EduIDButton>

--- a/src/components/Orcid.js
+++ b/src/components/Orcid.js
@@ -49,13 +49,18 @@ class Orcid extends Component {
     } else {
       orcidData = (
         <Fragment>
-          <EduIDButton buttonstyle="primary" id="connect-orcid-button" onClick={this.props.handleOrcidConnect}>
-            <div className="orcid-logo-container">
+          <div className="buttons">
+            <EduIDButton
+              buttonstyle="primary"
+              id="connect-orcid-button"
+              className="btn-logo"
+              onClick={this.props.handleOrcidConnect}
+            >
               <img className="orcid-logo" src={orcidIcon} />
-            </div>
-            {this.props.translate("orc.button_connect")}
-          </EduIDButton>
-          <p className="orcid-btn-help">{this.props.translate("orc.long_description")}</p>
+              {this.props.translate("orc.button_connect")}
+            </EduIDButton>
+          </div>
+          <p className="help-text">{this.props.translate("orc.long_description")}</p>
         </Fragment>
       );
     }

--- a/src/components/Phones.tsx
+++ b/src/components/Phones.tsx
@@ -172,7 +172,7 @@ function Phones() {
                       />
                     }
                   />
-                  <div className="flex-buttons">
+                  <div className="buttons">
                     <EduIDButton id="cancel-adding-mobile" buttonstyle="secondary" onClick={handleCancel}>
                       <FormattedMessage defaultMessage="Cancel" description="button cancel" />
                     </EduIDButton>

--- a/src/login/components/LoginApp/Login/UsernamePw.tsx
+++ b/src/login/components/LoginApp/Login/UsernamePw.tsx
@@ -60,7 +60,7 @@ export default function UsernamePw() {
               </fieldset>
 
               <div className="flex-between">
-                <div className="button-pair">
+                <div className="buttons">
                   <LoginAbortButton />
                   <UsernamePwSubmitButton {...formProps} />
                   <UsernamePwAnotherDeviceButton />
@@ -126,11 +126,11 @@ function UsernameInputPart(): JSX.Element {
 function RenderRegisterLink(): JSX.Element {
   const toSignup = useAppSelector((state) => state.config.signup_url);
   return (
-    <p className="secondary-link text-small">
+    <div className="secondary-link text-small">
       <FormattedMessage defaultMessage="Don't have eduID? " description="Login front page" />
       &nbsp;&nbsp;
       <Link href={toSignup} text={<FormattedMessage defaultMessage=" Register" description="Login front page" />} />
-    </p>
+    </div>
   );
 }
 

--- a/src/login/components/PersonalData/PersonalDataForm.tsx
+++ b/src/login/components/PersonalData/PersonalDataForm.tsx
@@ -94,13 +94,15 @@ interface RenderSavePersonalDataButtonProps {
 const RenderSavePersonalDataButton = ({ invalid, pristine, submitting }: RenderSavePersonalDataButtonProps) => {
   const loading = useDashboardAppSelector((state) => state.config.loading_data);
   return (
-    <EduIDButton
-      id="personal-data-button"
-      buttonstyle="primary"
-      disabled={loading || pristine || invalid || submitting}
-    >
-      {translate("button_save")}
-    </EduIDButton>
+    <div className="buttons">
+      <EduIDButton
+        id="personal-data-button"
+        buttonstyle="primary"
+        disabled={loading || pristine || invalid || submitting}
+      >
+        {translate("button_save")}
+      </EduIDButton>
+    </div>
   );
 };
 

--- a/src/login/styles/_AccountLinking.scss
+++ b/src/login/styles/_AccountLinking.scss
@@ -1,14 +1,5 @@
-// #orcid {
-//   margin-bottom: 30px;
-// }
-
-// @import "../variables.scss";
-
 .orcid-logo-container {
   display: inline-flex;
-
-  // align-items: center;
-  // padding-left: 0.25em;
   padding-right: 0.35em;
   fill: currentcolor;
 
@@ -21,12 +12,11 @@
     min-width: 22px;
   }
 
+  //remove or merge with above?
   .orcid-logo {
     display: inline-flex;
-    align-self: center;
     height: 22px;
     width: 22px;
-    top: 0.3em;
     position: relative;
   }
 
@@ -37,21 +27,8 @@
   }
 }
 
-.orcid-logo-container label {
-  margin: 0 0 0 10px;
-}
-
-// streamline this styling with the other help text across the website (.help-text)
-.orcid-btn-help {
-  margin: 0;
-  line-height: 1.2;
-  color: $gray;
-  font-size: 14px;
-  margin-top: 15px;
-}
-
-// remove this when all button styles are refactored
-#connect-orcid-button {
-  line-height: 2;
-  margin-bottom: 0;
+button .orcid-logo {
+  height: 22px;
+  width: 22px;
+  margin-right: 0.5rem;
 }

--- a/src/login/styles/_Login.scss
+++ b/src/login/styles/_Login.scss
@@ -26,10 +26,6 @@
       margin-bottom: $margin;
     }
 
-    button {
-      margin: 0.25rem 0 #{1 * $margin};
-    }
-
     .welcome-back-container {
       margin: 0 0 1rem;
       display: flex;
@@ -63,10 +59,6 @@ a {
   &:hover {
     text-decoration: underline;
   }
-
-  //  @media (max-width: $bp-sm) {
-  //    margin: 1rem 0;
-  //  }
 }
 
 a .disabled {
@@ -78,7 +70,7 @@ a .disabled {
   }
 }
 
-// terms of use
+// TODO align with modal dl.terms
 .tou {
   .tou-text {
     margin-top: $margin;
@@ -239,33 +231,12 @@ a .disabled {
   }
 }
 
-// TODO: make .button-pair and .buttons same
 .username-pw {
-  .button-pair {
-    flex-direction: column;
-    justify-content: flex-start;
-    align-items: center;
-    margin: 0.5rem 0;
-    width: 100%;
-
-    button {
-      svg {
-        transform: rotate(0);
-        margin-right: 8px;
-      }
-    }
-
-    @media (min-width: $bp-xs) {
-      flex-direction: row;
-      width: auto;
-
-      button {
-        // min-width: 100px;
-
-        &:nth-child(n + 2) {
-          margin-left: 1rem;
-        }
-      }
+  /* TODO find where this svg rotation is required instead */
+  button {
+    svg {
+      transform: rotate(0);
+      margin-right: 8px;
     }
   }
 

--- a/src/login/styles/_buttons.scss
+++ b/src/login/styles/_buttons.scss
@@ -139,6 +139,12 @@ button.btn-link {
   }
 }
 
+/* e.g. orcid button with logo left of button text */
+button.btn-logo {
+  display: flex;
+  align-items: center;
+}
+
 .flex-buttons {
   display: flex;
   column-gap: 1rem;

--- a/src/login/styles/_buttons.scss
+++ b/src/login/styles/_buttons.scss
@@ -159,17 +159,19 @@ button.btn-logo {
   }
 }
 
+/* Wraps all buttons for responsive behaviour independend on number */
 .buttons {
   display: flex;
   column-gap: 1rem;
-  padding-top: 1rem;
+  padding: 0.5rem 0;
+  width: 100%;
 
   button {
     min-width: 100px;
   }
 
-  button[type="submit"] {
-    order: 2;
+  @media (min-width: $bp-xs) {
+    width: auto;
   }
 
   @media (max-width: $bp-md) {
@@ -179,12 +181,8 @@ button.btn-logo {
   @media (max-width: $bp-xs) {
     flex-direction: column-reverse;
 
-    button:nth-child(n + 1) {
-      margin-bottom: 0.5rem;
-    }
-
-    button:nth-child(n + 2) {
-      margin-bottom: 1.5rem;
+    button {
+      margin: 0.5rem 0;
     }
   }
 }

--- a/src/login/styles/_buttons.scss
+++ b/src/login/styles/_buttons.scss
@@ -145,6 +145,7 @@ button.btn-logo {
   align-items: center;
 }
 
+/* TODO possibly replace with .buttons */
 .flex-buttons {
   display: flex;
   column-gap: 1rem;


### PR DESCRIPTION
#### Description:

Added .buttons wrapper where missing, for site-aligned resposive behaviour
Reduced similar wrapper classes
Refactored orcid css and login css
Swapped order of ch pw buttons as to rest of site

(There might be some slight differences in spacing around buttons compared to before but the gain is common code)

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
