### PR TITLE
help translatable formatted text and typo

### DIFF
--- a/src/components/Help.tsx
+++ b/src/components/Help.tsx
@@ -428,7 +428,14 @@ export function Help(): JSX.Element {
                     description="verification methods - list definition"
                     defaultMessage="{emphasis}, verifying it can be done via:"
                     values={{
-                      emphasis: <strong>If you have a Swedish personal identity number</strong>,
+                      emphasis: (
+                        <strong>
+                          <FormattedMessage
+                            description="swedish nin - heading"
+                            defaultMessage={`If you have a Swedish personal identity number`}
+                          />
+                        </strong>
+                      ),
                     }}
                   />
                 </p>
@@ -440,7 +447,11 @@ export function Help(): JSX.Element {
                       registered at Skatteverket (the Swedish Tax Agency), and instructions on how to complete the 
                       verification on eduid.se,`}
                       values={{
-                        post: <em>post:</em>,
+                        post: (
+                          <em>
+                            <FormattedMessage description="swedish nin post - heading" defaultMessage="post:" />
+                          </em>
+                        ),
                       }}
                     />
                   </li>
@@ -451,7 +462,11 @@ export function Help(): JSX.Element {
                       in the Swedish telephone register, and instructions on how to complete the verification on 
                       eduid.se,`}
                       values={{
-                        mobile: <em>mobile:</em>,
+                        mobile: (
+                          <em>
+                            <FormattedMessage description="swedish nin mobile - heading" defaultMessage="mobile:" />
+                          </em>
+                        ),
                       }}
                     />
                   </li>
@@ -462,7 +477,14 @@ export function Help(): JSX.Element {
                       use their service. If you don't have Freja+ you have to create it separately before you can
                       complete verification of your eduID. Read more about Freja+ below.`}
                       values={{
-                        freja: <em>Freja+ (digital ID-card):</em>,
+                        freja: (
+                          <em>
+                            <FormattedMessage
+                              description="swedish nin freja - heading"
+                              defaultMessage="Freja+ (digital ID-card):"
+                            />
+                          </em>
+                        ),
                       }}
                     />
                   </li>
@@ -475,7 +497,14 @@ export function Help(): JSX.Element {
                     defaultMessage={`{strong}, you could use 
                     {emphasis} to verify your identity. Read more about eIDAS below.`}
                     values={{
-                      strong: <strong>If you are an EU citizen and without a Swedish personal identity number</strong>,
+                      strong: (
+                        <strong>
+                          <FormattedMessage
+                            description="method eidas - heading"
+                            defaultMessage={`If you are an EU citizen and without a Swedish personal identity number`}
+                          />
+                        </strong>
+                      ),
                       emphasis: <em>eIDAS</em>,
                     }}
                   />
@@ -489,7 +518,12 @@ export function Help(): JSX.Element {
                     Read more about Svipe iD below.`}
                     values={{
                       strong: (
-                        <strong>If you are not an EU citizen and without a Swedish personal identity number</strong>
+                        <strong>
+                          <FormattedMessage
+                            description="method svipe - heading"
+                            defaultMessage={`If you are not an EU citizen and without a Swedish personal identity number`}
+                          />
+                        </strong>
                       ),
                       emphasis: <em>Svipe eID</em>,
                     }}
@@ -836,7 +870,7 @@ export function Help(): JSX.Element {
                         href="https://sunet.se/om-sunet/behandling-av-personuppgifter-i-eduid"
                         target="_blank"
                       >
-                        Privacy policy
+                        <FormattedMessage description="privacy policy - link" defaultMessage="Privacy policy" />
                       </a>
                     ),
                   }}
