### PR TITLE
Not send request when cancelling add process for adding security key

### DIFF
--- a/src/login/app_utils/helperFunctions/navigatorCredential.ts
+++ b/src/login/app_utils/helperFunctions/navigatorCredential.ts
@@ -68,22 +68,22 @@ export const createCredential = createAsyncThunk(
   "eduid/credentials/createCredential",
   async (webauthn_challenge: string, thunkAPI): Promise<webauthnAttestation | undefined> => {
     const decoded_challenge = decodeChallenge(webauthn_challenge);
-    const credential = await navigator.credentials
-      .create(decoded_challenge)
-      .then()
-      .catch(() => {
-        // create credential failed / cancelled
-        return thunkAPI.rejectWithValue("Create credential failed, or was cancelled");
-      });
-
-    if (credential instanceof PublicKeyCredential && credential.response instanceof AuthenticatorAttestationResponse) {
-      // encode the credential into strings that can be stored in the state
-      const encoded_credential: webauthnAttestation = {
-        attestationObject: safeEncode(credential.response.attestationObject),
-        clientDataJSON: safeEncode(credential.response.clientDataJSON),
-        credentialId: safeEncode(credential.rawId),
-      };
-      return encoded_credential;
+    const credential = await navigator.credentials.create(decoded_challenge);
+    try {
+      if (
+        credential instanceof PublicKeyCredential &&
+        credential.response instanceof AuthenticatorAttestationResponse
+      ) {
+        // encode the credential into strings that can be stored in the state
+        const encoded_credential: webauthnAttestation = {
+          attestationObject: safeEncode(credential.response.attestationObject),
+          clientDataJSON: safeEncode(credential.response.clientDataJSON),
+          credentialId: safeEncode(credential.rawId),
+        };
+        return encoded_credential;
+      }
+    } catch (e) {
+      thunkAPI.rejectWithValue("Credential creation failed, or was cancelled");
     }
   }
 );

--- a/src/login/app_utils/helperFunctions/navigatorCredential.ts
+++ b/src/login/app_utils/helperFunctions/navigatorCredential.ts
@@ -42,15 +42,9 @@ export const decodeChallenge = (webauthn_options: string): { [key: string]: any 
  */
 export const performAuthentication = createAsyncThunk(
   "eduid/credentials/performAuthentication",
-  async (webauthn_challenge: string, thunkAPI): Promise<webauthnAssertion | undefined> => {
+  async (webauthn_challenge: string, thunkAPI) => {
     const decoded_challenge = decodeChallenge(webauthn_challenge);
-    const assertion = await navigator.credentials
-      .get(decoded_challenge)
-      .then()
-      .catch(() => {
-        // assertion failed / cancelled
-        return thunkAPI.rejectWithValue("Authentication failed, or was cancelled");
-      });
+    const assertion = await navigator.credentials.get(decoded_challenge).then().catch();
     if (assertion instanceof PublicKeyCredential && assertion.response instanceof AuthenticatorAssertionResponse) {
       // encode the assertion into strings that can be stored in the state
       const encoded_assertion: webauthnAssertion = {
@@ -61,6 +55,8 @@ export const performAuthentication = createAsyncThunk(
       };
       return encoded_assertion;
     }
+    // assertion failed / cancelled
+    return thunkAPI.rejectWithValue("Authentication failed, or was cancelled");
   }
 );
 
@@ -79,6 +75,7 @@ export const createCredential = createAsyncThunk(
       };
       return encoded_credential;
     }
+    // create credential failed / cancelled
     return thunkAPI.rejectWithValue("Credential creation failed, or was cancelled");
   }
 );

--- a/src/login/app_utils/helperFunctions/navigatorCredential.ts
+++ b/src/login/app_utils/helperFunctions/navigatorCredential.ts
@@ -66,24 +66,19 @@ export const performAuthentication = createAsyncThunk(
 
 export const createCredential = createAsyncThunk(
   "eduid/credentials/createCredential",
-  async (webauthn_challenge: string, thunkAPI): Promise<webauthnAttestation | undefined> => {
+  async (webauthn_challenge: string, thunkAPI) => {
     const decoded_challenge = decodeChallenge(webauthn_challenge);
-    const credential = await navigator.credentials.create(decoded_challenge);
-    try {
-      if (
-        credential instanceof PublicKeyCredential &&
-        credential.response instanceof AuthenticatorAttestationResponse
-      ) {
-        // encode the credential into strings that can be stored in the state
-        const encoded_credential: webauthnAttestation = {
-          attestationObject: safeEncode(credential.response.attestationObject),
-          clientDataJSON: safeEncode(credential.response.clientDataJSON),
-          credentialId: safeEncode(credential.rawId),
-        };
-        return encoded_credential;
-      }
-    } catch (e) {
-      thunkAPI.rejectWithValue("Credential creation failed, or was cancelled");
+    const credential = await navigator.credentials.create(decoded_challenge).then().catch();
+
+    if (credential instanceof PublicKeyCredential && credential.response instanceof AuthenticatorAttestationResponse) {
+      // encode the credential into strings that can be stored in the state
+      const encoded_credential: webauthnAttestation = {
+        attestationObject: safeEncode(credential.response.attestationObject),
+        clientDataJSON: safeEncode(credential.response.clientDataJSON),
+        credentialId: safeEncode(credential.rawId),
+      };
+      return encoded_credential;
     }
+    return thunkAPI.rejectWithValue("Credential creation failed, or was cancelled");
   }
 );


### PR DESCRIPTION
#### Description:

fixed issue regarding when user cancelling process of adding security key, previous user received an error message "form error"

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
