### PR TITLE
When there is no input value, do not display an error, and keep the button disabled

### DIFF
--- a/src/components/Dashboard/NinForm.tsx
+++ b/src/components/Dashboard/NinForm.tsx
@@ -7,7 +7,7 @@ import { FormattedMessage, useIntl } from "react-intl";
 
 function validateNin(value: string): string | undefined {
   if (!value) {
-    return "required";
+    return undefined;
   }
   // accept only digits
   if (/[^0-9]+/.test(value)) return "nins.illegal_chars";
@@ -64,7 +64,7 @@ function NinForm(): JSX.Element {
       initialValues={{
         nin: nin?.number || "",
       }}
-      render={({ handleSubmit, pristine, invalid }) => {
+      render={({ handleSubmit, pristine, invalid, values }) => {
         return (
           <form onSubmit={handleSubmit} className="single-input-form x-adjust">
             <fieldset id="nins-form" className="tabpane">
@@ -85,7 +85,12 @@ function NinForm(): JSX.Element {
               />
             </fieldset>
             <div className="buttons">
-              <EduIDButton id="add-nin-button" buttonstyle="primary" disabled={pristine || invalid} type="submit">
+              <EduIDButton
+                id="add-nin-button"
+                buttonstyle="primary"
+                disabled={pristine || invalid || !values.nin}
+                type="submit"
+              >
                 <FormattedMessage description="button_add" defaultMessage="Add" />
               </EduIDButton>
             </div>


### PR DESCRIPTION
#### Description:
Considering that the error message appears to be necessary for users utilizing the Freja and Bank ID users, disable the button without presenting an error message when there is no value.

- before
![Screenshot 2023-11-21 at 15 37 44](https://github.com/SUNET/eduid-front/assets/44289056/7f617a22-4e0f-4f49-bfbc-3eba4908314e)

- after
![Screenshot 2023-11-21 at 15 37 15](https://github.com/SUNET/eduid-front/assets/44289056/f9998436-fe1e-4f9d-8dfe-cb09ecfaff9e)




#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
