### PR TITLE
Improved "letterproofing" on the start page

### DIFF
--- a/src/components/DashboardStart.tsx
+++ b/src/components/DashboardStart.tsx
@@ -62,7 +62,7 @@ function VerificationProgress(props: { identities: UserIdentities }): JSX.Elemen
  * Currently process of letter proofing and/or verification of identity
  */
 function LetterProofingProgress(props: { letter_proofing: LetterProofingState }): JSX.Element | null {
-  let letterStatus;
+  let letterStatus, helpText;
 
   if (!props.letter_proofing.letter_sent) {
     return null;
@@ -70,20 +70,90 @@ function LetterProofingProgress(props: { letter_proofing: LetterProofingState })
 
   if (props.letter_proofing.letter_expired) {
     letterStatus = (
-      <FormattedMessage description="Verification letter expired" defaultMessage="Verification letter expired" />
+      <FormattedMessage
+        description="Verification letter expired, status"
+        defaultMessage="A verification letter has been expired"
+      />
     );
-  } else
+    helpText = (
+      <FormattedMessage
+        description="Verification letter expired, help text"
+        defaultMessage="To request a new letter, please follow the steps below"
+      />
+    );
+  } else {
     letterStatus = (
-      <FormattedMessage description="Verification letter requested" defaultMessage="Verification letter requested" />
+      <FormattedMessage
+        description="Verification letter requested, status"
+        defaultMessage="A verification letter has been requested."
+      />
     );
+    helpText = (
+      <FormattedMessage
+        description="Verification letter requested, help text"
+        defaultMessage="Once you receive the letter, please follow steps to enter the code."
+      />
+    );
+  }
 
   return (
-    <div className="data-container">
-      {letterStatus}
-      <Link to="verify-identity/#letter-proofing">
-        <FormattedMessage description="link to detail page" defaultMessage="order a new code" />
-      </Link>
-    </div>
+    <>
+      <figure className="status letter-proofing">
+        <h3>{letterStatus}</h3>
+        <p className="help-text">{helpText}</p>
+      </figure>
+      <div className="steps">
+        <h4>
+          <FormattedMessage description="help text" defaultMessage="Steps:" />
+        </h4>
+        <ol className="listed-steps">
+          <li>
+            <FormattedMessage
+              description="help text"
+              defaultMessage={`{Identity} `}
+              values={{
+                Identity: (
+                  <Link to="verify-identity/#letter-proofing">
+                    <FormattedMessage description="link to detail page" defaultMessage="Go to the Identity" />
+                  </Link>
+                ),
+              }}
+            />
+          </li>
+          <li>
+            <FormattedMessage
+              description="help text"
+              defaultMessage={`Select the {Swedish_personal_ID_number}. `}
+              values={{ Swedish_personal_ID_number: <strong>Swedish personal ID number</strong> }}
+            />
+          </li>
+          <li>
+            <FormattedMessage
+              description="help text"
+              defaultMessage={`Select the {BY_POST} option below the {verify_id_number}. `}
+              values={{ BY_POST: <strong>BY POST</strong>, verify_id_number: <strong>Verify your ID number</strong> }}
+            />
+          </li>
+          <li>
+            <FormattedMessage
+              description="help text"
+              defaultMessage={`Press the {Proceed} button. `}
+              values={{ Proceed: <strong>PROCEED</strong> }}
+            />
+          </li>
+          {/* display this only when the letter has not expired. */}
+          {!props.letter_proofing.letter_expired && (
+            <li>
+              <FormattedMessage
+                description="help text"
+                defaultMessage={`Enter the {code} in the modal. `}
+                values={{ code: <strong>Code</strong> }}
+              />
+            </li>
+          )}
+        </ol>
+      </div>
+    </>
   );
 }
 

--- a/src/components/DashboardStart.tsx
+++ b/src/components/DashboardStart.tsx
@@ -5,16 +5,18 @@ import { fetchLetterProofingState } from "apis/eduidLetterProofing";
 import { UserIdentities } from "apis/eduidPersonalData";
 import { useDashboardAppDispatch, useDashboardAppSelector } from "dashboard-hooks";
 import React, { useEffect } from "react";
