### PR TITLE
Fixed so that the SMS phone button will not be displayed when user has selected security key

### DIFF
--- a/src/login/components/LoginApp/ResetPassword/ExtraSecurity.tsx
+++ b/src/login/components/LoginApp/ResetPassword/ExtraSecurity.tsx
@@ -221,7 +221,7 @@ export function ExtraSecurity(): JSX.Element | null {
         />
       )}
       {extra_security.external_mfa && !selected_option && <ExternalMFA handleOnClickFreja={handleOnClickFreja} />}
-      {extra_security.phone_numbers && (
+      {extra_security.phone_numbers && !selected_option && (
         <SecurityWithSMSButton
           requestedPhoneCode={requestedPhoneCode}
           extraSecurityPhone={extra_security.phone_numbers}

--- a/src/tests/login/LoginResetPasswordExtraSecurity-test.tsx
+++ b/src/tests/login/LoginResetPasswordExtraSecurity-test.tsx
@@ -1,0 +1,71 @@
+import {
+  NewPasswordRequest,
+  NewPasswordResponse,
+  VerifyCodeRequest,
+  VerifyCodeResponse,
+} from "apis/eduidResetPassword";
+import { LoginMain } from "login/components/LoginMain";
+import { mswServer, rest } from "setupTests";
+import { fireEvent, render, screen, waitFor } from "../helperFunctions/LoginTestApp-rtl";
+
+test("renders extra security screen as expected", async () => {
+  const email = "test@example.org";
+  const code = "0c860943-540f-4ce6-aebf-e874f4efd7c1";
+  const password = "very-secret";
+  mswServer.use(
+    rest.post("/reset-password-url/verify-email", (req, res, ctx) => {
+      const body = req.body as VerifyCodeRequest;
+      if (body.email_code != code) {
+        return res(ctx.status(400));
+      }
+      const payload: VerifyCodeResponse = {
+        suggested_password: password,
+        email_code: code,
+        email_address: email,
+        extra_security: {
+          external_mfa: true,
+          phone_numbers: [{ number: "07012312344", index: 0 }],
+          tokens: { webauthn_options: "dummy-webauthn-options" },
+        },
+        success: true,
+        zxcvbn_terms: [],
+      };
+      return res(ctx.json({ type: "test response", payload: payload }));
+    }),
+    rest.post("/reset-password-url/new-password-extra-security-token", (req, res, ctx) => {
+      const body = req.body as NewPasswordRequest;
+      if (body.email_code != code || body.password != password) {
+        return res(ctx.status(400));
+      }
+      const payload: NewPasswordResponse = {};
+      return res(ctx.json({ type: "test response", payload: payload }));
+    })
+  );
+
+  mswServer.printHandlers();
+
+  render(<LoginMain />, { routes: [`/reset-password/email-code/${code}`] });
+
+  // Wait for the extra security screen to be displayed
+  await waitFor(() => {
+    expect(screen.getByRole("heading", { name: /^select an extra security option/i })).toBeInTheDocument();
+  });
+
+  const securityKeyButton = screen.getByRole("button", { name: /^use security key/i });
+  expect(securityKeyButton).toBeEnabled();
+
+  const phoneCodeButton = screen.getByRole("button", { name: /Send sms to .*/i });
+  expect(phoneCodeButton).toBeEnabled();
+
+  const frejaeIDButton = screen.getByRole("button", { name: /^use my Freja eID/i });
+  expect(frejaeIDButton).toBeEnabled();
+
+  fireEvent.click(securityKeyButton);
+
+  // Wait for the selected security key screen to be displayed
+  await waitFor(() => {
+    expect(screen.getByText(/Use your security key .*has a button, tap it./i)).toBeInTheDocument();
+    expect(phoneCodeButton).not.toBeInTheDocument();
+    expect(frejaeIDButton).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
#### Description:
issue: 
![Screenshot 2022-11-18 at 11 05 00](https://user-images.githubusercontent.com/44289056/202676293-b05c193a-49d2-4677-9192-ff446216ea0b.png)

fixed:

![Screenshot 2022-11-18 at 11 05 39](https://user-images.githubusercontent.com/44289056/202676372-c07628ce-7a44-4072-9654-03972fb9b6fb.png)


#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
