### PR TITLE
Add select display name

### DIFF
--- a/src/components/Common/PersonalDataForm.tsx
+++ b/src/components/Common/PersonalDataForm.tsx
@@ -89,7 +89,7 @@ function SelectDisplayName(): JSX.Element {
     if (given_name && surname) {
       setSelectedOptions(transformedOptions);
     }
-  }, [given_name, surname]);
+  }, [selectedOptions]);
 
   const handleSelectChange = (selectedOptions: [{ label: string; value: string }]) => {
     setSelectedOptions(selectedOptions);
@@ -103,7 +103,6 @@ function SelectDisplayName(): JSX.Element {
       <Select
         isMulti
         defaultValue={selectedOptions}
-        // defaultValue={displayName}
         name="display name"
         options={transformedOptions}
         onChange={() => handleSelectChange}

--- a/src/components/Common/PersonalDataForm.tsx
+++ b/src/components/Common/PersonalDataForm.tsx
@@ -11,6 +11,7 @@ import validatePersonalData from "helperFunctions/validation/validatePersonalDat
 import { Fragment } from "react";
 import { Field, Form as FinalForm } from "react-final-form";
 import { FormattedMessage } from "react-intl";
+import Select from "react-select";
 import { updateIntl } from "slices/Internationalisation";
 import CustomInput from "./CustomInput";
 import EduIDButton from "./EduIDButton";
@@ -57,7 +58,7 @@ export default function PersonalDataForm(props: PersonalDataFormProps) {
               {props.isVerifiedIdentity ? (
                 <RenderLockedNames labels={labels} />
               ) : (
-                <RenderEditableNames labels={labels} />
+                <RenderEditableNames labels={labels} displayName={personal_data?.display_name} />
               )}
             </fieldset>
             <RenderLanguageSelect />
@@ -143,7 +144,13 @@ const RenderLockedNames = (props: { labels: NameLabels }) => {
   );
 };
 
-function RenderEditableNames(props: { labels: NameLabels }) {
+function RenderEditableNames(props: { labels: NameLabels; displayName: string | undefined }) {
+  const splitDisplayName = props?.displayName?.split(" ") || props?.displayName?.split("-");
+  const transformedOptions = splitDisplayName?.map((name) => ({
+    label: name,
+    value: name,
+  }));
+
   return (
     <Fragment>
       <fieldset>
@@ -166,6 +173,28 @@ function RenderEditableNames(props: { labels: NameLabels }) {
           name="surname"
           label={props.labels.last}
           placeholder={props.labels.last}
+        />
+      </fieldset>
+      <fieldset>
+        <legend className="require">
+          <FormattedMessage defaultMessage="Display name" description="Display name select legend" />
+        </legend>
+        <Select
+          isMulti
+          defaultValue={transformedOptions}
+          name="display name"
+          options={transformedOptions}
+          className="basic-multi-select"
+          classNamePrefix="select"
+          noOptionsMessage={() => (
+            <FormattedMessage
+              defaultMessage="To change the display name, delete and choose again"
+              description="Display name noOptionsMessage"
+            />
+          )}
+          placeholder={
+            <FormattedMessage defaultMessage="Select display name..." description="Display name select placeholder" />
+          }
         />
       </fieldset>
       <p className="help-text">

--- a/src/components/Common/PersonalDataForm.tsx
+++ b/src/components/Common/PersonalDataForm.tsx
@@ -58,7 +58,7 @@ export default function PersonalDataForm(props: PersonalDataFormProps) {
               {props.isVerifiedIdentity ? (
                 <RenderLockedNames labels={labels} />
               ) : (
-                <RenderEditableNames labels={labels} displayName={personal_data?.display_name} />
+                <RenderEditableNames labels={labels} />
               )}
             </fieldset>
             <RenderLanguageSelect />
@@ -193,7 +193,7 @@ const RenderLockedNames = (props: { labels: NameLabels }) => {
   );
 };
 
-function RenderEditableNames(props: { labels: NameLabels; displayName: string | undefined }) {
+function RenderEditableNames(props: { labels: NameLabels }) {
   return (
     <Fragment>
       <fieldset>

--- a/src/components/Common/PersonalDataForm.tsx
+++ b/src/components/Common/PersonalDataForm.tsx
@@ -8,7 +8,7 @@ import { NameLabels } from "components/Dashboard/PersonalDataParent";
 import { useDashboardAppDispatch, useDashboardAppSelector } from "dashboard-hooks";
 import { AVAILABLE_LANGUAGES, LOCALIZED_MESSAGES } from "globals";
 import validatePersonalData from "helperFunctions/validation/validatePersonalData";
-import { Fragment } from "react";
+import { Fragment, useEffect, useState } from "react";
 import { Field, Form as FinalForm } from "react-final-form";
 import { FormattedMessage } from "react-intl";
 import Select from "react-select";
@@ -71,6 +71,53 @@ export default function PersonalDataForm(props: PersonalDataFormProps) {
         );
       }}
     />
+  );
+}
+
+function SelectDisplayName(): JSX.Element {
+  const display_name = useDashboardAppSelector((state) => state.personal_data.response?.display_name);
+  const splitDisplayName = display_name?.split(" ") || display_name?.split("-");
+  const transformedOptions = splitDisplayName?.map((name) => ({
+    label: name,
+    value: name,
+  }));
+  const [selectedOptions, setSelectedOptions] = useState(transformedOptions);
+
+  useEffect(() => {
+    if (display_name) {
+      setSelectedOptions(transformedOptions);
+    }
+  }, [display_name]);
+
+  const handleSelectChange = (selectedOptions: [{ label: string; value: string }]) => {
+    setSelectedOptions(selectedOptions);
+  };
+
+  return (
+    <fieldset>
+      <legend className="require">
+        <FormattedMessage defaultMessage="Display name" description="Display name select legend" />
+      </legend>
+      <Select
+        isMulti
+        value={selectedOptions}
+        // defaultValue={displayName}
+        name="display name"
+        options={transformedOptions}
+        onChange={() => handleSelectChange}
+        className="basic-multi-select"
+        classNamePrefix="select"
+        noOptionsMessage={() => (
+          <FormattedMessage
+            defaultMessage="To change the display name, delete and choose again"
+            description="Display name noOptionsMessage"
+          />
+        )}
+        placeholder={
+          <FormattedMessage defaultMessage="Select display name..." description="Display name select placeholder" />
+        }
+      />
+    </fieldset>
   );
 }
 
@@ -140,17 +187,12 @@ const RenderLockedNames = (props: { labels: NameLabels }) => {
           />
         </label>
       </div>
+      <SelectDisplayName />
     </Fragment>
   );
 };
 
 function RenderEditableNames(props: { labels: NameLabels; displayName: string | undefined }) {
-  const splitDisplayName = props?.displayName?.split(" ") || props?.displayName?.split("-");
-  const transformedOptions = splitDisplayName?.map((name) => ({
-    label: name,
-    value: name,
-  }));
-
   return (
     <Fragment>
       <fieldset>
@@ -175,28 +217,7 @@ function RenderEditableNames(props: { labels: NameLabels; displayName: string | 
           placeholder={props.labels.last}
         />
       </fieldset>
-      <fieldset>
-        <legend className="require">
-          <FormattedMessage defaultMessage="Display name" description="Display name select legend" />
-        </legend>
-        <Select
-          isMulti
-          defaultValue={transformedOptions}
-          name="display name"
-          options={transformedOptions}
-          className="basic-multi-select"
-          classNamePrefix="select"
-          noOptionsMessage={() => (
-            <FormattedMessage
-              defaultMessage="To change the display name, delete and choose again"
-              description="Display name noOptionsMessage"
-            />
-          )}
-          placeholder={
-            <FormattedMessage defaultMessage="Select display name..." description="Display name select placeholder" />
-          }
-        />
-      </fieldset>
+      <SelectDisplayName />
       <p className="help-text">
         <FormattedMessage
           defaultMessage="First and last name will be replaced with your legal name if you verify your eduID with your personal id number."

--- a/src/components/Common/PersonalDataForm.tsx
+++ b/src/components/Common/PersonalDataForm.tsx
@@ -78,7 +78,7 @@ function SelectDisplayName(): JSX.Element {
   const given_name = useDashboardAppSelector((state) => state.personal_data.response?.given_name);
   const surname = useDashboardAppSelector((state) => state.personal_data.response?.surname);
   const fullName = `${given_name} ${surname}`;
-  const splitFullName = fullName?.split(" ") || fullName?.split("-");
+  const splitFullName = fullName?.split(/[\s-]+/);
   const transformedOptions = splitFullName?.map((name) => ({
     label: name,
     value: name,

--- a/src/components/Common/PersonalDataForm.tsx
+++ b/src/components/Common/PersonalDataForm.tsx
@@ -11,7 +11,7 @@ import validatePersonalData from "helperFunctions/validation/validatePersonalDat
 import { Fragment, useEffect, useState } from "react";
 import { Field, Form as FinalForm } from "react-final-form";
 import { FormattedMessage } from "react-intl";
-import Select from "react-select";
+import Select, { MultiValue } from "react-select";
 import { updateIntl } from "slices/Internationalisation";
 import CustomInput from "./CustomInput";
 import EduIDButton from "./EduIDButton";
@@ -28,8 +28,11 @@ export default function PersonalDataForm(props: PersonalDataFormProps) {
   const personal_data = useDashboardAppSelector((state) => state.personal_data.response);
   const messages = LOCALIZED_MESSAGES;
 
+  const [displayName, setDisplayName] = useState<string | undefined>();
+
   async function formSubmit(values: PersonalDataRequest) {
-    const response = await dispatch(postPersonalData(values));
+    const response = await dispatch(postPersonalData(displayName ? { ...values, display_name: displayName } : values));
+
     if (postPersonalData.fulfilled.match(response)) {
       props.setEditMode(false); // tell parent component we're done editing
       if (response.payload.language) {
@@ -56,9 +59,9 @@ export default function PersonalDataForm(props: PersonalDataFormProps) {
           <form id="personaldata-view-form" onSubmit={formProps.handleSubmit}>
             <fieldset className="name-inputs">
               {props.isVerifiedIdentity ? (
-                <RenderLockedNames labels={labels} />
+                <RenderLockedNames labels={labels} setDisplayName={setDisplayName} />
               ) : (
-                <RenderEditableNames labels={labels} />
+                <RenderEditableNames labels={labels} setDisplayName={setDisplayName} />
               )}
             </fieldset>
             <RenderLanguageSelect />
@@ -74,13 +77,29 @@ export default function PersonalDataForm(props: PersonalDataFormProps) {
   );
 }
 
-function SelectDisplayName(): JSX.Element {
+function SelectDisplayName(props: { setDisplayName: any }): JSX.Element {
+  const is_verified = useDashboardAppSelector((state) => state.identities.is_verified);
   const given_name = useDashboardAppSelector((state) => state.personal_data.response?.given_name);
   const surname = useDashboardAppSelector((state) => state.personal_data.response?.surname);
   const [selectedOptions, setSelectedOptions] = useState<{ label: string; value: string }[]>([]);
+  const [defaultValues, setDefaultValues] = useState<{ label: string; value: string }[]>([]);
+  const givenNameInputElement = document.getElementById("given_name") as HTMLInputElement;
+  const givenNameInputValue = givenNameInputElement?.value;
+  const surNameInputElement = document.getElementById("surname") as HTMLInputElement;
+  const surNameInputValue = surNameInputElement?.value;
 
   useEffect(() => {
-    if (given_name && surname) {
+    if (!is_verified && givenNameInputValue && surNameInputValue) {
+      const fullName = `${givenNameInputValue} ${surNameInputValue}`;
+      const splitFullName = fullName?.split(/[\s-]+/);
+      const transformedOptions = splitFullName?.map((name) => ({
+        label: name,
+        value: name,
+      }));
+      setSelectedOptions(transformedOptions);
+      setDefaultValues(transformedOptions);
+    }
+    if (is_verified && given_name && surname) {
       const fullName = `${given_name} ${surname}`;
       const splitFullName = fullName?.split(/[\s-]+/);
       const transformedOptions = splitFullName?.map((name) => ({
@@ -88,14 +107,23 @@ function SelectDisplayName(): JSX.Element {
         value: name,
       }));
       setSelectedOptions(transformedOptions);
+      setDefaultValues(transformedOptions);
     }
-  }, [given_name, surname]);
+  }, [given_name, surname, givenNameInputValue, surNameInputValue]);
 
-  const handleSelectChange = (selectedOptions: { label: string; value: string }[]) => {
-    setSelectedOptions(selectedOptions);
+  const handleSelectChange = (newValue: MultiValue<{ label: string; value: string }>) => {
+    const updatedValue = Array.from(newValue);
+    if (updatedValue) {
+      setSelectedOptions(updatedValue);
+      const result = updatedValue.map((name: any) => name.value).join(" ");
+      if (result) {
+        props.setDisplayName(result);
+        console.log("result", result);
+      }
+    }
   };
 
-  if (!selectedOptions.length) {
+  if (!defaultValues.length) {
     return <></>;
   }
 
@@ -108,8 +136,8 @@ function SelectDisplayName(): JSX.Element {
         isMulti
         defaultValue={selectedOptions}
         name="display_name"
-        options={selectedOptions}
-        onChange={() => handleSelectChange}
+        options={defaultValues}
+        onChange={handleSelectChange}
         className="basic-multi-select"
         classNamePrefix="select"
         noOptionsMessage={() => (
@@ -156,7 +184,7 @@ function RenderLanguageSelect(): JSX.Element {
  * the legal names from Skatteverket. There is however a button to request renewal of the names
  * from Skatteverket, which the user can use to speed up syncing in case of name change.
  */
-const RenderLockedNames = (props: { labels: NameLabels }) => {
+const RenderLockedNames = (props: { labels: NameLabels; setDisplayName: any }) => {
   const dispatch = useDashboardAppDispatch();
   const loading = useDashboardAppSelector((state) => state.config.loading_data);
   const given_name = useDashboardAppSelector((state) => state.personal_data.response?.given_name);
@@ -192,12 +220,12 @@ const RenderLockedNames = (props: { labels: NameLabels }) => {
           />
         </label>
       </div>
-      <SelectDisplayName />
+      <SelectDisplayName setDisplayName={props.setDisplayName} />
     </Fragment>
   );
 };
 
-function RenderEditableNames(props: { labels: NameLabels }) {
+function RenderEditableNames(props: { labels: NameLabels; setDisplayName: any }) {
   return (
     <Fragment>
       <fieldset>
@@ -222,7 +250,7 @@ function RenderEditableNames(props: { labels: NameLabels }) {
           placeholder={props.labels.last}
         />
       </fieldset>
-      <SelectDisplayName />
+      <SelectDisplayName setDisplayName={props.setDisplayName} />
       <p className="help-text">
         <FormattedMessage
           defaultMessage="First and last name will be replaced with your legal name if you verify your eduID with your personal id number."

--- a/src/components/Common/PersonalDataForm.tsx
+++ b/src/components/Common/PersonalDataForm.tsx
@@ -75,19 +75,21 @@ export default function PersonalDataForm(props: PersonalDataFormProps) {
 }
 
 function SelectDisplayName(): JSX.Element {
-  const display_name = useDashboardAppSelector((state) => state.personal_data.response?.display_name);
-  const splitDisplayName = display_name?.split(" ") || display_name?.split("-");
-  const transformedOptions = splitDisplayName?.map((name) => ({
+  const given_name = useDashboardAppSelector((state) => state.personal_data.response?.given_name);
+  const surname = useDashboardAppSelector((state) => state.personal_data.response?.surname);
+  const fullName = `${given_name} ${surname}`;
+  const splitFullName = fullName?.split(" ") || fullName?.split("-");
+  const transformedOptions = splitFullName?.map((name) => ({
     label: name,
     value: name,
   }));
   const [selectedOptions, setSelectedOptions] = useState(transformedOptions);
 
   useEffect(() => {
-    if (display_name) {
+    if (given_name && surname) {
       setSelectedOptions(transformedOptions);
     }
-  }, [display_name]);
+  }, [given_name, surname]);
 
   const handleSelectChange = (selectedOptions: [{ label: string; value: string }]) => {
     setSelectedOptions(selectedOptions);
@@ -100,7 +102,7 @@ function SelectDisplayName(): JSX.Element {
       </legend>
       <Select
         isMulti
-        value={selectedOptions}
+        defaultValue={selectedOptions}
         // defaultValue={displayName}
         name="display name"
         options={transformedOptions}

--- a/src/components/Common/PersonalDataForm.tsx
+++ b/src/components/Common/PersonalDataForm.tsx
@@ -77,23 +77,27 @@ export default function PersonalDataForm(props: PersonalDataFormProps) {
 function SelectDisplayName(): JSX.Element {
   const given_name = useDashboardAppSelector((state) => state.personal_data.response?.given_name);
   const surname = useDashboardAppSelector((state) => state.personal_data.response?.surname);
-  const fullName = `${given_name} ${surname}`;
-  const splitFullName = fullName?.split(/[\s-]+/);
-  const transformedOptions = splitFullName?.map((name) => ({
-    label: name,
-    value: name,
-  }));
-  const [selectedOptions, setSelectedOptions] = useState(transformedOptions);
+  const [selectedOptions, setSelectedOptions] = useState<{ label: string; value: string }[]>([]);
 
   useEffect(() => {
     if (given_name && surname) {
+      const fullName = `${given_name} ${surname}`;
+      const splitFullName = fullName?.split(/[\s-]+/);
+      const transformedOptions = splitFullName?.map((name) => ({
+        label: name,
+        value: name,
+      }));
       setSelectedOptions(transformedOptions);
     }
-  }, [selectedOptions]);
+  }, [given_name, surname]);
 
-  const handleSelectChange = (selectedOptions: [{ label: string; value: string }]) => {
+  const handleSelectChange = (selectedOptions: { label: string; value: string }[]) => {
     setSelectedOptions(selectedOptions);
   };
+
+  if (!selectedOptions.length) {
+    return <></>;
+  }
 
   return (
     <fieldset>
@@ -103,8 +107,8 @@ function SelectDisplayName(): JSX.Element {
       <Select
         isMulti
         defaultValue={selectedOptions}
-        name="display name"
-        options={transformedOptions}
+        name="display_name"
+        options={selectedOptions}
         onChange={() => handleSelectChange}
         className="basic-multi-select"
         classNamePrefix="select"

--- a/src/components/Dashboard/PersonalDataParent.tsx
+++ b/src/components/Dashboard/PersonalDataParent.tsx
@@ -9,6 +9,7 @@ export interface NameLabels {
   // These are translated labels for "First" and "Last" name input- or text-fields
   first: string;
   last: string;
+  display_name: string;
 }
 
 interface RenderAddPersonalDataPromptProps {
@@ -31,6 +32,7 @@ function RenderAddPersonalDataPrompt({ setEditMode }: RenderAddPersonalDataPromp
 function RenderPersonalData(props: { labels: NameLabels }) {
   const first_name = useDashboardAppSelector((state) => state.personal_data.response?.given_name);
   const last_name = useDashboardAppSelector((state) => state.personal_data.response?.surname);
+  const display_name = useDashboardAppSelector((state) => state.personal_data.response?.display_name);
   const pref_language = useDashboardAppSelector((state) => state.personal_data.response?.language);
   // if language is set render label
   const hasPrefLanguage = pref_language !== undefined && pref_language !== null;
@@ -47,6 +49,7 @@ function RenderPersonalData(props: { labels: NameLabels }) {
     <div className="personal-data-info">
       <NameDisplay htmlFor="first name" label={props.labels.first} name={first_name} />
       <NameDisplay htmlFor="last name" label={props.labels.last} name={last_name} />
+      <NameDisplay htmlFor="display name" label={props.labels.display_name} name={display_name} />
       {hasPrefLanguage ? (
         <NameDisplay
           htmlFor="language"
@@ -119,6 +122,11 @@ function PersonalDataParent() {
       id: "pd.surname",
       defaultMessage: "Last name",
       description: "Last name label/template (edit personal data)",
+    }),
+    display_name: intl.formatMessage({
+      id: "pd.display_name",
+      defaultMessage: "Display name",
+      description: "Display name label/template (edit personal data)",
     }),
   };
 

--- a/src/styles/_forms.scss
+++ b/src/styles/_forms.scss
@@ -126,3 +126,9 @@ fieldset {
     }
   }
 }
+
+// React-select
+.select__multi-value__label {
+  font-size: 1.25rem !important;
+  align-self: center !important;
+}

--- a/src/translation/extractedMessages.json
+++ b/src/translation/extractedMessages.json
@@ -1053,6 +1053,10 @@
     "developer_comment": "Dashboard change password modal main text",
     "string": "You will need to log in again to change your password."
   },
+  "Ryb62w": {
+    "developer_comment": "Display name noOptionsMessage",
+    "string": "To change the display name, delete and choose again"
+  },
   "S1ESg7": {
     "developer_comment": "Currently in progress title",
     "string": "Currently in progress"
@@ -1272,6 +1276,10 @@
   "XzQO4I": {
     "developer_comment": "choosing usb key - list definition",
     "string": "Check with the manufacturer or retailer that the product meets the following requirements:"
+  },
+  "XzScE+": {
+    "developer_comment": "Display name select legend",
+    "string": "Display name"
   },
   "Y33LNf": {
     "developer_comment": "explanation text for vetting phone",
@@ -1587,6 +1595,10 @@
   "e0xgSg": {
     "developer_comment": "how to contact support - paragraph 3",
     "string": ", but for simple matters you can also reach us on phone number {phone}."
+  },
+  "eFceSz": {
+    "developer_comment": "Display name select placeholder",
+    "string": "Select display name..."
   },
   "eIAskC": {
     "developer_comment": "Start",
@@ -2300,6 +2312,10 @@
   "pb/yW9": {
     "developer_comment": "help - headline",
     "string": "Help and contact"
+  },
+  "pd.display_name": {
+    "developer_comment": "Display name label/template (edit personal data)",
+    "string": "Display name"
   },
   "pd.given_name": {
     "developer_comment": "First name label/template (edit personal data)",


### PR DESCRIPTION
#### Description:
Users can select a display name for existing names. the name will be split by spaces or hyphens in the middle of the name.

![Screenshot 2024-03-08 at 10 23 36](https://github.com/SUNET/eduid-front/assets/44289056/3c9373fb-78b4-410d-a9b4-f457ab49342f)



#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
