### PR TITLE
Fix, Swedish ID number is already entered, but the description text i…

### DIFF
--- a/src/components/Dashboard/LookupMobileProofing.tsx
+++ b/src/components/Dashboard/LookupMobileProofing.tsx
@@ -3,7 +3,7 @@ import { fetchIdentities, requestAllPersonalData } from "apis/eduidPersonalData"
 import EduIDButton from "components/EduIDButton";
 import NotificationModal from "components/NotificationModal";
 import { useDashboardAppDispatch, useDashboardAppSelector } from "dashboard-hooks";
-import { useState } from "react";
+import { Fragment, useState } from "react";
 import { FormattedMessage } from "react-intl";
 import { HashLink } from "react-router-hash-link";
 import { clearNotifications } from "slices/Notifications";
@@ -22,43 +22,40 @@ function ExplanationText(): JSX.Element {
     </HashLink>
   );
 
-  if (nin) {
-    if (phones === undefined || phones.length === 0) {
-      return (
-        <FormattedMessage
-          defaultMessage="Start by adding your Swedish phone number in {linkToSettings}"
-          description="verify identity vetting explanation add phone number"
-          values={{ linkToSettings: linkToSettings }}
-        />
-      );
-    } else {
-      if (phones.some((num) => num.verified === false)) {
-        return (
-          <FormattedMessage
-            defaultMessage="Confirm your phone number in {linkToSettings}"
-            description="verify identity vetting explanation verify phone"
-            values={{ linkToSettings: linkToSettings }}
-          />
-        );
-      } else {
-        if (!phones.some((num) => num.number.startsWith("+46"))) {
-          return (
-            <FormattedMessage
-              defaultMessage="Only possible with Swedish phone number"
-              description="verify identity vetting explanation add swedish phone"
-              values={{ linkToSettings: linkToSettings }}
-            />
-          );
-        }
-      }
-    }
+  if (!nin) {
+    return (
+      <FormattedMessage
+        defaultMessage="Start by adding your ID number above"
+        description="verify identity vetting explanation add nin"
+      />
+    );
+  } else if (phones === undefined || phones.length === 0) {
+    return (
+      <FormattedMessage
+        defaultMessage="Start by adding your Swedish phone number in {linkToSettings}"
+        description="verify identity vetting explanation add phone number"
+        values={{ linkToSettings: linkToSettings }}
+      />
+    );
+  } else if (phones.some((num) => num.verified === false)) {
+    return (
+      <FormattedMessage
+        defaultMessage="Confirm your phone number in {linkToSettings}"
+        description="verify identity vetting explanation verify phone"
+        values={{ linkToSettings: linkToSettings }}
+      />
+    );
+  } else if (!phones.some((num) => num.number.startsWith("+46"))) {
+    return (
+      <FormattedMessage
+        defaultMessage="Only possible with Swedish phone number"
+        description="verify identity vetting explanation add swedish phone"
+        values={{ linkToSettings: linkToSettings }}
+      />
+    );
+  } else {
+    return <Fragment />;
   }
-  return (
-    <FormattedMessage
-      defaultMessage="Start by adding your ID number above"
-      description="verify identity vetting explanation add nin"
-    />
-  );
 }
 
 function LookupMobileProofing(props: LookupMobileProofingProps): JSX.Element {


### PR DESCRIPTION
…ncorrectly indicates that the user needs to enter the Swedish ID number

#### Description:
The user has already entered their personal number and verified their phone code. However, the user is prompted to enter personal number.

 - Issue 
![Screenshot 2023-08-08 at 11 00 23](https://github.com/SUNET/eduid-front/assets/44289056/6ea583a1-68ba-44ec-b704-b3a66d43a0ba)

- Fixed 

![Screenshot 2023-08-08 at 10 58 19](https://github.com/SUNET/eduid-front/assets/44289056/2e4140d5-2771-4755-aced-ac7557af9371)




#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
