### PR TITLE
fix problem with collapse of accordion onclick after verification of foreign id

### DIFF
--- a/src/components/VerifyIdentity.tsx
+++ b/src/components/VerifyIdentity.tsx
@@ -190,7 +190,7 @@ function VerifiedIdentitiesTable(): JSX.Element {
                   </td>
                   <td>
                     <strong>
-                      <FormattedMessage defaultMessage="Svipe ID" description="Verified identity" />
+                      <FormattedMessage defaultMessage="Foreign Svipe identity" description="Verified identity" />
                     </strong>
                   </td>
                   <td>

--- a/src/components/VerifyIdentity.tsx
+++ b/src/components/VerifyIdentity.tsx
@@ -217,7 +217,7 @@ function VerifiedIdentitiesTable(): JSX.Element {
               defaultMessage={`Verify your eduID with a Swedish national ID number.`}
             />
           </p>
-          <Accordion>
+          <Accordion allowZeroExpanded>
             <AccordionItemSwedish />
           </Accordion>
         </React.Fragment>

--- a/src/login/translation/extractedMessages.json
+++ b/src/login/translation/extractedMessages.json
@@ -67,6 +67,10 @@
     "developer_comment": "ToU first paragraph",
     "string": "that SUNET's ethical rules regulate the “other” usage."
   },
+  "0xT3Pl": {
+    "developer_comment": "Verified identity",
+    "string": "Foreign Svipe identity"
+  },
   "12hWj7": {
     "developer_comment": "ErrorURL authentication failure",
     "string": "You may need to confirm your identity in the eduID Dashboard before trying again."
@@ -1234,10 +1238,6 @@
   "exo9+K": {
     "developer_comment": "eidas freja instructions step2",
     "string": "Create a Freja eID Plus account (awarded the \"Svensk e-legitimation\" quality mark)"
-  },
-  "f6zYSE": {
-    "developer_comment": "Verified identity",
-    "string": "Svipe ID"
   },
   "fEKz/1": {
     "developer_comment": "Personal data update locked names",


### PR DESCRIPTION
#### Description:
- Add allowZeroExpanded for accordion 
- Svipe -> Foreign Svipe identity 

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
