### PR TITLE
Ct reset password style update

### DIFF
--- a/src/login/components/LoginApp/ResetPassword/EmailForm.tsx
+++ b/src/login/components/LoginApp/ResetPassword/EmailForm.tsx
@@ -46,6 +46,7 @@ function EmailForm(props: EmailFormProps): JSX.Element {
               <EmailInput name="email" autoFocus={true} required={true} autoComplete="username" />
 
               <div className="buttons">
+                <GoBackButton />
                 <EduIDButton
                   buttonstyle="primary"
                   id="reset-password-button"
@@ -54,7 +55,6 @@ function EmailForm(props: EmailFormProps): JSX.Element {
                 >
                   <FormattedMessage defaultMessage="send email" description="Reset Password button" />
                 </EduIDButton>
-                <GoBackButton />
               </div>
             </fieldset>
           </form>

--- a/src/login/components/LoginApp/ResetPassword/EmailForm.tsx
+++ b/src/login/components/LoginApp/ResetPassword/EmailForm.tsx
@@ -45,7 +45,7 @@ function EmailForm(props: EmailFormProps): JSX.Element {
             <fieldset>
               <EmailInput name="email" autoFocus={true} required={true} autoComplete="username" />
 
-              <div className="button-pair">
+              <div className="buttons">
                 <EduIDButton
                   buttonstyle="primary"
                   id="reset-password-button"

--- a/src/login/components/LoginApp/ResetPassword/EmailLinkSent.tsx
+++ b/src/login/components/LoginApp/ResetPassword/EmailLinkSent.tsx
@@ -54,7 +54,24 @@ export function EmailLinkSent(): JSX.Element | null {
           description="Reset Password email link sent"
         />
       </p>
-      <div className="resend-timer">
+      <p>
+        <FormattedMessage
+          defaultMessage="If you didn’t receive the email, check your junk email, or resend the email."
+          description="Reset Password email link sent"
+        />
+      </p>
+
+      <div className="buttons">
+        <EduIDButton
+          buttonstyle="primary"
+          type="submit"
+          className="settings-button"
+          id="send-email-button"
+          onClick={sendEmailOnClick}
+          disabled={resendDisabled}
+        >
+          <FormattedMessage defaultMessage="Resend e-mail" description="Resend e-mail button" />
+        </EduIDButton>
         <TimeRemainingWrapper
           name="reset-password-email-expires"
           unique_id={response?.email}
@@ -63,20 +80,9 @@ export function EmailLinkSent(): JSX.Element | null {
         >
           <ExpiresMeter showMeter={false} expires_max={response?.throttled_max} />
         </TimeRemainingWrapper>
-
-        <div className="button-pair">
-          <EduIDButton
-            buttonstyle="primary"
-            type="submit"
-            className="settings-button"
-            id="send-email-button"
-            onClick={sendEmailOnClick}
-            disabled={resendDisabled}
-          >
-            <FormattedMessage defaultMessage="Resend e-mail" description="Resend e-mail button" />
-          </EduIDButton>
-          <GoBackButton primary={true} />
-        </div>
+      </div>
+      <div className="buttons">
+        <GoBackButton link={true} />
       </div>
     </React.Fragment>
   );

--- a/src/login/components/LoginApp/ResetPassword/EmailLinkSent.tsx
+++ b/src/login/components/LoginApp/ResetPassword/EmailLinkSent.tsx
@@ -62,6 +62,7 @@ export function EmailLinkSent(): JSX.Element | null {
       </p>
 
       <div className="buttons">
+        <GoBackButton secondary={true} />
         <EduIDButton
           buttonstyle="primary"
           type="submit"
@@ -80,9 +81,6 @@ export function EmailLinkSent(): JSX.Element | null {
         >
           <ExpiresMeter showMeter={false} expires_max={response?.throttled_max} />
         </TimeRemainingWrapper>
-      </div>
-      <div className="buttons">
-        <GoBackButton link={true} />
       </div>
     </React.Fragment>
   );

--- a/src/login/components/LoginApp/ResetPassword/EmailLinkSent.tsx
+++ b/src/login/components/LoginApp/ResetPassword/EmailLinkSent.tsx
@@ -62,7 +62,7 @@ export function EmailLinkSent(): JSX.Element | null {
       </p>
 
       <div className="buttons">
-        <GoBackButton secondary={true} />
+        <GoBackButton />
         <EduIDButton
           buttonstyle="primary"
           type="submit"

--- a/src/login/components/LoginApp/ResetPassword/GoBackButton.tsx
+++ b/src/login/components/LoginApp/ResetPassword/GoBackButton.tsx
@@ -6,8 +6,6 @@ import { useNavigate } from "react-router-dom";
 
 interface BackToLoginButtonProps {
   primary?: boolean;
-  secondary?: boolean;
-  link?: boolean;
   onClickHandler?(): void; // optional callback for when the button is clicked
 }
 
@@ -29,7 +27,7 @@ export function GoBackButton(props: BackToLoginButtonProps): JSX.Element | null 
     }
   }
 
-  const style = props.primary ? "primary" : props.secondary ? "secondary" : "link";
+  const style = props.primary ? "primary" : "secondary";
 
   return (
     <EduIDButton buttonstyle={style} className="normal-case" id="go-back-button" onClick={onClick}>

--- a/src/login/components/LoginApp/ResetPassword/GoBackButton.tsx
+++ b/src/login/components/LoginApp/ResetPassword/GoBackButton.tsx
@@ -1,5 +1,3 @@
-import { faArrowLeft } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import EduIDButton from "components/EduIDButton";
 import { useAppSelector } from "login/app_init/hooks";
 import React from "react";
@@ -7,7 +5,9 @@ import { FormattedMessage } from "react-intl";
 import { useNavigate } from "react-router-dom";
 
 interface BackToLoginButtonProps {
-  primary?: boolean; // use styling "primary" instead of the default, "secondary"
+  primary?: boolean;
+  secondary?: boolean;
+  link?: boolean;
   onClickHandler?(): void; // optional callback for when the button is clicked
 }
 
@@ -29,13 +29,11 @@ export function GoBackButton(props: BackToLoginButtonProps): JSX.Element | null 
     }
   }
 
-  const style = props.primary ? "primary" : "secondary";
+  const style = props.primary ? "primary" : props.secondary ? "secondary" : "link";
 
   return (
-    <EduIDButton buttonstyle={style} id="go-back-button" onClick={onClick}>
-      <FontAwesomeIcon icon={faArrowLeft} />
-      &nbsp;
-      <FormattedMessage defaultMessage="Go back" description="Account recovery Go back button" />
+    <EduIDButton buttonstyle={style} className="normal-case" id="go-back-button" onClick={onClick}>
+      <FormattedMessage defaultMessage="Go back to Login" description="Account recovery Go back button" />
     </EduIDButton>
   );
 }

--- a/src/login/components/LoginApp/ResetPassword/GoBackButton.tsx
+++ b/src/login/components/LoginApp/ResetPassword/GoBackButton.tsx
@@ -33,7 +33,7 @@ export function GoBackButton(props: BackToLoginButtonProps): JSX.Element | null 
 
   return (
     <EduIDButton buttonstyle={style} className="normal-case" id="go-back-button" onClick={onClick}>
-      <FormattedMessage defaultMessage="Go back to Login" description="Account recovery Go back button" />
+      <FormattedMessage defaultMessage="Go back" description="Account recovery Go back button" />
     </EduIDButton>
   );
 }

--- a/src/login/components/LoginApp/ResetPassword/ResetPassword.tsx
+++ b/src/login/components/LoginApp/ResetPassword/ResetPassword.tsx
@@ -27,7 +27,7 @@ function ResetPassword(): JSX.Element {
       <h1>
         <FormattedMessage defaultMessage="Reset password" description="Reset Password heading" />
       </h1>
-      <div className="lead"></div>
+      <hr className="border-line" />
       <div id="reset-pass-display">
         <Routes>
           <Route path="extra-security" element={<ExtraSecurity />} />

--- a/src/login/components/LoginApp/ResetPassword/ResetPasswordEnterEmail.tsx
+++ b/src/login/components/LoginApp/ResetPassword/ResetPasswordEnterEmail.tsx
@@ -13,7 +13,7 @@ export function ResetPasswordEnterEmail(): JSX.Element {
 
   return (
     <React.Fragment>
-      <p className="heading">
+      <p>
         <FormattedMessage
           defaultMessage="Enter the email address registered to your eduID account."
           description="Reset password add email heading"

--- a/src/login/components/LoginApp/ResetPassword/ResetPasswordLayout.tsx
+++ b/src/login/components/LoginApp/ResetPassword/ResetPasswordLayout.tsx
@@ -24,7 +24,7 @@ const ResetPasswordLayout = (props: ResetPasswordLayoutProps): JSX.Element => {
   };
   return (
     <>
-      <h1>{props.heading}</h1>
+      <h2>{props.heading}</h2>
       <div id="reset-pass-display">
         <p>{props.description}</p>
         {props.children}

--- a/src/login/components/LoginApp/ResetPassword/SetNewPassword.tsx
+++ b/src/login/components/LoginApp/ResetPassword/SetNewPassword.tsx
@@ -84,7 +84,7 @@ function NewPasswordForm(props: NewPasswordFormProps): JSX.Element {
               autoFocus={true}
             />
 
-            <div className="new-password-button-container">
+            <div className="buttons">
               {props.extra_security && Object.keys(props.extra_security).length > 0 && (
                 <EduIDButton
                   buttonstyle="secondary"
@@ -145,9 +145,9 @@ function SetNewPassword(): JSX.Element {
 
   return (
     <Splash showChildren={!!password}>
-      <p className="heading">
+      <h1>
         <FormattedMessage defaultMessage="Set your new password" description="Set new password" />
-      </p>
+      </h1>
       <p>
         <FormattedMessage
           defaultMessage={`A strong password has been generated for you. To proceed you will need to repeat copy the

--- a/src/login/styles/_ResetPassword.scss
+++ b/src/login/styles/_ResetPassword.scss
@@ -73,7 +73,7 @@
   }
 
   .expires-meter {
-    text-align: left;
+    align-self: center;
   }
 }
 


### PR DESCRIPTION
#### Description:

- Site consistent look and placement of buttons and timer
- Adding/adjusting heading hierarchy across the reset-password steps
- Re-adding lost junk-email copy
- Making goback-button able to use eduid-button link-style
- Replaced empty Lead with strictly visual divider

![Skärmavbild 2022-08-26 kl  12 31 46](https://user-images.githubusercontent.com/79106074/186885297-0f9dec64-8691-4a39-be67-1cf853b3e8c7.png)
#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
