### PR TITLE
Ct generic error styling

### DIFF
--- a/src/components/GenericError.tsx
+++ b/src/components/GenericError.tsx
@@ -9,7 +9,7 @@ export function GenericError(props: FallbackProps) {
   return (
     <Fragment>
       <div className="horizontal-content-margin content">
-        <div className="error-boundary swamid-error">
+        <div className="error-boundary error-page">
           <h1>
             {" "}
             <FormattedMessage

--- a/src/components/GenericError.tsx
+++ b/src/components/GenericError.tsx
@@ -21,7 +21,7 @@ export function GenericError(props: FallbackProps) {
             />
           </p>
           <p>
-            You can try to <TryAgainOption {...props} /> or <ToHomeOption />.
+            <ToHomeOption />
           </p>
         </div>
       </div>
@@ -29,34 +29,10 @@ export function GenericError(props: FallbackProps) {
   );
 }
 
-function TryAgainOption(props: FallbackProps) {
-  return (
-    <a
-      id=""
-      className="text-link"
-      onClick={() => {
-        if (props.resetErrorBoundary) {
-          props.resetErrorBoundary();
-        }
-      }}
-    >
-      <FormattedMessage defaultMessage="reload the page" description="generic error page" />
-    </a>
-  );
-}
-
 function ToHomeOption() {
   const toHome = useAppSelector((state) => state.config.eduid_site_url);
   return (
-    <a
-      id=""
-      className="text-link"
-      onClick={() => {
-        if (toHome) {
-          window.location.href = toHome;
-        }
-      }}
-    >
+    <a className="text-link" href={toHome}>
       <FormattedMessage defaultMessage="Return to home" description="generic error page" />
     </a>
   );

--- a/src/components/GenericError.tsx
+++ b/src/components/GenericError.tsx
@@ -1,9 +1,8 @@
-import { faHome, faRedo } from "@fortawesome/free-solid-svg-icons";
-import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { useAppSelector } from "login/app_init/hooks";
 import { Fragment } from "react";
 import { FallbackProps } from "react-error-boundary";
 import { FormattedMessage } from "react-intl";
+import EduIDButton from "components/EduIDButton";
 
 export function GenericError(props: FallbackProps) {
   return (
@@ -23,10 +22,12 @@ export function GenericError(props: FallbackProps) {
               description="generic error page"
             />
           </p>
-          <div className="options">
+          <p className="buttons">
+            You can try to
             <TryAgainOption {...props} />
+            or
             <ToHomeOption />
-          </div>
+          </p>
         </div>
       </div>
     </Fragment>
@@ -35,51 +36,35 @@ export function GenericError(props: FallbackProps) {
 
 function TryAgainOption(props: FallbackProps) {
   return (
-    <div className="option">
-      <label>
-        <FormattedMessage defaultMessage="Try again:" description="generic error page" />
-      </label>
-      <div className="icon-text">
-        <button
-          className="icon"
-          onClick={() => {
-            if (props.resetErrorBoundary) {
-              props.resetErrorBoundary();
-            }
-          }}
-        >
-          <FontAwesomeIcon icon={faRedo} />
-        </button>
-        <p>
-          <FormattedMessage defaultMessage="Reload page" description="generic error page" />
-        </p>
-      </div>
-    </div>
+    <EduIDButton
+      id=""
+      buttonstyle="link"
+      className=" lowercase"
+      onClick={() => {
+        if (props.resetErrorBoundary) {
+          props.resetErrorBoundary();
+        }
+      }}
+    >
+      <FormattedMessage defaultMessage="Reload the page" description="generic error page" />
+    </EduIDButton>
   );
 }
 
 function ToHomeOption() {
   const toHome = useAppSelector((state) => state.config.eduid_site_url);
   return (
-    <div className="option">
-      <label>
-        <FormattedMessage defaultMessage="Start over" description="generic error page" />
-      </label>
-      <div className="icon-text">
-        <button
-          className="icon"
-          onClick={() => {
-            if (toHome) {
-              window.location.href = toHome;
-            }
-          }}
-        >
-          <FontAwesomeIcon icon={faHome} />
-        </button>
-        <p>
-          <FormattedMessage defaultMessage="Return to home" description="generic error page" />
-        </p>
-      </div>
-    </div>
+    <EduIDButton
+      id=""
+      buttonstyle="link"
+      className=" lowercase"
+      onClick={() => {
+        if (toHome) {
+          window.location.href = toHome;
+        }
+      }}
+    >
+      <FormattedMessage defaultMessage="Return to home" description="generic error page" />
+    </EduIDButton>
   );
 }

--- a/src/components/GenericError.tsx
+++ b/src/components/GenericError.tsx
@@ -2,7 +2,6 @@ import { useAppSelector } from "login/app_init/hooks";
 import { Fragment } from "react";
 import { FallbackProps } from "react-error-boundary";
 import { FormattedMessage } from "react-intl";
-import EduIDButton from "components/EduIDButton";
 
 export function GenericError(props: FallbackProps) {
   return (
@@ -10,7 +9,6 @@ export function GenericError(props: FallbackProps) {
       <div className="horizontal-content-margin content">
         <div className="error-boundary error-page">
           <h1>
-            {" "}
             <FormattedMessage
               defaultMessage="There was a problem displaying the page."
               description="generic error page"
@@ -22,11 +20,8 @@ export function GenericError(props: FallbackProps) {
               description="generic error page"
             />
           </p>
-          <p className="buttons">
-            You can try to
-            <TryAgainOption {...props} />
-            or
-            <ToHomeOption />
+          <p>
+            You can try to <TryAgainOption {...props} /> or <ToHomeOption />.
           </p>
         </div>
       </div>
@@ -36,28 +31,26 @@ export function GenericError(props: FallbackProps) {
 
 function TryAgainOption(props: FallbackProps) {
   return (
-    <EduIDButton
+    <a
       id=""
-      buttonstyle="link"
-      className=" lowercase"
+      className="text-link"
       onClick={() => {
         if (props.resetErrorBoundary) {
           props.resetErrorBoundary();
         }
       }}
     >
-      <FormattedMessage defaultMessage="Reload the page" description="generic error page" />
-    </EduIDButton>
+      <FormattedMessage defaultMessage="reload the page" description="generic error page" />
+    </a>
   );
 }
 
 function ToHomeOption() {
   const toHome = useAppSelector((state) => state.config.eduid_site_url);
   return (
-    <EduIDButton
+    <a
       id=""
-      buttonstyle="link"
-      className=" lowercase"
+      className="text-link"
       onClick={() => {
         if (toHome) {
           window.location.href = toHome;
@@ -65,6 +58,6 @@ function ToHomeOption() {
       }}
     >
       <FormattedMessage defaultMessage="Return to home" description="generic error page" />
-    </EduIDButton>
+    </a>
   );
 }

--- a/src/components/GenericError.tsx
+++ b/src/components/GenericError.tsx
@@ -1,9 +1,8 @@
 import { useAppSelector } from "login/app_init/hooks";
 import { Fragment } from "react";
-import { FallbackProps } from "react-error-boundary";
 import { FormattedMessage } from "react-intl";
 
-export function GenericError(props: FallbackProps) {
+export function GenericError() {
   return (
     <Fragment>
       <div className="horizontal-content-margin content">

--- a/src/components/GenericError.tsx
+++ b/src/components/GenericError.tsx
@@ -8,23 +8,25 @@ import { FormattedMessage } from "react-intl";
 export function GenericError(props: FallbackProps) {
   return (
     <Fragment>
-      <div className="error-boundary">
-        <h2 className="heading">
-          {" "}
-          <FormattedMessage
-            defaultMessage="There was a problem displaying the page."
-            description="generic error page"
-          />
-        </h2>
-        <p>
-          <FormattedMessage
-            defaultMessage="The issue has been reported to the team."
-            description="generic error page"
-          />
-        </p>
-        <div className="options">
-          <TryAgainOption {...props} />
-          <ToHomeOption />
+      <div className="horizontal-content-margin content">
+        <div className="error-boundary swamid-error">
+          <h1>
+            {" "}
+            <FormattedMessage
+              defaultMessage="There was a problem displaying the page."
+              description="generic error page"
+            />
+          </h1>
+          <p>
+            <FormattedMessage
+              defaultMessage="The issue has been reported to the team."
+              description="generic error page"
+            />
+          </p>
+          <div className="options">
+            <TryAgainOption {...props} />
+            <ToHomeOption />
+          </div>
         </div>
       </div>
     </Fragment>

--- a/src/login/components/LoginApp/LoginApp.tsx
+++ b/src/login/components/LoginApp/LoginApp.tsx
@@ -4,6 +4,7 @@ import UseOtherDevice2 from "./Login/UseOtherDevice2";
 import ResetPassword from "./ResetPassword/ResetPassword";
 
 function LoginApp(): JSX.Element {
+  throw new Error("test");
   return (
     <div id="content" className="horizontal-content-margin content">
       <Routes>

--- a/src/login/components/LoginApp/LoginApp.tsx
+++ b/src/login/components/LoginApp/LoginApp.tsx
@@ -4,7 +4,6 @@ import UseOtherDevice2 from "./Login/UseOtherDevice2";
 import ResetPassword from "./ResetPassword/ResetPassword";
 
 function LoginApp(): JSX.Element {
-  throw new Error("test");
   return (
     <div id="content" className="horizontal-content-margin content">
       <Routes>

--- a/src/login/components/SwamidErrors/Errors.tsx
+++ b/src/login/components/SwamidErrors/Errors.tsx
@@ -41,7 +41,7 @@ export function Errors() {
 
   return (
     <div className="horizontal-content-margin content">
-      <div className="swamid-error">
+      <div className="error-page">
         {errorURL.code === "IDENTIFICATION_FAILURE" && <IdentificationFailure errorURL={errorURL} />}
         {errorURL.code === "AUTHENTICATION_FAILURE" && <AuthenticationFailure errorURL={errorURL} />}
         {errorURL.code === "AUTHORIZATION_FAILURE" && <AuthorizationFailure errorURL={errorURL} />}

--- a/src/login/styles/_Errors.scss
+++ b/src/login/styles/_Errors.scss
@@ -118,6 +118,11 @@
     font-size: 1rem;
     margin-bottom: 1rem;
   }
+
+  button.btn.btn-link {
+    height: auto;
+    min-width: unset !important;
+  }
 }
 
 // small reddish alert with exclamation symbol

--- a/src/login/styles/_Errors.scss
+++ b/src/login/styles/_Errors.scss
@@ -1,4 +1,4 @@
-.swamid-error {
+.error-page {
   h1 {
     color: $dark-orange;
   }
@@ -71,7 +71,7 @@
   }
 }
 
-.swamid-error li {
+.error-page li {
   margin-top: 24px;
 }
 

--- a/src/login/styles/_Errors.scss
+++ b/src/login/styles/_Errors.scss
@@ -75,51 +75,6 @@
   margin-top: 24px;
 }
 
-// ErrorBoundary: generic error
-.error-boundary {
-  .options {
-    margin-top: 2rem;
-    display: flex;
-
-    @media (max-width: $bp-xs) {
-      flex-direction: column;
-      flex-wrap: wrap;
-    }
-  }
-
-  .option {
-    margin-right: 5rem;
-    margin-bottom: 2rem;
-
-    .icon-text {
-      display: flex;
-      align-items: baseline;
-
-      p {
-        margin-left: 1rem;
-        font-family: ProximaNova-Regular;
-        color: $black;
-      }
-
-      button,
-      button:active,
-      button:focus,
-      button:active:focus {
-        border: transparent solid 1px;
-        margin-top: 0;
-        padding: 0.75rem;
-        background-color: white;
-        border-radius: 50%;
-      }
-    }
-  }
-
-  label {
-    font-size: 1rem;
-    margin-bottom: 1rem;
-  }
-}
-
 // small reddish alert with exclamation symbol
 .warning-text {
   color: $dark-orange;

--- a/src/login/styles/_Errors.scss
+++ b/src/login/styles/_Errors.scss
@@ -118,11 +118,6 @@
     font-size: 1rem;
     margin-bottom: 1rem;
   }
-
-  button.btn.btn-link {
-    height: auto;
-    min-width: unset !important;
-  }
 }
 
 // small reddish alert with exclamation symbol


### PR DESCRIPTION
#### Description:
Aligned to site framework and error-page styling, replaced random buttons with simpler links, removed unnecessary css.

Before:
![image](https://user-images.githubusercontent.com/79106074/187382089-1c9ed58b-a59d-4302-a02b-90204d20f891.png)

After:
[Replace this with a description of what you've done - if styling-related work please include a screenshot]
![Skärmavbild 2022-08-26 kl  17 43 28](https://user-images.githubusercontent.com/79106074/187381648-21140b06-a48a-40cd-9d4c-c08ae6083461.png)

#### For reviewer:


- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