+import { Accordion } from "react-accessible-accordion";
 import { FormattedMessage, useIntl } from "react-intl";
-import { Link } from "react-router-dom";
 import { LetterProofingState } from "reducers/LetterProofing";
+import AccordionItemTemplate from "./AccordionItemTemplate";
 import { DashboardBreadcrumbs } from "./DashboardBreadcrumbs";
+import LetterProofing from "./LetterProofing";
 import { Recommendations } from "./Recommendations";
 
 function VerificationProgress(props: { identities: UserIdentities }): JSX.Element {
   if (!props.identities.is_verified) {
     return (
-      <figure className="verification-status unverified">
+      <figure className="status unverified">
         <FontAwesomeIcon icon={faCircleExclamation as IconProp} />
         <div>
           <h3>
@@ -41,7 +43,7 @@ function VerificationProgress(props: { identities: UserIdentities }): JSX.Elemen
     );
   }
   return (
-    <div className="verification-status verified">
+    <div className="status verified">
       <FontAwesomeIcon icon={faCircleCheck as IconProp} />
       <div>
         <h3>
@@ -90,70 +92,18 @@ function LetterProofingProgress(props: { letter_proofing: LetterProofingState })
     );
     helpText = (
       <FormattedMessage
-        description="Verification letter requested, help text"
-        defaultMessage="Once you receive the letter, please follow steps to enter the code."
+        defaultMessage="Add the code you have received by post"
+        description="explanation text for letter proofing"
       />
     );
   }
 
   return (
-    <>
-      <figure className="status letter-proofing">
-        <h3>{letterStatus}</h3>
-        <p className="help-text">{helpText}</p>
-      </figure>
-      <div className="steps">
-        <h4>
-          <FormattedMessage description="help text" defaultMessage="Steps:" />
-        </h4>
-        <ol className="listed-steps">
-          <li>
-            <FormattedMessage
-              description="help text"
-              defaultMessage={`{Identity} `}
-              values={{
-                Identity: (
-                  <Link to="verify-identity/#letter-proofing">
-                    <FormattedMessage description="link to detail page" defaultMessage="Go to the Identity" />
-                  </Link>
-                ),
-              }}
-            />
-          </li>
-          <li>
-            <FormattedMessage
-              description="help text"
-              defaultMessage={`Select the {Swedish_personal_ID_number}. `}
-              values={{ Swedish_personal_ID_number: <strong>Swedish personal ID number</strong> }}
-            />
-          </li>
-          <li>
-            <FormattedMessage
-              description="help text"
-              defaultMessage={`Select the {BY_POST} option below the {verify_id_number}. `}
-              values={{ BY_POST: <strong>BY POST</strong>, verify_id_number: <strong>Verify your ID number</strong> }}
-            />
-          </li>
-          <li>
-            <FormattedMessage
-              description="help text"
-              defaultMessage={`Press the {Proceed} button. `}
-              values={{ Proceed: <strong>PROCEED</strong> }}
-            />
-          </li>
-          {/* display this only when the letter has not expired. */}
-          {!props.letter_proofing.letter_expired && (
-            <li>
-              <FormattedMessage
-                description="help text"
-                defaultMessage={`Enter the {code} in the modal. `}
-                values={{ code: <strong>Code</strong> }}
-              />
-            </li>
-          )}
-        </ol>
-      </div>
-    </>
+    <Accordion allowMultipleExpanded allowZeroExpanded preExpanded={["se-letter"]}>
+      <AccordionItemTemplate title={letterStatus} additionalInfo={helpText} uuid="se-letter" disabled={false}>
+        <LetterProofing disabled={false} />
+      </AccordionItemTemplate>
+    </Accordion>
   );
 }
 
