### PR TITLE
moved conditional inside cell to not brake layout

### DIFF
--- a/src/components/Dashboard/DataTable.tsx
+++ b/src/components/Dashboard/DataTable.tsx
@@ -73,11 +73,11 @@ function DataTableRows(props: DataTableProps) {
               />
             </td>
             {/* not render the close button when there is only one email */}
-            {(props.data && props.data?.length > 1 && valueName === "email") || valueName === "number" ? (
-              <td className="remove-data">
+            <td className="remove-data">
+              {(props.data && props.data?.length > 1 && valueName === "email") || valueName === "number" ? (
                 <EduIDButton buttonstyle="close" size="sm" onClick={props.handleRemove} />
-              </td>
-            ) : null}
+              ) : null}
+            </td>
           </tr>
         );
       })}


### PR DESCRIPTION
#### Description:

Moved email/phone conditional inside table cell to not affect column alignment if empty.

![Skärmavbild 2023-10-05 kl  14 10 10](https://github.com/SUNET/eduid-front/assets/79106074/deacda2c-54e8-4c53-9358-d8c162c56191)


#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
