### PR TITLE
refactor custom input fields

### DIFF
--- a/src/login/app_utils/validation/validateEmail.ts
+++ b/src/login/app_utils/validation/validateEmail.ts
@@ -29,7 +29,8 @@ export const validate = validateEmailInForm;
 export function validateEmailField(value?: string): string | undefined {
   if (!value) {
     return "required";
-  } else if (!emailPattern.test(value)) {
+  }
+  if (!emailPattern.test(value)) {
     return "email.invalid_email";
   }
 }

--- a/src/login/components/GroupManagement/EmailForm.js
+++ b/src/login/components/GroupManagement/EmailForm.js
@@ -16,7 +16,7 @@ const RenderSubmitButton = ({ invalid, translate }) => (
 let EmailForm = (props, { submitButton, onSubmit }) => {
   return (
     <Form id="emailsview-form" role="form" onSubmit={onSubmit}>
-      <EmailInput {...props} />
+      <EmailInput name="email" {...props} />
       {submitButton && <RenderSubmitButton {...props} />}
     </Form>
   );

--- a/src/login/components/GroupManagement/Invites/CreateInviteForm.js
+++ b/src/login/components/GroupManagement/Invites/CreateInviteForm.js
@@ -23,7 +23,7 @@ let CreateInviteForm = (props) => {
     <Fragment>
       <Form id={"create-invite-form"} role="form" onSubmit={handleSubmit}>
         <FormSection name={"inviteEmail"}>
-          <EmailInput {...props} submitButton={false} required={true} />
+          <EmailInput name="email" {...props} submitButton={false} required={true} />
         </FormSection>
         <FormSection name={"inviteRoles"}>
           <InviteRoleCheckboxes {...props} helpBlock={"select one or more"} />

--- a/src/login/components/Inputs/CustomInput.tsx
+++ b/src/login/components/Inputs/CustomInput.tsx
@@ -7,44 +7,21 @@ export default function CustomInput(props: FieldRenderProps<string>): JSX.Elemen
   // the InputWrapper renders it's children plus a label, helpBlock and any error message from the field validation
   return (
     <InputWrapper {...props}>
-      <InputElement {...props} valid={props.meta.valid} invalid={props.meta.invalid} />
+      <InputElement {...props} />
     </InputWrapper>
   );
 }
 
 const InputElement = (props: FieldRenderProps<string>): JSX.Element => {
-  const { input, selectOptions, valid } = props;
-  if (selectOptions) {
-    const renderSelect = selectOptions.map((option: string[], index: number) => {
-      return (
-        <Fragment key={index}>
-          <label key={option[0]} htmlFor={option[1]}>
-            <input
-              className={props.meta.error && props.meta.visited ? "radio-input error" : "radio-input"}
-              key={option[0]}
-              id={option[1]}
-              type="radio"
-              {...input}
-              value={option[0]}
-              checked={option[0] === input.value}
-            />
-            <span key={index}>{option[1]}</span>
-          </label>
-        </Fragment>
-      );
-    });
-
-    return <div className="radio-input-container">{renderSelect}</div>;
-  }
   return (
     <Input
-      id={input.name}
+      {...props.input}
+      id={props.input.name}
       type={props.type}
       placeholder={props.placeholder}
-      valid={input.value !== "" && valid}
-      aria-required={input.required}
+      aria-required={props.input.required}
+      valid={props.meta.valid}
       invalid={props.invalid}
-      {...input}
       autoFocus={props.autoFocus}
     />
   );

--- a/src/login/components/Inputs/CustomInput.tsx
+++ b/src/login/components/Inputs/CustomInput.tsx
@@ -1,31 +1,18 @@
-import React, { Fragment, useState } from "react";
+import React, { Fragment } from "react";
 import { FieldRenderProps } from "react-final-form";
-import { FormattedMessage } from "react-intl";
-import { Input, InputProps } from "reactstrap";
-import InputWrapper from "./InputWrapper";
-
-interface CustomInputProps extends FieldRenderProps<string> {
-  label?: string;
-  helpBlock?: React.ReactNode;
-  disabled?: boolean;
-  autocomplete?: string;
-}
+import { Input } from "reactstrap";
+import { InputWrapper } from "./InputWrapper";
 
 export default function CustomInput(props: FieldRenderProps<string>): JSX.Element {
-  const { meta, input } = props;
-
+  // the InputWrapper renders it's children plus a label, helpBlock and any error message from the field validation
   return (
     <InputWrapper {...props}>
-      {input.name === "current-password" ? (
-        <PasswordInputElement {...props} name={input.name} id={input.name} valid={meta.valid} invalid={meta.invalid} />
-      ) : (
-        <InputElement {...props} valid={meta.valid} invalid={meta.invalid} />
-      )}
+      <InputElement {...props} valid={props.meta.valid} invalid={props.meta.invalid} />
     </InputWrapper>
   );
 }
 
-const InputElement = (props: CustomInputProps): JSX.Element => {
+const InputElement = (props: FieldRenderProps<string>): JSX.Element => {
   const { input, selectOptions, valid } = props;
   if (selectOptions) {
     const renderSelect = selectOptions.map((option: string[], index: number) => {
@@ -62,47 +49,3 @@ const InputElement = (props: CustomInputProps): JSX.Element => {
     />
   );
 };
-
-/**
- * Render a Password input component, with a checkmark if something has been entered and a Show/Hide button
- * to toggle between text-input and password-input.
- * @param props
- * @returns
- */
-function PasswordInputElement(props: InputProps): JSX.Element {
-  const { input } = props;
-  const [showPassword, setShowPassword] = useState(false);
-
-  function toggleShowPassword() {
-    setShowPassword(!showPassword);
-  }
-
-  return (
-    <div className="password-input">
-      <Input
-        {...input}
-        type={showPassword ? "text" : "password"}
-        placeholder={props.placeholder}
-        valid={props.valid}
-        invalid={props.invalid}
-        autoComplete={props.autoComplete}
-        aria-label={props.ariaLabel}
-        aria-required={props.required}
-        id={props.id}
-      />
-
-      <button
-        type="button"
-        aria-label={showPassword ? "hide password" : "show password"}
-        className="show-hide-button"
-        onClick={toggleShowPassword}
-      >
-        {showPassword ? (
-          <FormattedMessage defaultMessage="HIDE" description="nin/password button label" />
-        ) : (
-          <FormattedMessage defaultMessage="SHOW" description="nin/password button label" />
-        )}
-      </button>
-    </div>
-  );
-}

--- a/src/login/components/Inputs/CustomInput.tsx
+++ b/src/login/components/Inputs/CustomInput.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from "react";
+import React from "react";
 import { FieldRenderProps } from "react-final-form";
 import { Input } from "reactstrap";
 import { InputWrapper } from "./InputWrapper";

--- a/src/login/components/Inputs/CustomInput.tsx
+++ b/src/login/components/Inputs/CustomInput.tsx
@@ -1,8 +1,8 @@
-import { translate } from "login/translation";
 import React, { Fragment, useState } from "react";
 import { FieldRenderProps } from "react-final-form";
 import { FormattedMessage } from "react-intl";
-import { FormGroup, FormText, Input, InputProps, Label } from "reactstrap";
+import { Input, InputProps } from "reactstrap";
+import InputWrapper from "./InputWrapper";
 
 interface CustomInputProps extends FieldRenderProps<string> {
   label?: string;
@@ -15,49 +15,15 @@ export default function CustomInput(props: FieldRenderProps<string>): JSX.Elemen
   const { meta, input } = props;
 
   return (
-    <FormGroup id={`${input.name}-wrapper`}>
-      <RenderLabelAndHelpText {...props} name={input.name} />
+    <InputWrapper {...props}>
       {input.name === "current-password" ? (
         <PasswordInputElement {...props} name={input.name} id={input.name} valid={meta.valid} invalid={meta.invalid} />
       ) : (
         <InputElement {...props} valid={meta.valid} invalid={meta.invalid} />
       )}
-      <RenderErrorMessage {...props} name={input.name} />
-    </FormGroup>
+    </InputWrapper>
   );
 }
-
-const RenderLabelAndHelpText = (props: CustomInputProps): JSX.Element => {
-  const { label, name, helpBlock, required } = props;
-  return (
-    <div className="input-label-help-text-container">
-      {label && (
-        <Label aria-required="true" htmlFor={name}>
-          {label}
-          {required && <span className="label-required">*</span>}
-        </Label>
-      )}
-      {helpBlock && <span className="help-block">{helpBlock}</span>}
-    </div>
-  );
-};
-
-const RenderErrorMessage = (props: CustomInputProps): JSX.Element => {
-  const { meta } = props;
-
-  if (meta.pristine || !meta.error) {
-    return <Fragment />;
-  }
-
-  const errmsg = translate(meta.error) || "";
-  return (
-    <FormText>
-      <span role="alert" aria-invalid="true" tabIndex={0} className="input-validate-error">
-        {errmsg}
-      </span>
-    </FormText>
-  );
-};
 
 const InputElement = (props: CustomInputProps): JSX.Element => {
   const { input, selectOptions, valid } = props;
@@ -103,7 +69,7 @@ const InputElement = (props: CustomInputProps): JSX.Element => {
  * @param props
  * @returns
  */
-export function PasswordInputElement(props: InputProps): JSX.Element {
+function PasswordInputElement(props: InputProps): JSX.Element {
   const { input } = props;
   const [showPassword, setShowPassword] = useState(false);
 

--- a/src/login/components/Inputs/EmailInput.tsx
+++ b/src/login/components/Inputs/EmailInput.tsx
@@ -24,7 +24,7 @@ export default function EmailInput(props: EmailInputProps): JSX.Element {
   });
 
   function validate(value: string, allValues: object, meta?: FieldState<string>) {
-    if (!value && props.autoComplete && !meta?.touched) {
+    if (!value) {
       /* Browsers handle auto-completed fields differently. Current Chrome for example seems to often (but not always)
        * fill in the value on-screen, but not tell Javascript about it so the validator doesn't see that a value has
        * been entered, and might show "required", which will confuse the user. As soon as the user clicks anywhere on
@@ -33,7 +33,7 @@ export default function EmailInput(props: EmailInputProps): JSX.Element {
        *
        * We want to suppress this exact validation error before the user clicks anywhere.
        */
-      return null;
+      return undefined;
     }
 
     return validateEmailField(value);

--- a/src/login/components/Inputs/EmailInput.tsx
+++ b/src/login/components/Inputs/EmailInput.tsx
@@ -1,3 +1,4 @@
+import { FieldState } from "final-form";
 import { validateEmailField } from "login/app_utils/validation/validateEmail";
 import { translate } from "login/translation";
 import React from "react";
@@ -8,7 +9,9 @@ import CustomInput from "./CustomInput";
 interface EmailInputProps {
   required: boolean;
   autoFocus: boolean;
-  name?: string;
+  name: string;
+  autoComplete?: "username";
+  helpBlock?: React.ReactNode; // help text shown above input
 }
 
 export default function EmailInput(props: EmailInputProps): JSX.Element {
@@ -20,19 +23,37 @@ export default function EmailInput(props: EmailInputProps): JSX.Element {
     description: "placeholder text for email input",
   });
 
+  function validate(value: string, allValues: object, meta?: FieldState<string>) {
+    if (!value && props.autoComplete && !meta?.touched) {
+      /* Browsers handle auto-completed fields differently. Current Chrome for example seems to often (but not always)
+       * fill in the value on-screen, but not tell Javascript about it so the validator doesn't see that a value has
+       * been entered, and might show "required", which will confuse the user. As soon as the user clicks anywhere on
+       * the page (including on a seemingly disabled submit-button), the validator will run and the error will be
+       * cleared.
+       *
+       * We want to suppress this exact validation error before the user clicks anywhere.
+       */
+      return null;
+    }
+
+    return validateEmailField(value);
+  }
+
   return (
     <FinalField
       required={props.required}
-      label={translate("profile.email_display_title")}
       component={CustomInput}
       componentClass="input"
       type="email"
-      name={props.name || "email"}
+      name={props.name}
       autoFocus={props.autoFocus}
       ariaLabel={"enter your email address to login"}
       autoComplete="username"
       placeholder={placeholder}
-      validate={validateEmailField}
+      validate={validate}
+      // parameters for InputWrapper
+      helpBlock={props.helpBlock}
+      label={translate("profile.email_display_title")}
     />
   );
 }

--- a/src/login/components/Inputs/InputWrapper.tsx
+++ b/src/login/components/Inputs/InputWrapper.tsx
@@ -41,16 +41,21 @@ function RenderLabelAndHelpText(props: InputWrapperProps): JSX.Element {
 function RenderErrorMessage(props: InputWrapperProps): JSX.Element | null {
   const { meta } = props;
 
-  if (!meta.error) {
+  if (!meta.error && !meta.submitError) {
     // no error, no message
     return null;
   }
 
-  const errorMsg = translate(meta.error) || "";
+  const errorMsg = meta.error ? translate(meta.error) : null;
+  let submitErrorMsg = null;
+  if (meta.submitError && !meta.dirtySinceLastSubmit) {
+    submitErrorMsg = translate(meta.submitError) || null;
+  }
+
   return (
     <FormText>
       <span role="alert" aria-invalid="true" tabIndex={0} className="input-validate-error">
-        {errorMsg}
+        {errorMsg || submitErrorMsg}
       </span>
     </FormText>
   );

--- a/src/login/components/Inputs/InputWrapper.tsx
+++ b/src/login/components/Inputs/InputWrapper.tsx
@@ -3,18 +3,17 @@ import React from "react";
 import { FieldRenderProps } from "react-final-form";
 import { FormGroup, FormText, Label } from "reactstrap";
 
-interface InputWrapperProps extends FieldRenderProps<string> {
+export interface InputWrapperProps extends FieldRenderProps<string> {
   label?: string; // label shown above input
   helpBlock?: React.ReactNode; // help text show above input
-  //   disabled?: boolean;
-  //   autocomplete?: string;
+  autoComplete?: "current-password" | "new-password" | "username";
   children?: React.ReactNode;
 }
 
 /**
  * Render an input with an optional label and help text, and an error message when validation fails.
  */
-export default function InputWrapper(props: InputWrapperProps): JSX.Element {
+export function InputWrapper(props: InputWrapperProps): JSX.Element {
   return (
     <FormGroup id={`${props.input.name}-wrapper`}>
       <RenderLabelAndHelpText {...props} />
@@ -44,11 +43,6 @@ function RenderErrorMessage(props: InputWrapperProps): JSX.Element | null {
 
   if (!meta.error) {
     // no error, no message
-    return null;
-  }
-
-  if (meta.pristine) {
-    // not changed from initial value, don't show an error
     return null;
   }
 

--- a/src/login/components/Inputs/InputWrapper.tsx
+++ b/src/login/components/Inputs/InputWrapper.tsx
@@ -1,0 +1,63 @@
+import { translate } from "login/translation";
+import React from "react";
+import { FieldRenderProps } from "react-final-form";
+import { FormGroup, FormText, Label } from "reactstrap";
+
+interface InputWrapperProps extends FieldRenderProps<string> {
+  label?: string; // label shown above input
+  helpBlock?: React.ReactNode; // help text show above input
+  //   disabled?: boolean;
+  //   autocomplete?: string;
+  children?: React.ReactNode;
+}
+
+/**
+ * Render an input with an optional label and help text, and an error message when validation fails.
+ */
+export default function InputWrapper(props: InputWrapperProps): JSX.Element {
+  return (
+    <FormGroup id={`${props.input.name}-wrapper`}>
+      <RenderLabelAndHelpText {...props} />
+      {props.children}
+      <RenderErrorMessage {...props} />
+    </FormGroup>
+  );
+}
+
+function RenderLabelAndHelpText(props: InputWrapperProps): JSX.Element {
+  const { input, label, helpBlock, required } = props;
+  return (
+    <div className="input-label-help-text-container">
+      {label && (
+        <Label aria-required="true" htmlFor={input.name}>
+          {label}
+          {required && <span className="label-required">*</span>}
+        </Label>
+      )}
+      {helpBlock && <span className="help-block">{helpBlock}</span>}
+    </div>
+  );
+}
+
+function RenderErrorMessage(props: InputWrapperProps): JSX.Element | null {
+  const { meta } = props;
+
+  if (!meta.error) {
+    // no error, no message
+    return null;
+  }
+
+  if (meta.pristine) {
+    // not changed from initial value, don't show an error
+    return null;
+  }
+
+  const errorMsg = translate(meta.error) || "";
+  return (
+    <FormText>
+      <span role="alert" aria-invalid="true" tabIndex={0} className="input-validate-error">
+        {errorMsg}
+      </span>
+    </FormText>
+  );
+}

--- a/src/login/components/Inputs/PasswordInput.tsx
+++ b/src/login/components/Inputs/PasswordInput.tsx
@@ -58,7 +58,7 @@ export function WrappedPasswordInput(props: FieldRenderProps<string>): JSX.Eleme
   // the InputWrapper renders it's children plus a label, helpBlock and any error message from the field validation
   return (
     <InputWrapper {...props}>
-      <PasswordInputElement {...props} name={input.name} id={input.name} valid={meta.valid} invalid={meta.invalid} />
+      <PasswordInputElement {...props} />
     </InputWrapper>
   );
 }
@@ -77,7 +77,13 @@ function PasswordInputElement(props: InputProps): JSX.Element {
 
   return (
     <div className="password-input">
-      <Input {...props.input} type={showPassword ? "text" : "password"} />
+      <Input
+        {...props.input}
+        id={props.input.name}
+        type={showPassword ? "text" : "password"}
+        valid={props.meta.valid}
+        invalid={props.meta.invalid}
+      />
 
       <button
         type="button"

--- a/src/login/components/Inputs/PasswordInput.tsx
+++ b/src/login/components/Inputs/PasswordInput.tsx
@@ -1,9 +1,17 @@
-import React from "react";
-import { Field as FinalField } from "react-final-form";
+import { FieldState } from "final-form";
+import { InputWrapper } from "login/components/Inputs/InputWrapper";
+import React, { useState } from "react";
+import { Field as FinalField, FieldRenderProps } from "react-final-form";
 import { FormattedMessage, useIntl } from "react-intl";
-import CustomInput from "./CustomInput";
+import { Input, InputProps } from "reactstrap";
 
-export default function PasswordInput(props: { name?: string }): JSX.Element {
+interface PasswordInputProps {
+  name: string;
+  autoComplete?: "current-password" | "new-password";
+  helpBlock?: React.ReactNode; // help text shown above input
+}
+
+export default function PasswordInput(props: PasswordInputProps): JSX.Element {
   const intl = useIntl();
   // placeholder can't be an Element, we need to get the actual translated string here
   const placeholder = intl.formatMessage({
@@ -12,19 +20,77 @@ export default function PasswordInput(props: { name?: string }): JSX.Element {
     description: "placeholder text for password input",
   });
 
-  const required = (value: string) => (value ? undefined : "required");
+  function required(value: string, allValues: object, meta?: FieldState<string>) {
+    if (!value && props.autoComplete && !meta?.touched) {
+      /* Browsers handle auto-completed fields differently. Current Chrome for example seems to often (but not always)
+       * fill in the value on-screen, but not tell Javascript about it so the validator doesn't see that a value has
+       * been entered, and might show "required", which will confuse the user. As soon as the user clicks anywhere on
+       * the page (including on a seemingly disabled submit-button), the validator will run and the error will be
+       * cleared.
+       *
+       * We want to suppress this exact validation error before the user clicks anywhere.
+       */
+      return null;
+    }
+
+    if (!value) return "required";
+  }
 
   return (
     <FinalField
       type="password"
-      name={props.name || "current-password"}
-      component={CustomInput}
-      autoComplete="current-password"
+      name={props.name}
+      component={WrappedPasswordInput}
+      autoComplete={props.autoComplete}
       required={true}
-      label={<FormattedMessage defaultMessage="Password" description="password input field label" />}
       placeholder={placeholder}
-      helpBlock={""}
       validate={required}
+      // parameters for InputWrapper
+      helpBlock={props.helpBlock}
+      label={<FormattedMessage defaultMessage="Password" description="password input field label" />}
     />
+  );
+}
+
+export function WrappedPasswordInput(props: FieldRenderProps<string>): JSX.Element {
+  const { input, meta } = props;
+
+  // the InputWrapper renders it's children plus a label, helpBlock and any error message from the field validation
+  return (
+    <InputWrapper {...props}>
+      <PasswordInputElement {...props} name={input.name} id={input.name} valid={meta.valid} invalid={meta.invalid} />
+    </InputWrapper>
+  );
+}
+
+/**
+ * Render a Password input component and a Show/Hide button to toggle between text-input and password-input.
+ * @param props
+ * @returns
+ */
+function PasswordInputElement(props: InputProps): JSX.Element {
+  const [showPassword, setShowPassword] = useState(false);
+
+  function toggleShowPassword() {
+    setShowPassword(!showPassword);
+  }
+
+  return (
+    <div className="password-input">
+      <Input {...props.input} type={showPassword ? "text" : "password"} />
+
+      <button
+        type="button"
+        aria-label={showPassword ? "hide password" : "show password"}
+        className="show-hide-button"
+        onClick={toggleShowPassword}
+      >
+        {showPassword ? (
+          <FormattedMessage defaultMessage="HIDE" description="nin/password button label" />
+        ) : (
+          <FormattedMessage defaultMessage="SHOW" description="nin/password button label" />
+        )}
+      </button>
+    </div>
   );
 }

--- a/src/login/components/Inputs/PasswordInput.tsx
+++ b/src/login/components/Inputs/PasswordInput.tsx
@@ -20,22 +20,6 @@ export default function PasswordInput(props: PasswordInputProps): JSX.Element {
     description: "placeholder text for password input",
   });
 
-  function required(value: string, allValues: object, meta?: FieldState<string>) {
-    if (!value && props.autoComplete && !meta?.touched) {
-      /* Browsers handle auto-completed fields differently. Current Chrome for example seems to often (but not always)
-       * fill in the value on-screen, but not tell Javascript about it so the validator doesn't see that a value has
-       * been entered, and might show "required", which will confuse the user. As soon as the user clicks anywhere on
-       * the page (including on a seemingly disabled submit-button), the validator will run and the error will be
-       * cleared.
-       *
-       * We want to suppress this exact validation error before the user clicks anywhere.
-       */
-      return null;
-    }
-
-    if (!value) return "required";
-  }
-
   return (
     <FinalField
       type="password"
@@ -44,7 +28,6 @@ export default function PasswordInput(props: PasswordInputProps): JSX.Element {
       autoComplete={props.autoComplete}
       required={true}
       placeholder={placeholder}
-      validate={required}
       // parameters for InputWrapper
       helpBlock={props.helpBlock}
       label={<FormattedMessage defaultMessage="Password" description="password input field label" />}

--- a/src/login/components/Inputs/RadioInput.tsx
+++ b/src/login/components/Inputs/RadioInput.tsx
@@ -1,0 +1,38 @@
+import React, { Fragment } from "react";
+import { FieldRenderProps } from "react-final-form";
+import { InputWrapper } from "./InputWrapper";
+
+export default function CustomInput(props: FieldRenderProps<string>): JSX.Element {
+  // the InputWrapper renders it's children plus a label, helpBlock and any error message from the field validation
+  return (
+    <InputWrapper {...props}>
+      <RadioInputElement {...props} />
+    </InputWrapper>
+  );
+}
+
+const RadioInputElement = (props: FieldRenderProps<string>): JSX.Element => {
+  const { input, selectOptions } = props;
+  let renderSelect = null;
+  if (selectOptions) {
+    renderSelect = selectOptions.map((option: string[], index: number) => {
+      return (
+        <Fragment key={index}>
+          <label key={option[0]} htmlFor={option[1]}>
+            <input
+              className={props.meta.error && props.meta.visited ? "radio-input error" : "radio-input"}
+              key={option[0]}
+              id={option[1]}
+              type="radio"
+              {...input}
+              value={option[0]}
+              checked={option[0] === input.value}
+            />
+            <span key={index}>{option[1]}</span>
+          </label>
+        </Fragment>
+      );
+    });
+  }
+  return <div className="radio-input-container">{renderSelect}</div>;
+};

--- a/src/login/components/LoginApp/Login/UsernamePw.tsx
+++ b/src/login/components/LoginApp/Login/UsernamePw.tsx
@@ -1,8 +1,16 @@
+import { faQrcode } from "@fortawesome/free-solid-svg-icons";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import EduIDButton from "components/EduIDButton";
+import TextInput from "components/EduIDTextInput";
 import { useAppDispatch, useAppSelector } from "login/app_init/hooks";
+import EmailInput from "login/components/Inputs/EmailInput";
+import PasswordInput from "login/components/Inputs/PasswordInput";
+import { callUsernamePasswordSaga } from "login/redux/sagas/login/postUsernamePasswordSaga";
 import loginSlice from "login/redux/slices/loginSlice";
 import resetPasswordSlice from "login/redux/slices/resetPasswordSlice";
 import { translate } from "login/translation";
 import React from "react";
+import { Field as FinalField, Form as FinalForm, FormRenderProps } from "react-final-form";
 import { FormattedMessage } from "react-intl";
 import { useHistory } from "react-router-dom";
 import { emailPattern } from "../../../app_utils/validation/regexPatterns";
@@ -10,17 +18,9 @@ import Link from "../../Links/Link";
 import LinkRedirect from "../../Links/LinkRedirect";
 import { setLocalStorage } from "../ResetPassword/CountDownTimer";
 import { LOCAL_STORAGE_PERSISTED_EMAIL } from "../ResetPassword/ResetPasswordMain";
-import { Form as FinalForm, FormRenderProps, Field as FinalField } from "react-final-form";
-import EmailInput from "login/components/Inputs/EmailInput";
-import PasswordInput from "login/components/Inputs/PasswordInput";
-import { callUsernamePasswordSaga } from "login/redux/sagas/login/postUsernamePasswordSaga";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { faQrcode } from "@fortawesome/free-solid-svg-icons";
-import TextInput from "components/EduIDTextInput";
-import EduIDButton from "components/EduIDButton";
-import { forgetThisDevice } from "./NewDevice";
-import { LoginAtServiceInfo } from "./LoginAtServiceInfo";
 import { LoginAbortButton } from "./LoginAbortButton";
+import { LoginAtServiceInfo } from "./LoginAtServiceInfo";
+import { forgetThisDevice } from "./NewDevice";
 
 interface UsernamePwFormData {
   email?: string;
@@ -32,9 +32,20 @@ export default function UsernamePw() {
   const service_info = useAppSelector((state) => state.login.service_info);
 
   function handleSubmitUsernamePw(values: UsernamePwFormData) {
+    const errors: UsernamePwFormData = {};
+
     if (values.email && values["current-password"]) {
       dispatch(callUsernamePasswordSaga({ email: values.email, currentPassword: values["current-password"] }));
+      return;
     }
+
+    if (!values.email) {
+      errors.email = "required";
+    }
+    if (!values["current-password"]) {
+      errors["current-password"] = "required";
+    }
+    return errors;
   }
 
   return (
@@ -166,12 +177,20 @@ function RenderResetPasswordLink(): JSX.Element {
 function UsernamePwSubmitButton(props: FormRenderProps<UsernamePwFormData>): JSX.Element {
   const loading = useAppSelector((state) => state.app.loading_data);
 
+  /* Disable the button when:
+   *   - the app is loading data
+   *   - there is a form validation error
+   *   - the last submit resulted in a submitError, and no changes have been made since
+   */
+  const _submitError = Boolean(props.submitError && !props.dirtySinceLastSubmit);
+  const _disabled = Boolean(props.hasValidationErrors || _submitError || loading);
+
   return (
     <EduIDButton
       buttonstyle="primary"
       type="submit"
-      disabled={props.invalid || loading}
-      aria-disabled={props.invalid || loading}
+      disabled={_disabled}
+      aria-disabled={_disabled}
       id="login-form-button"
       onClick={props.handleSubmit}
     >

--- a/src/login/components/LoginApp/Login/UsernamePw.tsx
+++ b/src/login/components/LoginApp/Login/UsernamePw.tsx
@@ -56,7 +56,7 @@ export default function UsernamePw() {
             <form onSubmit={formProps.handleSubmit}>
               <UsernameInputPart />
               <fieldset>
-                <PasswordInput name="current-password" />
+                <PasswordInput name="current-password" autoComplete="current-password" />
               </fieldset>
 
               <div className="flex-between">
@@ -120,7 +120,7 @@ function UsernameInputPart(): JSX.Element {
       </React.Fragment>
     );
   }
-  return <EmailInput name="email" autoFocus={true} required={true} />;
+  return <EmailInput name="email" autoFocus={true} required={true} autoComplete="username" />;
 }
 
 function RenderRegisterLink(): JSX.Element {
@@ -165,6 +165,7 @@ function RenderResetPasswordLink(): JSX.Element {
 
 function UsernamePwSubmitButton(props: FormRenderProps<UsernamePwFormData>): JSX.Element {
   const loading = useAppSelector((state) => state.app.loading_data);
+
   return (
     <EduIDButton
       buttonstyle="primary"

--- a/src/login/components/PersonalData/PersonalDataForm.tsx
+++ b/src/login/components/PersonalData/PersonalDataForm.tsx
@@ -14,6 +14,7 @@ import { DashboardRootState } from "dashboard-init-app";
 import { PersonalDataData } from "reducers/PersonalData";
 import { Form } from "reactstrap";
 import EduIDButton from "../../../components/EduIDButton";
+import RadioInput from "../Inputs/RadioInput";
 
 interface NameStrings {
   first: string;
@@ -168,7 +169,7 @@ const PersonalDataForm = (props: PersonalDataFormProps) => {
         />
       </fieldset>
       <Field
-        component={CustomInput}
+        component={RadioInput}
         required={true}
         name="language"
         selectOptions={available_languages}


### PR DESCRIPTION
Refactor CustomInput to a couple of discrete components instead of one trying to work for everything.

Move the "required" part of e-mail and password validation to a submitError in order to have the login button enabled when browsers does auto-complete (Javascript often sees no "value" until the user clicks somewhere). This way, no error message about a missing value is show until after the user has tried to submit the data.