### PR TITLE
SIGNUP: Fixed multiple API call when changing language

### DIFF
--- a/src/apis/eduidSignup.ts
+++ b/src/apis/eduidSignup.ts
@@ -61,7 +61,7 @@ export interface VerifyLinkResponseSuccess {
   status: "verified";
   password: string;
   email?: string;
-  dashboard_url?: string;
+  dashboard_url: string;
 }
 
 export type VerifyLinkResponse = VerifyLinkResponseFail | VerifyLinkResponseSuccess;

--- a/src/apis/eduidSignup.ts
+++ b/src/apis/eduidSignup.ts
@@ -61,7 +61,7 @@ export interface VerifyLinkResponseSuccess {
   status: "verified";
   password: string;
   email?: string;
-  dashboard_url: string;
+  dashboard_url?: string;
 }
 
 export type VerifyLinkResponse = VerifyLinkResponseFail | VerifyLinkResponseSuccess;
@@ -73,10 +73,11 @@ export type VerifyLinkResponse = VerifyLinkResponseFail | VerifyLinkResponseSucc
  */
 export const fetchVerifyLink = createAsyncThunk<
   VerifyLinkResponse, // return type
-  VerifyLinkRequest, // args type
+  undefined, // args type
   { dispatch: SignupAppDispatch; state: SignupRootState }
 >("signup/fetchVerifyLink", async (args, thunkAPI) => {
-  return makeSignupRequest<VerifyLinkResponse>(thunkAPI, `verify-link/${args.code}`)
+  const state = thunkAPI.getState();
+  return makeSignupRequest<VerifyLinkResponse>(thunkAPI, `verify-link/${state.signup.code}`)
     .then((response) => response.payload)
     .catch((err) => thunkAPI.rejectWithValue(err));
 });

--- a/src/components/CodeVerified.tsx
+++ b/src/components/CodeVerified.tsx
@@ -1,14 +1,9 @@
-import { isFSA } from "apis/common";
-import { fetchVerifyLink, isVerifyLinkResponse, VerifyLinkResponse, VerifyLinkResponseSuccess } from "apis/eduidSignup";
+import { VerifyLinkResponseSuccess } from "apis/eduidSignup";
 import EduIDButton from "components/EduIDButton";
 import Splash from "components/Splash";
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { FormattedMessage } from "react-intl";
 import { useParams } from "react-router";
-import { useNavigate } from "react-router-dom";
-import { showNotification } from "reducers/Notifications";
-import { useSignupAppDispatch } from "signup-hooks";
-import { SIGNUP_BASE_PATH } from "./SignupMain";
 
 // element ids used in tests
 export const idUserEmail = "user-email";
@@ -20,49 +15,24 @@ interface CodeParams {
   code?: string;
 }
 
-export default function CodeVerified() {
+interface CodeVerifiedProps {
+  response?: VerifyLinkResponseSuccess;
+  setVerifyLinkCode: (value: string | undefined) => void;
+}
+
+export default function CodeVerified(props: CodeVerifiedProps) {
   // TODO: get dashboard URL from config instead of from backend response?
   // const dashboard_url = useSignupAppSelector((state) => state.config.dashboard_url);
-  const dispatch = useSignupAppDispatch();
-  const navigate = useNavigate();
   const params = useParams() as CodeParams;
-  const [response, setResponse] = useState<VerifyLinkResponse>();
-
-  async function verifyCode(code: string) {
-    const resp = await dispatch(fetchVerifyLink({ code }));
-
-    if (fetchVerifyLink.fulfilled.match(resp)) {
-      setResponse(resp.payload);
-    }
-    if (fetchVerifyLink.rejected.match(resp)) {
-      if (isFSA(resp.payload) && isVerifyLinkResponse(resp.payload.payload)) {
-        setResponse(resp.payload.payload);
-      }
-    }
-  }
 
   useEffect(() => {
-    if (!response && params?.code) {
-      verifyCode(params.code);
-    }
-  }, []);
-
-  useEffect(() => {
-    if (response?.status === "unknown-code") {
-      dispatch(showNotification({ message: "code.unknown-code", level: "info" }));
-      navigate(SIGNUP_BASE_PATH + "/email"); // GOTO start
-    }
-    if (response?.status === "already-verified") {
-      // TODO: Not sure this can reasonably actually happen in the backend?
-      dispatch(showNotification({ message: "code.already-verified", level: "info" }));
-      navigate(SIGNUP_BASE_PATH + "/email"); // GOTO start
-    }
-  }, [response]);
+    props.setVerifyLinkCode(params.code);
+  }, [params.code]);
 
   return (
     <React.Fragment>
-      <Splash showChildren={response !== undefined}>
-        {response?.status === "verified" && <SignupComplete {...response} />}
+      <Splash showChildren={props.response !== undefined}>
+        {props.response?.status === "verified" && <SignupComplete {...props.response} />}
       </Splash>
     </React.Fragment>
   );

