### PR TITLE
Revert vertical spacing refactor due to notification bar

### DIFF
--- a/src/login/styles/_base.scss
+++ b/src/login/styles/_base.scss
@@ -31,11 +31,19 @@ body {
   display: flex;
   flex-direction: column;
   flex: 1;
-  padding: 3rem 0 6rem;
+  padding-bottom: 6rem;
   background-color: $light-gray;
 
   @media (max-width: $bp-lg) {
-    padding-bottom: 2rem 0 4rem;
+    padding-bottom: 4rem;
+  }
+
+  .content {
+    padding-top: 3rem;
+
+    @media (max-width: $bp-lg) {
+      padding-top: 2rem;
+    }
   }
 }
 

--- a/src/login/styles/_links.scss
+++ b/src/login/styles/_links.scss
@@ -7,9 +7,12 @@ a,
   text-decoration: none;
   transition: all 0.2s ease;
   cursor: pointer;
+  border-bottom: none;
 
   &:hover {
     color: $orange-highlight;
+    border-bottom: none;
+    text-decoration: underline;
   }
 
   // hiding opt in beta link


### PR DESCRIPTION
#### Description:

Vertical content spacing was simplified (all applied to panel), but top padding need to be applied inside to keep notification bar on top, thus reverted.

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
