### PR TITLE
Fix enter phone code link not presented

### DIFF
--- a/src/login/components/LoginApp/ResetPassword/ExtraSecurity.tsx
+++ b/src/login/components/LoginApp/ResetPassword/ExtraSecurity.tsx
@@ -132,15 +132,14 @@ function SecurityWithSMSButton({
           );
         })}
       </div>
-      {requestedPhoneCode.index !== undefined && (
-        <p className="enter-phone-code">
-          <FormattedMessage description="received sms" defaultMessage="Already received sms?" />
-          &nbsp;
-          <a className="text-link" onClick={toPhoneCodeForm}>
-            <FormattedMessage description="enter code" defaultMessage="enter code" />
-          </a>
-        </p>
-      )}
+
+      <p className="enter-phone-code">
+        <FormattedMessage description="received sms" defaultMessage="Already received sms?" />
+        &nbsp;
+        <a className={`text-link ${requestedPhoneCode.index === undefined && "disabled"}`} onClick={toPhoneCodeForm}>
+          <FormattedMessage description="enter code" defaultMessage="enter code" />
+        </a>
+      </p>
     </React.Fragment>
   );
 }
@@ -189,7 +188,7 @@ export function ExtraSecurity(): JSX.Element | null {
 
   function toPhoneCodeForm() {
     dispatch(clearNotifications());
-    navigate("/reset-password/phone-code");
+    navigate("/reset-password/phone-code-sent");
   }
 
   function continueSetPassword() {

--- a/src/login/components/LoginApp/ResetPassword/ExtraSecurity.tsx
+++ b/src/login/components/LoginApp/ResetPassword/ExtraSecurity.tsx
@@ -136,7 +136,11 @@ function SecurityWithSMSButton({
       <p className="enter-phone-code">
         <FormattedMessage description="received sms" defaultMessage="Already received sms?" />
         &nbsp;
-        <a className={`text-link ${requestedPhoneCode.index === undefined && "disabled"}`} onClick={toPhoneCodeForm}>
+        <a
+          className={`text-link ${requestedPhoneCode.index === undefined && "disabled"}`}
+          role="link"
+          onClick={toPhoneCodeForm}
+        >
           <FormattedMessage description="enter code" defaultMessage="enter code" />
         </a>
       </p>

--- a/src/login/styles/_links.scss
+++ b/src/login/styles/_links.scss
@@ -21,9 +21,11 @@ a,
   }
 }
 
-a .disabled {
+a .disabled,
+.text-link.disabled {
   color: $txt-gray;
   text-decoration: none;
+  pointer-events: none;
 
   &:hover {
     cursor: not-allowed;

--- a/src/tests/login/LoginResetPasswordExtraSecurity-test.tsx
+++ b/src/tests/login/LoginResetPasswordExtraSecurity-test.tsx
@@ -57,6 +57,8 @@ test("renders extra security screen as expected", async () => {
   const phoneCodeButton = screen.getByRole("button", { name: /Send sms to .*/i });
   expect(phoneCodeButton).toBeEnabled();
 
+  expect(screen.getByRole("link", { name: /enter code/i })).toBeInTheDocument();
+
   const frejaeIDButton = screen.getByRole("button", { name: /^use my Freja eID/i });
   expect(frejaeIDButton).toBeEnabled();
 


### PR DESCRIPTION
#### Description:

During testing of staging it was found the enter phone code link was not showing properly on "reset password" 
Now rectified and added a test to confirm that the enter code link is showing in the view.

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
