### PR TITLE
current-password -> currentPassword

### DIFF
--- a/src/styles/_SignupMain.scss
+++ b/src/styles/_SignupMain.scss
@@ -2,7 +2,7 @@
   flex: 1;
 }
 
-#current-password-wrapper {
+#currentPassword-wrapper {
   margin-top: 2rem !important;
 }
 

--- a/src/styles/_inputs.scss
+++ b/src/styles/_inputs.scss
@@ -156,7 +156,7 @@ input:focus {
   display: flex;
   position: relative;
 
-  input[name="current-password"].is-valid {
+  input[name="currentPassword"].is-valid {
     background-image: none;
   }
 }


### PR DESCRIPTION
#### Description:

![Screenshot 2023-09-06 at 09 05 46](https://github.com/SUNET/eduid-front/assets/44289056/ebbb0c5a-4e39-407b-a02f-be340dd53229)

I changed the input name from "current-password" to "currentPassword" before, which is why the unique ID styling was not applied.

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
