### PR TITLE
bugfix: have to remember verify-link response in redux state

### DIFF
--- a/src/components/CodeVerified.tsx
+++ b/src/components/CodeVerified.tsx
@@ -1,13 +1,12 @@
-import { isFSA } from "apis/common";
-import { fetchVerifyLink, isVerifyLinkResponse, VerifyLinkResponse, VerifyLinkResponseSuccess } from "apis/eduidSignup";
+import { fetchVerifyLink, VerifyLinkResponseSuccess } from "apis/eduidSignup";
 import EduIDButton from "components/EduIDButton";
 import Splash from "components/Splash";
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { FormattedMessage } from "react-intl";
 import { useParams } from "react-router";
 import { useNavigate } from "react-router-dom";
 import { showNotification } from "reducers/Notifications";
-import { useSignupAppDispatch } from "signup-hooks";
+import { useSignupAppDispatch, useSignupAppSelector } from "signup-hooks";
 import { SIGNUP_BASE_PATH } from "./SignupMain";
 
 // element ids used in tests
@@ -26,24 +25,11 @@ export default function CodeVerified() {
   const dispatch = useSignupAppDispatch();
   const navigate = useNavigate();
   const params = useParams() as CodeParams;
-  const [response, setResponse] = useState<VerifyLinkResponse>();
-
-  async function verifyCode(code: string) {
-    const resp = await dispatch(fetchVerifyLink({ code }));
-
-    if (fetchVerifyLink.fulfilled.match(resp)) {
-      setResponse(resp.payload);
-    }
-    if (fetchVerifyLink.rejected.match(resp)) {
-      if (isFSA(resp.payload) && isVerifyLinkResponse(resp.payload.payload)) {
-        setResponse(resp.payload.payload);
-      }
-    }
-  }
+  const response = useSignupAppSelector((state) => state.signup.verify_link_response);
 
   useEffect(() => {
     if (!response && params?.code) {
-      verifyCode(params.code);
+      dispatch(fetchVerifyLink({ code: params.code }));
     }
   }, []);
 

--- a/src/reducers/Signup.ts
+++ b/src/reducers/Signup.ts
@@ -1,12 +1,21 @@
 import { createSlice, PayloadAction } from "@reduxjs/toolkit";
 import { isFSA } from "apis/common";
-import { fetchTryCaptcha, isTryCaptchaResponse, TryCaptchaNextStep, TryCaptchaResponse } from "apis/eduidSignup";
-import { response } from "msw";
+import {
+  fetchTryCaptcha,
+  fetchVerifyLink,
+  isTryCaptchaResponse,
+  TryCaptchaNextStep,
+  VerifyLinkResponse,
+} from "apis/eduidSignup";
 
 interface SignupState {
   email?: string;
   tou_accepted: boolean;
   current_step: "register" | TryCaptchaNextStep;
+  // Fetching verify-link is a one-shot operation, so we have to store the response in
+  // redux state (rather than in component state) in case switching language causes us
+  // to re-render the component
+  verify_link_response?: VerifyLinkResponse;
 }
 
 // export for use in tests
@@ -45,6 +54,9 @@ export const signupSlice = createSlice({
            */
           state.current_step = action.payload.payload.next;
         }
+      })
+      .addCase(fetchVerifyLink.fulfilled, (state, action) => {
+        state.verify_link_response = action.payload;
       });
   },
 });

--- a/src/reducers/Signup.ts
+++ b/src/reducers/Signup.ts
@@ -4,6 +4,7 @@ import {
   fetchTryCaptcha,
   fetchVerifyLink,
   isTryCaptchaResponse,
+  isVerifyLinkResponse,
   TryCaptchaNextStep,
   VerifyLinkResponse,
 } from "apis/eduidSignup";
@@ -57,6 +58,12 @@ export const signupSlice = createSlice({
       })
       .addCase(fetchVerifyLink.fulfilled, (state, action) => {
         state.verify_link_response = action.payload;
+      })
+      .addCase(fetchVerifyLink.rejected, (state, action) => {
+        // action.payload is the whole JSON response from the backend (or some other error)
+        if (isFSA(action.payload) && isVerifyLinkResponse(action.payload.payload)) {
+          state.verify_link_response = action.payload.payload;
+        }
       });
   },
 });


### PR DESCRIPTION
The backend currently only allows fetching this data once, so in order to still have it after a language switch causes the component to re-render, we have to put it in the redux state instead of in component state.

#### Description:

[Replace this with a description of what you've done - if styling-related work please include a screenshot]

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