@@ -912,18 +946,21 @@ export function Help(): JSX.Element {
               <p>
                 <FormattedMessage
                   description="what is accessibility report - paragraph 1"
-                  defaultMessage={`Read the full {accessability} regarding the eduID site at Sunets website, where you 
+                  defaultMessage={`Read the full {accessibility} regarding the eduID site at Sunets website, where you 
                   also find instructions on how to report accessibility issues. The report addresses how eduID adheres 
                   to the Swedish law governing accessibility to digital public services as well as currently known 
                   issues of the site (in Swedish).`}
                   values={{
-                    accessability: (
+                    accessibility: (
                       <a
                         className="text-link"
                         href="https://sunet.se/om-sunet/tillganglighet-for-eduid-se"
                         target="_blank"
                       >
-                        Accessibility report
+                        <FormattedMessage
+                          description="accessibility report - link"
+                          defaultMessage="Accessibility report"
+                        />
                       </a>
                     ),
                   }}
@@ -1018,7 +1055,14 @@ export function Help(): JSX.Element {
                   defaultMessage="{strong}, but for simple
               matters you can also reach us on phone number {phone}."
                   values={{
-                    strong: <strong>In order to get best possible support, we recommend that you send e-mail</strong>,
+                    strong: (
+                      <strong>
+                        <FormattedMessage
+                          description="how to contact support email - strong"
+                          defaultMessage={`In order to get best possible support, we recommend that you send e-mail`}
+                        />
+                      </strong>
+                    ),
                     phone: (
                       <a className="text-link" href="tel:+46455-385200">
                         0455-385200

--- a/src/components/Help.tsx
+++ b/src/components/Help.tsx
@@ -424,87 +424,69 @@ export function Help(): JSX.Element {
               </p>
               <section>
                 <p>
+                  <strong>
+                    <FormattedMessage
+                      description="swedish nin - heading"
+                      defaultMessage={`If you have a Swedish personal identity number`}
+                    />
+                  </strong>
                   <FormattedMessage
                     description="verification methods - list definition"
-                    defaultMessage="{emphasis}, verifying it can be done via:"
-                    values={{
-                      emphasis: (
-                        <strong>
-                          <FormattedMessage
-                            description="swedish nin - heading"
-                            defaultMessage={`If you have a Swedish personal identity number`}
-                          />
-                        </strong>
-                      ),
-                    }}
+                    defaultMessage=", verifying it can be done via:"
                   />
                 </p>
                 <ul className="bullets">
                   <li>
+                    <em>
+                      <FormattedMessage description="swedish nin post - heading" defaultMessage="post:" />
+                    </em>
                     <FormattedMessage
                       description="verification methods - list item 1"
-                      defaultMessage={`{post} the user receives a letter with a code sent to their home address as 
+                      defaultMessage={` the user receives a letter with a code sent to their home address as 
                       registered at Skatteverket (the Swedish Tax Agency), and instructions on how to complete the 
                       verification on eduid.se,`}
-                      values={{
-                        post: (
-                          <em>
-                            <FormattedMessage description="swedish nin post - heading" defaultMessage="post:" />
-                          </em>
-                        ),
-                      }}
                     />
                   </li>
                   <li>
+                    <em>
+                      <FormattedMessage description="swedish nin mobile - heading" defaultMessage="mobile:" />
+                    </em>
                     <FormattedMessage
                       description="verification methods - list item 2"
-                      defaultMessage={`{mobile} the user receives a message sent to the phone number that is registered 
+                      defaultMessage={` the user receives a message sent to the phone number that is registered 
                       in the Swedish telephone register, and instructions on how to complete the verification on 
                       eduid.se,`}
-                      values={{
-                        mobile: (
-                          <em>
-                            <FormattedMessage description="swedish nin mobile - heading" defaultMessage="mobile:" />
-                          </em>
-                        ),
-                      }}
                     />
                   </li>
                   <li>
+                    <em>
+                      <FormattedMessage
+                        description="swedish nin freja - heading"
+                        defaultMessage="Freja+ (digital ID-card):"
+                      />
+                    </em>
                     <FormattedMessage
                       description="verification methods - list item 3"
-                      defaultMessage={`{freja} the user will be directed to the Freja eID website to
+                      defaultMessage={` the user will be directed to the Freja eID website to
                       use their service. If you don't have Freja+ you have to create it separately before you can
                       complete verification of your eduID. Read more about Freja+ below.`}
-                      values={{
-                        freja: (
-                          <em>
-                            <FormattedMessage
-                              description="swedish nin freja - heading"
-                              defaultMessage="Freja+ (digital ID-card):"
-                            />
-                          </em>
-                        ),
-                      }}
                     />
                   </li>
                 </ul>
               </section>
               <section>
                 <p>
+                  <strong>
+                    <FormattedMessage
+                      description="method eidas - heading"
+                      defaultMessage={`If you are an EU citizen and without a Swedish personal identity number`}
+                    />
+                  </strong>
                   <FormattedMessage
                     description="method eidas - paragraph"
-                    defaultMessage={`{strong}, you could use 
+                    defaultMessage={`, you could use 
                     {emphasis} to verify your identity. Read more about eIDAS below.`}
                     values={{
-                      strong: (
-                        <strong>
-                          <FormattedMessage
-                            description="method eidas - heading"
-                            defaultMessage={`If you are an EU citizen and without a Swedish personal identity number`}
-                          />
-                        </strong>
-                      ),
                       emphasis: <em>eIDAS</em>,
                     }}
                   />
@@ -512,19 +494,17 @@ export function Help(): JSX.Element {
               </section>
               <section>
                 <p>
+                  <strong>
+                    <FormattedMessage
+                      description="method svipe - heading"
+                      defaultMessage={`If you are not an EU citizen and without a Swedish personal identity number`}
+                    />
+                  </strong>
                   <FormattedMessage
                     description="method svipe - paragraph"
-                    defaultMessage={`{strong}, you could use {emphasis} to verify your identity using your passport. 
+                    defaultMessage={`, you could use {emphasis} to verify your identity using your passport. 
                     Read more about Svipe iD below.`}
                     values={{
-                      strong: (
-                        <strong>
-                          <FormattedMessage
-                            description="method svipe - heading"
-                            defaultMessage={`If you are not an EU citizen and without a Swedish personal identity number`}
-                          />
-                        </strong>
-                      ),
                       emphasis: <em>Svipe eID</em>,
                     }}
                   />
@@ -1050,19 +1030,17 @@ export function Help(): JSX.Element {
                 />
               </p>
               <p>
+                <strong>
+                  <FormattedMessage
+                    description="how to contact support email - strong"
+                    defaultMessage={`In order to get best possible support, we recommend that you send e-mail`}
+                  />
+                </strong>
                 <FormattedMessage
                   description="how to contact support - paragraph 3"
-                  defaultMessage="{strong}, but for simple
+                  defaultMessage=", but for simple
               matters you can also reach us on phone number {phone}."
                   values={{
-                    strong: (
-                      <strong>
-                        <FormattedMessage
-                          description="how to contact support email - strong"
-                          defaultMessage={`In order to get best possible support, we recommend that you send e-mail`}
-                        />
-                      </strong>
-                    ),
                     phone: (
                       <a className="text-link" href="tel:+46455-385200">
                         0455-385200

--- a/src/translation/extractedMessages.json
+++ b/src/translation/extractedMessages.json
@@ -67,6 +67,10 @@
     "developer_comment": "Login OtherDevice",
     "string": "Retry"
   },
+  "/aIXqR": {
+    "developer_comment": "what is accessibility report - paragraph 1",
+    "string": "Read the full {accessibility} regarding the eduID site at Sunets website, where you also find instructions on how to report accessibility issues. The report addresses how eduID adheres to the Swedish law governing accessibility to digital public services as well as currently known issues of the site (in Swedish)."
+  },
   "/h666/": {
     "developer_comment": "select extra webauthn",
     "string": "Choose extra identification method:"
@@ -282,6 +286,10 @@
     "developer_comment": "Phone display title",
     "string": "Phone number"
   },
+  "58dN25": {
+    "developer_comment": "method eidas - heading",
+    "string": "If you are an EU citizen and without a Swedish personal identity number"
+  },
   "5P95+P": {
     "developer_comment": "Reset password add email heading",
     "string": "Enter the email address registered to your eduID account."
@@ -397,6 +405,10 @@
     "developer_comment": "explanation text for letter proofing",
     "string": "by post"
   },
+  "9ftFZW": {
+    "developer_comment": "swedish nin mobile - heading",
+    "string": "mobile:"
+  },
   "9t9vVw": {
     "developer_comment": "what is svipe - paragraph 1",
     "string": "Svipe iD is based on an identity verification platform using biometric documents from over 140 countries, e.g. passports and ID-cards, combined with the users mobile device face-recognition ability, to create a verified digital identity than can be used remotely."
@@ -452,6 +464,10 @@
   "BRcd2V": {
     "developer_comment": "how change language - paragraph",
     "string": "To change the default language you can log into eduID and select your language preference in the Personal information area in eduID. The default language is based on the language setting that your browser uses. You can also change the displayed language in the footer of the webpage. Available options are Swedish and English."
+  },
+  "C+b7F7": {
+    "developer_comment": "swedish nin - heading",
+    "string": "If you have a Swedish personal identity number"
   },
   "CBJ51T": {
     "developer_comment": "explanation text for letter proofing",
@@ -1008,6 +1024,10 @@
     "developer_comment": "Reset Password heading",
     "string": "Reset password"
   },
+  "SK2AK4": {
+    "developer_comment": "method svipe - heading",
+    "string": "If you are not an EU citizen and without a Swedish personal identity number"
+  },
   "SL6O2c": {
     "developer_comment": "Password label",
     "string": "Password"
@@ -1311,6 +1331,10 @@
     "developer_comment": "verify identity with swedish ID description",
     "string": "Verify your eduID with a Swedish national ID number."
   },
+  "b/o0DY": {
+    "developer_comment": "swedish nin freja - heading",
+    "string": "Freja+ (digital ID-card):"
+  },
   "bCIMPQ": {
     "developer_comment": "security key title",
     "string": "Make your eduID more secure"
@@ -1452,6 +1476,10 @@
   "dwXdVR": {
     "developer_comment": "when use eduID - heading",
     "string": "When will I use eduID?"
+  },
+  "e+YGAd": {
+    "developer_comment": "privacy policy - link",
+    "string": "Privacy policy"
   },
   "eIAskC": {
     "developer_comment": "Start",
@@ -1718,6 +1746,10 @@
     "developer_comment": "chpass old password label",
     "string": "Current password"
   },
+  "ibG0qO": {
+    "developer_comment": "accessibility report - link",
+    "string": "Accessibility report"
+  },
   "irC/sN": {
     "developer_comment": "Reset Password phone code sent",
     "string": "Enter the code sent to {phone}"
@@ -1757,6 +1789,10 @@
   "k8/V1T": {
     "developer_comment": "about eidas - handle",
     "string": "About eIDAS"
+  },
+  "kFNEXu": {
+    "developer_comment": "swedish nin post - heading",
+    "string": "post:"
   },
   "kHCeni": {
     "string": "Enter the six digit code sent to {email} to verify your email address. You can also copy and paste the code from the email into the input field."
@@ -2211,10 +2247,6 @@
   "pwfield.weak": {
     "string": "Weak password"
   },
-  "pyGKbH": {
-    "developer_comment": "what is accessibility report - paragraph 1",
-    "string": "Read the full {accessability} regarding the eduID site at Sunets website, where you also find instructions on how to report accessibility issues. The report addresses how eduID adheres to the Swedish law governing accessibility to digital public services as well as currently known issues of the site (in Swedish)."
-  },
   "pzYR/3": {
     "developer_comment": "ToU second paragraph",
     "string": "clearly wastes available resources (personnel, hardware or software)"
@@ -2246,6 +2278,10 @@
   "qJxWkn": {
     "developer_comment": "verify identity vetting explanation add nin",
     "string": "Start by adding your ID number above"
+  },
+  "qMRp3m": {
+    "developer_comment": "how to contact support email - strong",
+    "string": "In order to get best possible support, we recommend that you send e-mail"
   },
   "qS5PLP": {
     "developer_comment": "Reset Password button",


### PR DESCRIPTION
#### Description:

Nested formatted text tags (hope it works!) for language dependent "value" contents in FAQ page (some links, italics, bold).

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
