### PR TITLE
Clear notification when the user receives a successful response

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -118,9 +118,9 @@
       }
     },
     "node_modules/@adobe/css-tools": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.2.0.tgz",
-      "integrity": "sha512-E09FiIft46CmH5Qnjb0wsW54/YQd69LsxeKUOWawmws1XWvyFGURnAChH0mlr7YPFR1ofwvUQfcL0J3lMxXqPA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
+      "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==",
       "dev": true
     },
     "node_modules/@ampproject/remapping": {
@@ -17769,9 +17769,9 @@
       "dev": true
     },
     "@adobe/css-tools": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.2.0.tgz",
-      "integrity": "sha512-E09FiIft46CmH5Qnjb0wsW54/YQd69LsxeKUOWawmws1XWvyFGURnAChH0mlr7YPFR1ofwvUQfcL0J3lMxXqPA==",
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.1.tgz",
+      "integrity": "sha512-/62yikz7NLScCGAAST5SHdnjaDJQBDq0M2muyRTpf2VQhw6StBg2ALiu73zSJQ4fMVLA+0uBhBHAle7Wg+2kSg==",
       "dev": true
     },
     "@ampproject/remapping": {

--- a/src/components/Dashboard/Phones.tsx
+++ b/src/components/Dashboard/Phones.tsx
@@ -64,10 +64,10 @@ function Phones() {
 
   async function handleAdd(values: PhoneFormData) {
     const number = toE164Number(values.number, default_country_code);
-
     if (number.startsWith("+")) {
       const response = await dispatch(postNewPhone({ number: number }));
       if (postNewPhone.fulfilled.match(response)) {
+        dispatch(clearNotifications());
         // phone number form closed when user have successfully added phone number
         return setShowPhoneForm(false);
       }


### PR DESCRIPTION
#### Description:

Issue: Even when the user receives a success response, the error message they previously received is still being presented. 

![Screenshot 2023-11-22 at 09 09 50](https://github.com/SUNET/eduid-front/assets/44289056/217d07e7-ef2f-4a6f-aa30-4b33dff92f3d)

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
