### PR TITLE
fix minor issues

### DIFF
--- a/src/components/Dashboard/LetterProofing.tsx
+++ b/src/components/Dashboard/LetterProofing.tsx
@@ -101,7 +101,7 @@ export default function LetterProofing(props: LetterProofingProps): JSX.Element 
           </p>
           <p className="description">
             <FormattedMessage
-              defaultMessage="Click here to order a new code"
+              defaultMessage="To request a new code, proceed by clicking the button below."
               description="explanation text for letter proofing"
             />
           </p>

--- a/src/styles/_DashboardMain.scss
+++ b/src/styles/_DashboardMain.scss
@@ -8,6 +8,10 @@
   .display-nin-show-hide {
     display: flex;
 
+    .display-data {
+      width: 200px;
+    }
+
     // show and hide button
     button {
       margin-left: 1rem;

--- a/src/styles/_buttons.scss
+++ b/src/styles/_buttons.scss
@@ -134,7 +134,6 @@ button.btn-link {
   &:not(:disabled):not(.disabled):active:focus {
     color: $txt-orange;
     background-color: transparent;
-    transform: scale(1);
     text-decoration: underline;
     box-shadow: none;
   }

--- a/src/tests/LetterProofing-test.tsx
+++ b/src/tests/LetterProofing-test.tsx
@@ -46,7 +46,7 @@ test("renders LetterProofing, expired letter enabled to resend letter", async ()
       },
     },
   });
-  expect(screen.getByText(/Click here to order a new code/i)).toBeInTheDocument();
+  expect(screen.getByText(/To request a new code, proceed by clicking the button below./i)).toBeInTheDocument();
   const button = screen.getByRole("button", { name: /proceed/i });
   expect(button).toBeEnabled();
   act(() => {


### PR DESCRIPTION
#### Description:
- Updated description text when the letter is expired.
- Added width for personal number to prevent the button from moving when the show/hide button is clicked 
```
    .display-data {
      width: 200px;
    }
```
 ![Screenshot 2023-08-10 at 10 54 29](https://github.com/SUNET/eduid-front/assets/44289056/9b3a1295-b892-4275-95a8-b3eee5e04752)

- Removed the effect of letters moving slightly when hovering


#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