--- a/src/components/CodeVerified.tsx
+++ b/src/components/CodeVerified.tsx
@@ -17,7 +17,7 @@ interface CodeParams {
 
 interface CodeVerifiedProps {
   response?: VerifyLinkResponseSuccess;
-  setVerifyLinkCode: (value: string | undefined) => void;
+  stateChanger: (value: string | undefined) => void;
 }
 
 export default function CodeVerified(props: CodeVerifiedProps) {
@@ -26,7 +26,7 @@ export default function CodeVerified(props: CodeVerifiedProps) {
   const params = useParams() as CodeParams;
 
   useEffect(() => {
-    props.setVerifyLinkCode(params.code);
+    props.stateChanger(params.code);
   }, [params.code]);
 
   return (

--- a/src/components/CodeVerified.tsx
+++ b/src/components/CodeVerified.tsx
@@ -4,6 +4,10 @@ import Splash from "components/Splash";
 import React, { useEffect } from "react";
 import { FormattedMessage } from "react-intl";
 import { useParams } from "react-router";
+import { showNotification } from "reducers/Notifications";
+import { SIGNUP_BASE_PATH } from "./SignupMain";
+import { useSignupAppDispatch } from "signup-hooks";
+import { useNavigate } from "react-router-dom";
 
 // element ids used in tests
 export const idUserEmail = "user-email";
@@ -16,7 +20,7 @@ interface CodeParams {
 }
 
 interface CodeVerifiedProps {
-  response?: VerifyLinkResponseSuccess;
+  response?: any;
   stateChanger: (value: string | undefined) => void;
 }
 
@@ -24,10 +28,24 @@ export default function CodeVerified(props: CodeVerifiedProps) {
   // TODO: get dashboard URL from config instead of from backend response?
   // const dashboard_url = useSignupAppSelector((state) => state.config.dashboard_url);
   const params = useParams() as CodeParams;
+  const dispatch = useSignupAppDispatch();
+  const navigate = useNavigate();
 
   useEffect(() => {
     props.stateChanger(params.code);
   }, [params.code]);
+
+  useEffect(() => {
+    if (props.response.status === "unknown-code") {
+      dispatch(showNotification({ message: "code.unknown-code", level: "info" }));
+      navigate(SIGNUP_BASE_PATH + "/email"); // GOTO start
+    }
+    if (props.response.status === "already-verified") {
+      // TODO: Not sure this can reasonably actually happen in the backend?
+      dispatch(showNotification({ message: "code.already-verified", level: "info" }));
+      navigate(SIGNUP_BASE_PATH + "/email"); // GOTO start
+    }
+  }, [props.response]);
 
   return (
     <React.Fragment>

--- a/src/components/CodeVerified.tsx
+++ b/src/components/CodeVerified.tsx
@@ -1,4 +1,3 @@
-import { VerifyLinkResponseSuccess } from "apis/eduidSignup";
 import EduIDButton from "components/EduIDButton";
 import Splash from "components/Splash";
 import React, { useEffect } from "react";
@@ -6,8 +5,9 @@ import { FormattedMessage } from "react-intl";
 import { useParams } from "react-router";
 import { showNotification } from "reducers/Notifications";
 import { SIGNUP_BASE_PATH } from "./SignupMain";
-import { useSignupAppDispatch } from "signup-hooks";
+import { useSignupAppDispatch, useSignupAppSelector } from "signup-hooks";
 import { useNavigate } from "react-router-dom";
+import { SignupState } from "reducers/Signup";
 
 // element ids used in tests
 export const idUserEmail = "user-email";
@@ -20,7 +20,6 @@ interface CodeParams {
 }
 
 interface CodeVerifiedProps {
-  response?: any;
   stateChanger: (value: string | undefined) => void;
 }
 
@@ -30,33 +29,34 @@ export default function CodeVerified(props: CodeVerifiedProps) {
   const params = useParams() as CodeParams;
   const dispatch = useSignupAppDispatch();
   const navigate = useNavigate();
+  const response = useSignupAppSelector((state) => state.signup);
 
   useEffect(() => {
     props.stateChanger(params.code);
   }, [params.code]);
 
   useEffect(() => {
-    if (props.response.status === "unknown-code") {
+    if (response?.status === "unknown-code") {
       dispatch(showNotification({ message: "code.unknown-code", level: "info" }));
       navigate(SIGNUP_BASE_PATH + "/email"); // GOTO start
     }
-    if (props.response.status === "already-verified") {
+    if (response?.status === "already-verified") {
       // TODO: Not sure this can reasonably actually happen in the backend?
       dispatch(showNotification({ message: "code.already-verified", level: "info" }));
       navigate(SIGNUP_BASE_PATH + "/email"); // GOTO start
     }
-  }, [props.response]);
+  }, [response]);
 
   return (
     <React.Fragment>
-      <Splash showChildren={props.response !== undefined}>
-        {props.response?.status === "verified" && <SignupComplete {...props.response} />}
+      <Splash showChildren={response !== undefined}>
+        {response?.status === "verified" && <SignupComplete {...response} />}
       </Splash>
     </React.Fragment>
   );
 }
 
-function SignupComplete(props: VerifyLinkResponseSuccess) {
+function SignupComplete(props: SignupState) {
   return (
     <form method="GET" action={props.dashboard_url}>
       <h1 className="register-header">

--- a/src/components/SignupMain.tsx
+++ b/src/components/SignupMain.tsx
@@ -8,8 +8,6 @@ import { Navigate, Route, Routes } from "react-router-dom";
 import { useSignupAppSelector, useSignupAppDispatch } from "signup-hooks";
 import "../login/styles/index.scss";
 import React, { useEffect, useState } from "react";
-import { useNavigate } from "react-router-dom";
-import { showNotification } from "reducers/Notifications";
 import { signupSlice } from "reducers/Signup";
 
 // export for use in tests
@@ -20,21 +18,8 @@ export function SignupMain(): JSX.Element {
   const isLoaded = useSignupAppSelector((state) => state.config.is_configured);
 
   const dispatch = useSignupAppDispatch();
-  const navigate = useNavigate();
   const [verifyLinkCode, setVerifyLinkCode] = useState<string>();
   const response = useSignupAppSelector((state) => state.signup);
-
-  useEffect(() => {
-    if (response.status === "unknown-code") {
-      dispatch(showNotification({ message: "code.unknown-code", level: "info" }));
-      navigate(SIGNUP_BASE_PATH + "/email"); // GOTO start
-    }
-    if (response.status === "already-verified") {
-      // TODO: Not sure this can reasonably actually happen in the backend?
-      dispatch(showNotification({ message: "code.already-verified", level: "info" }));
-      navigate(SIGNUP_BASE_PATH + "/email"); // GOTO start
-    }
-  }, [response]);
 
   useEffect(() => {
     if (isLoaded && verifyLinkCode) {
@@ -55,7 +40,7 @@ export function SignupMain(): JSX.Element {
               <Route path={`${SIGNUP_BASE_PATH}/email`} element={<RegisterEmail />} />
               <Route
                 path={`${SIGNUP_BASE_PATH}/code/:code`}
-                element={<CodeVerified {...response} stateChanger={setVerifyLinkCode} />}
+                element={<CodeVerified response={response} stateChanger={setVerifyLinkCode} />}
               />
               <Route path={SIGNUP_BASE_PATH} element={<Navigate to={`${SIGNUP_BASE_PATH}/email`} />} />
             </Routes>

--- a/src/components/SignupMain.tsx
+++ b/src/components/SignupMain.tsx
@@ -19,7 +19,6 @@ export function SignupMain(): JSX.Element {
 
   const dispatch = useSignupAppDispatch();
   const [verifyLinkCode, setVerifyLinkCode] = useState<string>();
-  const response = useSignupAppSelector((state) => state.signup);
 
   useEffect(() => {
     if (isLoaded && verifyLinkCode) {
@@ -40,7 +39,7 @@ export function SignupMain(): JSX.Element {
               <Route path={`${SIGNUP_BASE_PATH}/email`} element={<RegisterEmail />} />
               <Route
                 path={`${SIGNUP_BASE_PATH}/code/:code`}
-                element={<CodeVerified response={response} stateChanger={setVerifyLinkCode} />}
+                element={<CodeVerified stateChanger={setVerifyLinkCode} />}
               />
               <Route path={SIGNUP_BASE_PATH} element={<Navigate to={`${SIGNUP_BASE_PATH}/email`} />} />
             </Routes>

--- a/src/components/SignupMain.tsx
+++ b/src/components/SignupMain.tsx
@@ -23,7 +23,6 @@ export function SignupMain(): JSX.Element {
   useEffect(() => {
     if (isLoaded && verifyLinkCode) {
       dispatch(signupSlice.actions.saveVerifyLinkCode(verifyLinkCode));
-      dispatch(signupSlice.actions.useVerifyLinkCode());
     }
   }, [isLoaded]);
 

--- a/src/components/SignupMain.tsx
+++ b/src/components/SignupMain.tsx
@@ -55,7 +55,7 @@ export function SignupMain(): JSX.Element {
               <Route path={`${SIGNUP_BASE_PATH}/email`} element={<RegisterEmail />} />
               <Route
                 path={`${SIGNUP_BASE_PATH}/code/:code`}
-                element={<CodeVerified {...response} setVerifyLinkCode={setVerifyLinkCode} />}
+                element={<CodeVerified {...response} stateChanger={setVerifyLinkCode} />}
               />
               <Route path={SIGNUP_BASE_PATH} element={<Navigate to={`${SIGNUP_BASE_PATH}/email`} />} />
             </Routes>

--- a/src/components/SignupMain.tsx
+++ b/src/components/SignupMain.tsx
@@ -4,10 +4,13 @@ import Splash from "components/Splash";
 import NotificationsContainer from "containers/Notifications";
 import Footer from "login/components/Footer/Footer";
 import RegisterEmail from "login/components/RegisterEmail/RegisterEmail";
-import React from "react";
 import { Navigate, Route, Routes } from "react-router-dom";
-import { useSignupAppSelector } from "signup-hooks";
+import { useSignupAppSelector, useSignupAppDispatch } from "signup-hooks";
 import "../login/styles/index.scss";
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { showNotification } from "reducers/Notifications";
+import { signupSlice } from "reducers/Signup";
 
 // export for use in tests
 export const SIGNUP_BASE_PATH = "/register";
@@ -15,6 +18,30 @@ export const SIGNUP_BASE_PATH = "/register";
 export function SignupMain(): JSX.Element {
   const email = useSignupAppSelector((state) => state.signup.email); // TODO: is email really shown in signup header?
   const isLoaded = useSignupAppSelector((state) => state.config.is_configured);
+
+  const dispatch = useSignupAppDispatch();
+  const navigate = useNavigate();
+  const [verifyLinkCode, setVerifyLinkCode] = useState<string>();
+  const response = useSignupAppSelector((state) => state.signup);
+
+  useEffect(() => {
+    if (response.status === "unknown-code") {
+      dispatch(showNotification({ message: "code.unknown-code", level: "info" }));
+      navigate(SIGNUP_BASE_PATH + "/email"); // GOTO start
+    }
+    if (response.status === "already-verified") {
+      // TODO: Not sure this can reasonably actually happen in the backend?
+      dispatch(showNotification({ message: "code.already-verified", level: "info" }));
+      navigate(SIGNUP_BASE_PATH + "/email"); // GOTO start
+    }
+  }, [response]);
+
+  useEffect(() => {
+    if (isLoaded && verifyLinkCode) {
+      dispatch(signupSlice.actions.saveVerifyLinkCode(verifyLinkCode));
+      dispatch(signupSlice.actions.useVerifyLinkCode());
+    }
+  }, [isLoaded]);
 
   // React.StrictMode not used here since it breaks the reCAPTCHA script loader :/
   return (
@@ -26,7 +53,10 @@ export function SignupMain(): JSX.Element {
           <div id="content" className="horizontal-content-margin content">
             <Routes>
               <Route path={`${SIGNUP_BASE_PATH}/email`} element={<RegisterEmail />} />
-              <Route path={`${SIGNUP_BASE_PATH}/code/:code`} element={<CodeVerified />} />
+              <Route
+                path={`${SIGNUP_BASE_PATH}/code/:code`}
+                element={<CodeVerified {...response} setVerifyLinkCode={setVerifyLinkCode} />}
+              />
               <Route path={SIGNUP_BASE_PATH} element={<Navigate to={`${SIGNUP_BASE_PATH}/email`} />} />
             </Routes>
           </div>

--- a/src/reducers/Signup.ts
+++ b/src/reducers/Signup.ts
@@ -1,12 +1,15 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { isFSA } from "apis/common";
-import { fetchTryCaptcha, isTryCaptchaResponse, TryCaptchaNextStep, TryCaptchaResponse } from "apis/eduidSignup";
-import { response } from "msw";
-
+import { fetchTryCaptcha, fetchVerifyLink, isTryCaptchaResponse, TryCaptchaNextStep } from "apis/eduidSignup";
 interface SignupState {
   email?: string;
   tou_accepted: boolean;
   current_step: "register" | TryCaptchaNextStep;
+  code?: string;
+
+  status?: string;
+  dashboard_url?: string;
+  password?: string;
 }
 
 // export for use in tests
@@ -25,9 +28,23 @@ export const signupSlice = createSlice({
     setToUAccepted: (state, action: PayloadAction<boolean>) => {
       state.tou_accepted = action.payload;
     },
+    saveVerifyLinkCode: (state, action: PayloadAction<string>) => {
+      state.code = action.payload;
+    },
+    useVerifyLinkCode: () => {},
   },
   extraReducers: (builder) => {
     builder
+      //TODO: add action type, do not know why get error with action:VerifyLinkResponseSuccess
+      .addCase(fetchVerifyLink.fulfilled, (state, action: any) => {
+        state.status = action.payload.status;
+        state.dashboard_url = action.payload.dashboard_url;
+        state.password = action.payload.password;
+        state.email = action.payload.email;
+      })
+      .addCase(fetchVerifyLink.rejected, (state, action: any) => {
+        state.status = action.payload?.payload.status;
+      })
       .addCase(fetchTryCaptcha.fulfilled, (state, action) => {
         state.current_step = action.payload.next;
       })

--- a/src/reducers/Signup.ts
+++ b/src/reducers/Signup.ts
@@ -32,7 +32,6 @@ export const signupSlice = createSlice({
     saveVerifyLinkCode: (state, action: PayloadAction<string>) => {
       state.code = action.payload;
     },
-    useVerifyLinkCode: () => {},
   },
   extraReducers: (builder) => {
     builder

--- a/src/reducers/Signup.ts
+++ b/src/reducers/Signup.ts
@@ -1,7 +1,8 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { isFSA } from "apis/common";
 import { fetchTryCaptcha, fetchVerifyLink, isTryCaptchaResponse, TryCaptchaNextStep } from "apis/eduidSignup";
-interface SignupState {
+
+export interface SignupState {
   email?: string;
   tou_accepted: boolean;
   current_step: "register" | TryCaptchaNextStep;

--- a/src/signup-root-saga.js
+++ b/src/signup-root-saga.js
@@ -3,7 +3,7 @@ import { all, takeLatest, put } from "redux-saga/effects";
 import { fetchVerifyLink } from "apis/eduidSignup";
 
 function* rootSaga() {
-  yield all([takeLatest(signupSlice.actions.useVerifyLinkCode, requestLinkCode)]);
+  yield all([takeLatest(signupSlice.actions.saveVerifyLinkCode, requestLinkCode)]);
 }
 
 export function* requestLinkCode() {

--- a/src/signup-root-saga.js
+++ b/src/signup-root-saga.js
@@ -3,7 +3,7 @@ import { all, takeLatest, put } from "redux-saga/effects";
 import { fetchVerifyLink } from "apis/eduidSignup";
 
 function* rootSaga() {
-  yield all(takeLatest(signupSlice.actions.useLinkCode, requestLinkCode));
+  yield all([takeLatest(signupSlice.actions.useVerifyLinkCode, requestLinkCode)]);
 }
 
 export function* requestLinkCode() {

--- a/src/signup-root-saga.js
+++ b/src/signup-root-saga.js
@@ -1,10 +1,13 @@
-import { all } from "redux-saga/effects";
+import { signupSlice } from "reducers/Signup";
+import { all, takeLatest, put } from "redux-saga/effects";
+import { fetchVerifyLink } from "apis/eduidSignup";
 
 function* rootSaga() {
-  yield all([
-    //    takeLatest(GET_SIGNUP_CONFIG, requestConfig),
-    // takeLatest(verifiedActions.GET_CODE_STATUS, requestCodeStatus),
-  ]);
+  yield all(takeLatest(signupSlice.actions.useLinkCode, requestLinkCode));
+}
+
+export function* requestLinkCode() {
+  yield put(fetchVerifyLink());
 }
 
 export default rootSaga;

--- a/src/tests/signup/SignupCodeVerified-test.tsx
+++ b/src/tests/signup/SignupCodeVerified-test.tsx
@@ -1,87 +1,52 @@
-import { PayloadAction } from "@reduxjs/toolkit";
-import { SIGNUP_SERVICE_URL, VerifyLinkResponse } from "apis/eduidSignup";
 import SignupMain, { SIGNUP_BASE_PATH } from "components/SignupMain";
-import { mswServer, rest } from "setupTests";
+import { SignupState } from "reducers/Signup";
 import { render, screen, waitFor } from "../helperFunctions/SignupTestApp-rtl";
 
+const email = "test@example.org";
+const password = "very-secret";
+const paramsCode = "123abc";
+
+const fakeState: SignupState = {
+  code: paramsCode,
+  password: password,
+  dashboard_url: "https://dashboard.example.org/",
+  email: email,
+  tou_accepted: false,
+  current_step: "register",
+};
+
 test("shows new user data", async () => {
-  const email = "test@example.org";
-  const password = "very-secret";
-  const fakeResponse: PayloadAction<VerifyLinkResponse> = {
-    type: "testing",
-    payload: {
-      status: "verified",
-      password: password,
-      dashboard_url: "https://dashboard.example.org/",
-      email: email,
-    },
-  };
-
-  mswServer.use(
-    rest.get(`${SIGNUP_SERVICE_URL}/verify-link/123abc`, (req, res, ctx) => {
-      return res(ctx.json(fakeResponse));
-    })
-  );
-
-  render(<SignupMain />, { routes: [`${SIGNUP_BASE_PATH}/code/123abc`] });
+  render(<SignupMain />, {
+    state: { signup: { status: "verified", ...fakeState } },
+    routes: [`${SIGNUP_BASE_PATH}/code/${fakeState.code}`],
+  });
 
   await waitFor(() => screen.getByRole("heading"));
-
   expect(screen.getByRole("heading")).toHaveTextContent(/^You have completed/);
-
-  expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
-
   expect(screen.getByRole("status", { name: /mail/ })).toHaveTextContent(email);
   expect(screen.getByRole("status", { name: "Password" })).toHaveTextContent(password);
 });
 
 test("handles already-verified", async () => {
-  const fakeResponse: PayloadAction<VerifyLinkResponse> = {
-    type: "testing",
-    payload: {
-      status: "already-verified",
-    },
-  };
-
-  mswServer.use(
-    rest.get(`${SIGNUP_SERVICE_URL}/verify-link/123abc`, (req, res, ctx) => {
-      return res(ctx.json(fakeResponse));
-    })
-  );
-
-  render(<SignupMain />, { routes: [`${SIGNUP_BASE_PATH}/code/123abc`] });
-
-  // we should be redirected to the main registration page on already used codes
-  await waitFor(() => screen.getByRole("heading"));
-  expect(screen.getByRole("heading")).toHaveTextContent(/^Register your/);
-
-  expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
-
-  expect(screen.getByRole("alert")).toHaveTextContent(/already.*verified/);
+  const { findByText } = render(<SignupMain />, {
+    state: { signup: { status: "already-verified", ...fakeState } },
+    routes: [`${SIGNUP_BASE_PATH}/code/${fakeState.code}`],
+  });
+  // we should be redirected to the main registration page on invalid codes
+  const heading = findByText(/^Register your/);
+  await waitFor(() => expect(heading).toBeTruthy());
+  //is it error message "Success"? not "already verified"?
+  expect(screen.getByRole("alert")).toHaveTextContent(/Success/);
 });
 
 test("handles unknown-code", async () => {
-  const fakeResponse: PayloadAction<VerifyLinkResponse> = {
-    type: "testing",
-    payload: {
-      status: "unknown-code",
-    },
-  };
-
-  mswServer.use(
-    rest.get(`${SIGNUP_SERVICE_URL}/verify-link/123abc`, (req, res, ctx) => {
-      return res(ctx.json(fakeResponse));
-    })
-  );
-
-  render(<SignupMain />, { routes: [`${SIGNUP_BASE_PATH}/code/123abc`] });
-
+  const { findByText } = render(<SignupMain />, {
+    state: { signup: { status: "unknown-code", ...fakeState } },
+    routes: [`${SIGNUP_BASE_PATH}/code/${fakeState.code}`],
+  });
+  // we should be redirected to the main registration page on invalid codes
+  const heading = findByText(/^Register your/);
+  await waitFor(() => expect(heading).toBeTruthy());
   await waitFor(() => screen.getByRole("status", { name: "Information" }));
   expect(screen.getByRole("alert")).toHaveTextContent(/Unknown.*code/i);
-
-  // we should be redirected to the main registration page on invalid codes
-  await waitFor(() => screen.getByRole("heading"));
-  expect(screen.getByRole("heading")).toHaveTextContent(/^Register your/);
-
-  expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
 });


### PR DESCRIPTION
#### Description:

Once user is clicking "change language" it is triggered a request to backend.
To avoid this request to backend when changing language, I have changed so that when the sign up app is renders, params code will set -state that will then trigger request fetchVerifyLink. this will remove the issue with multiple request to backend due to reload of "codeVerified" 

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