@@ -231,8 +181,8 @@ export default function Start(): JSX.Element {
 
         <VerificationProgress identities={identities} />
       </article>
-      <Recommendations />
       {progress}
+      <Recommendations />
     </React.Fragment>
   );
 }

--- a/src/components/DashboardStart.tsx
+++ b/src/components/DashboardStart.tsx
@@ -64,7 +64,7 @@ function VerificationProgress(props: { identities: UserIdentities }): JSX.Elemen
  * Currently process of letter proofing and/or verification of identity
  */
 function LetterProofingProgress(props: { letter_proofing: LetterProofingState }): JSX.Element | null {
-  let letterStatus, helpText;
+  let letterStatus;
 
   if (!props.letter_proofing.letter_sent) {
     return null;
@@ -77,12 +77,6 @@ function LetterProofingProgress(props: { letter_proofing: LetterProofingState })
         defaultMessage="A verification letter has been expired"
       />
     );
-    helpText = (
-      <FormattedMessage
-        description="Verification letter expired, help text"
-        defaultMessage="To request a new letter, please follow the steps below"
-      />
-    );
   } else {
     letterStatus = (
       <FormattedMessage
@@ -90,17 +84,11 @@ function LetterProofingProgress(props: { letter_proofing: LetterProofingState })
         defaultMessage="A verification letter has been requested."
       />
     );
-    helpText = (
-      <FormattedMessage
-        defaultMessage="Add the code you have received by post"
-        description="explanation text for letter proofing"
-      />
-    );
   }
 
   return (
     <Accordion allowMultipleExpanded allowZeroExpanded preExpanded={["se-letter"]}>
-      <AccordionItemTemplate title={letterStatus} additionalInfo={helpText} uuid="se-letter" disabled={false}>
+      <AccordionItemTemplate title={letterStatus} additionalInfo="" uuid="se-letter" disabled={false}>
         <LetterProofing disabled={false} />
       </AccordionItemTemplate>
     </Accordion>

--- a/src/components/VerifyIdentity.tsx
+++ b/src/components/VerifyIdentity.tsx
@@ -20,6 +20,7 @@ import NinDisplay from "./NinDisplay";
 
 /* UUIDs of accordion elements that we want to selectively pre-expand */
 type accordionUUID = "swedish" | "eu" | "world";
+type accordionSwedishUUID = "se-freja" | "se-letter" | "se-phone";
 
 function VerifyIdentity(): JSX.Element | null {
   const isAppLoaded = useDashboardAppSelector((state) => state.config.is_app_loaded);
@@ -251,6 +252,7 @@ function VerifiedIdentitiesTable(): JSX.Element {
 function AccordionItemSwedish(): JSX.Element | null {
   const nin = useDashboardAppSelector((state) => state.identities.nin);
   const phones = useDashboardAppSelector((state) => state.phones.phones);
+  const letter_sent = useDashboardAppSelector((state) => state.letter_proofing.letter_sent);
   const hasVerifiedSwePhone = phones?.some((phone) => phone.verified && phone.number.startsWith("+46"));
   // this is where the buttons are generated
   const addedNin = Boolean(nin);
@@ -259,6 +261,15 @@ function AccordionItemSwedish(): JSX.Element | null {
   const letterProofingDisabled = !addedNin;
   // proofing via mobile requires the user to have added a NIN first, and have a verified Swedish mobile phone
   const lookupMobileDisabled = !addedNin || !hasVerifiedSwePhone;
+
+  const preExpanded: accordionSwedishUUID[] = ["se-freja"];
+
+  if (letter_sent !== undefined) {
+    preExpanded.push("se-letter");
+  }
+  if (hasVerifiedSwePhone) {
+    preExpanded.push("se-phone");
+  }
 
   /* Show step two ("use one of these options to verify your NIN") only after step 1 (enter your NIN) is complete,
      and not in case the NIN is already verified. */
@@ -293,7 +304,12 @@ function AccordionItemSwedish(): JSX.Element | null {
               defaultMessage={`Choose a suitable method to verify that you have access to the added id number.`}
             />
           </p>
-          <Accordion allowMultipleExpanded allowZeroExpanded className="accordion accordion-nested x-adjust">
+          <Accordion
+            allowMultipleExpanded
+            allowZeroExpanded
+            className="accordion accordion-nested x-adjust"
+            preExpanded={preExpanded}
+          >
             <AccordionItemTemplate
               title={
                 <FormattedMessage description="eidas vetting button freja" defaultMessage={`with a digital ID-card`} />

--- a/src/login/styles/_DashboardMain.scss
+++ b/src/login/styles/_DashboardMain.scss
@@ -114,46 +114,4 @@
   &.verified svg {
     color: $success-green;
   }
-
-  &.letter-proofing {
-    display: block;
-  }
-}
-
-.steps {
-  text-align: left;
-  background: $white;
-  border-left: 4px solid $txt-orange;
-  border-left-color: $txt-orange;
-  padding: 1rem;
-  .listed-steps li {
-    margin-bottom: 0.5em;
-  }
-  h4 {
-    font-family: $inter-bold;
-    margin-bottom: 2.5rem;
-    margin-top: 0.5rem;
-  }
-}
-
-.progress-container {
-  @extend figure;
-  text-align: left;
-
-  div {
-    display: grid;
-    grid-template-columns: 1fr 1fr;
-    margin-bottom: 1rem;
-    align-items: center;
-    p {
-      margin-bottom: 0;
-    }
-    @media (max-width: $bp-sm) {
-      grid-template-columns: 1fr;
-
-      & :last-child {
-        margin-left: 0;
-      }
-    }
-  }
 }

--- a/src/login/styles/_DashboardMain.scss
+++ b/src/login/styles/_DashboardMain.scss
@@ -80,7 +80,7 @@
 }
 
 // --- VERIFICATION PROGRESS STYLES--- //
-.verification-status {
+.status {
   @extend figure;
 
   display: flex;
@@ -114,27 +114,46 @@
   &.verified svg {
     color: $success-green;
   }
-}
 
-.data-container :last-child {
-  margin-left: 2rem;
-}
-
-.data-container {
-  @extend figure;
-
-  display: flex;
-  align-items: center;
-
-  a {
-    font-size: 0.9rem;
+  &.letter-proofing {
+    display: block;
   }
+}
 
-  @media (max-width: $bp-sm) {
-    flex-direction: column;
+.steps {
+  text-align: left;
+  background: $white;
+  border-left: 4px solid $txt-orange;
+  border-left-color: $txt-orange;
+  padding: 1rem;
+  .listed-steps li {
+    margin-bottom: 0.5em;
+  }
+  h4 {
+    font-family: $inter-bold;
+    margin-bottom: 2.5rem;
+    margin-top: 0.5rem;
+  }
+}
 
-    & :last-child {
-      margin-left: 0;
+.progress-container {
+  @extend figure;
+  text-align: left;
+
+  div {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    margin-bottom: 1rem;
+    align-items: center;
+    p {
+      margin-bottom: 0;
+    }
+    @media (max-width: $bp-sm) {
+      grid-template-columns: 1fr;
+
+      & :last-child {
+        margin-left: 0;
+      }
     }
   }
 }


### PR DESCRIPTION
#### Description:

I have enabled users to perform "letterproofing" on the start page and added logic to expand the accordion on the identity page based on the user's state.

- During the letterproofing process, the user will encounter an accordion on the start page, allowing them to enter the code.

![Screenshot 2023-07-03 at 14 43 50](https://github.com/SUNET/eduid-front/assets/44289056/df8dd2c9-a199-4dfe-878d-40a8d90d25c7)

- Accordion expansion is determined by the user's ability to proceed with letterproofing or if phone verification is enabled.

![Screenshot 2023-07-03 at 14 44 07](https://github.com/SUNET/eduid-front/assets/44289056/b6b9d974-4a76-435a-8638-24d67229e741)

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
