### PR TITLE
The remove button has been changed to be hidden when only one security key is registered

### DIFF
--- a/src/components/Security.tsx
+++ b/src/components/Security.tsx
@@ -259,14 +259,16 @@ function SecurityKeyTable(props: RequestCredentialsResponse) {
           {date_success}
         </td>
         <td>{btnVerify}</td>
-        <td>
-          <EduIDButton
-            id="remove-webauthn"
-            buttonstyle="close"
-            size="sm"
-            onClick={() => handleRemoveWebauthnToken(cred.key)}
-          ></EduIDButton>
-        </td>
+        {tokens.length > 1 ? (
+          <td>
+            <EduIDButton
+              id="remove-webauthn"
+              buttonstyle="close"
+              size="sm"
+              onClick={() => handleRemoveWebauthnToken(cred.key)}
+            ></EduIDButton>
+          </td>
+        ) : null}
       </tr>
     );
   });

--- a/src/login/components/Modals/ConfirmModal.tsx
+++ b/src/login/components/Modals/ConfirmModal.tsx
@@ -49,11 +49,9 @@ function ConfirmModal(props: ConfirmModalProps): JSX.Element {
               <form
                 id={props.id + "-form"}
                 role="form"
-                onSubmit={(event) =>
-                  handleSubmit(event)?.then(() => {
-                    form.reset();
-                  })
-                }
+                onSubmit={(event) => {
+                  handleSubmit(event), form.reset();
+                }}
               >
                 <ModalBody>
                   <img src={props.captchaImage} />

--- a/src/tests/Security-test.tsx
+++ b/src/tests/Security-test.tsx
@@ -12,9 +12,7 @@ import securitySlice, { initialState } from "reducers/Security";
 import { mswServer, rest } from "setupTests";
 import { fireEvent, render, screen, waitFor } from "./helperFunctions/DashboardTestApp-rtl";
 
-test("renders security key as expected, not security key added", async () => {
-  render(<DashboardMain />);
-
+async function linkToAdvancedSettings() {
   // Navigate to Advanced settings
   const nav = screen.getByRole("link", { name: "Advanced settings" });
   act(() => {
@@ -23,6 +21,11 @@ test("renders security key as expected, not security key added", async () => {
 
   expect(screen.getByRole("heading", { name: /Make your eduID more secure/i })).toBeInTheDocument();
   expect(screen.getByRole("button", { name: "security key" })).toBeEnabled();
+}
+
+test("renders security key as expected, not security key added", async () => {
+  render(<DashboardMain />);
+  await linkToAdvancedSettings();
 });
 
 test("renders security key as expected, with added security key", async () => {
@@ -53,11 +56,7 @@ test("renders security key as expected, with added security key", async () => {
     },
   });
 
-  // Navigate to Advanced settings
-  const nav = screen.getByRole("link", { name: "Advanced settings" });
-  act(() => {
-    nav.click();
-  });
+  await linkToAdvancedSettings();
 
   expect(screen.getByRole("table")).toBeInTheDocument();
   expect(screen.getByRole("cell", { name: "touchID" })).toBeInTheDocument();
@@ -66,11 +65,7 @@ test("renders security key as expected, with added security key", async () => {
 
 test("renders modals onclick security key button", async () => {
   render(<DashboardMain />);
-  // Navigate to Advanced settings
-  const nav = screen.getByRole("link", { name: "Advanced settings" });
-  act(() => {
-    nav.click();
-  });
+  await linkToAdvancedSettings();
   const securityKeyButton = screen.getByRole("button", { name: "security key" });
   // Click the 'security key' button
   act(() => {
@@ -85,6 +80,30 @@ test("renders modals onclick security key button", async () => {
   expect(addSecurityKeyButton).toBeEnabled();
 });
 
+test("should not display close button when only one security key is added", async () => {
+  render(<DashboardMain />, {
+    state: {
+      security: {
+        credentials: [
+          {
+            created_ts: "2021-12-02",
+            credential_type: "security.webauthn_credential_type",
+            description: "touchID",
+            key: "dummy dummy",
+            success_ts: "2022-10-17",
+            used_for_login: false,
+            verified: false,
+          },
+        ],
+      },
+    },
+  });
+  await linkToAdvancedSettings();
+
+  const CloseButton = screen.getAllByLabelText("Close")[1];
+  expect(CloseButton).toBeUndefined();
+});
+
 test("can remove a security key", async () => {
   render(<DashboardMain />, {
     state: {
@@ -94,6 +113,15 @@ test("can remove a security key", async () => {
             created_ts: "2021-12-02",
             credential_type: "security.webauthn_credential_type",
             description: "touchID",
+            key: "dummy dummy",
+            success_ts: "2022-10-17",
+            used_for_login: false,
+            verified: false,
+          },
+          {
+            created_ts: "2021-12-02",
+            credential_type: "security.webauthn_credential_type",
+            description: "extra touchID",
             key: "dummy dummy",
             success_ts: "2022-10-17",
             used_for_login: false,
@@ -112,11 +140,7 @@ test("can remove a security key", async () => {
       },
     },
   });
-  // Navigate to Advanced settings
-  const nav = screen.getByRole("link", { name: "Advanced settings" });
-  act(() => {
-    nav.click();
-  });
+  await linkToAdvancedSettings();
 
   const CloseButton = screen.getAllByLabelText("Close")[1];
   expect(CloseButton).toBeEnabled();
@@ -161,10 +185,7 @@ test("api call webauthn/remove", async () => {
   render(<DashboardMain />, {
     state: { security: { credentials: response.credentials } },
   });
-  const nav = screen.getByRole("link", { name: "Advanced settings" });
-  act(() => {
-    nav.click();
-  });
+  await linkToAdvancedSettings();
   await waitFor(() => {
     expect(screen.getByRole("table")).toBeInTheDocument();
   });


### PR DESCRIPTION
#### Description:

1. The remove button has been changed to be hidden when only one security key is registered
2. Fixed a issue where the form was not being reset after the form submission in the confirmation modal.
3. Updated tests to reflect security component updates.

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
