### PR TITLE
introduce an email code for resetpw

### DIFF
--- a/src/components/Common/ResponseCodeAbortButton.tsx
+++ b/src/components/Common/ResponseCodeAbortButton.tsx
@@ -5,7 +5,8 @@ import EduIDButton from "./EduIDButton";
 
 interface ResponseCodeButtonsProps {
   formProps?: FormRenderProps<ResponseCodeValues>;
-  handleAbortButtonOnClick: () => void;
+  //TODO: Type definition needed
+  handleAbortButtonOnClick: any;
 }
 
 export function ResponseCodeButtons(props: ResponseCodeButtonsProps) {

--- a/src/components/Common/ResponseCodeAbortButton.tsx
+++ b/src/components/Common/ResponseCodeAbortButton.tsx
@@ -1,0 +1,56 @@
+import { ResponseCodeValues } from "components/Login/ResponseCodeForm";
+import { FormRenderProps } from "react-final-form";
+import { FormattedMessage } from "react-intl";
+import EduIDButton from "./EduIDButton";
+
+interface ResponseCodeButtonsProps {
+  formProps?: FormRenderProps<ResponseCodeValues>;
+  handleAbortButtonOnClick: any;
+}
+
+export function ResponseCodeButtons(props: ResponseCodeButtonsProps) {
+  if (!props.formProps) {
+    return null;
+  }
+
+  // 'convert' from FormRenderProps to a simple "disabled" boolean
+  return (
+    <ResponseCodeAbortButton
+      disabled={props.formProps.submitting}
+      invalid={props.formProps.invalid}
+      submit={props.formProps.form.submit}
+      handleAbortButtonOnClick={props.handleAbortButtonOnClick}
+    />
+  );
+}
+
+export function ResponseCodeAbortButton(props: {
+  disabled: boolean;
+  invalid: boolean;
+  submit: () => void;
+  handleAbortButtonOnClick: any;
+}) {
+  // abort button usable from both ResponseCodeButtons and when isExpired below
+  return (
+    <div className="buttons">
+      <EduIDButton
+        type="button"
+        buttonstyle="secondary"
+        onClick={props.handleAbortButtonOnClick}
+        id="response-code-abort-button"
+        disabled={props.disabled}
+      >
+        <FormattedMessage defaultMessage="Cancel" description="Short code form" />
+      </EduIDButton>
+      <EduIDButton
+        type="submit"
+        buttonstyle="primary"
+        onClick={props.submit}
+        id="response-code-ok-button"
+        disabled={props.invalid}
+      >
+        <FormattedMessage defaultMessage="Ok" description="Short code form Ok button" />
+      </EduIDButton>
+    </div>
+  );
+}

--- a/src/components/Common/ResponseCodeAbortButton.tsx
+++ b/src/components/Common/ResponseCodeAbortButton.tsx
@@ -5,7 +5,7 @@ import EduIDButton from "./EduIDButton";
 
 interface ResponseCodeButtonsProps {
   formProps?: FormRenderProps<ResponseCodeValues>;
-  handleAbortButtonOnClick: any;
+  handleAbortButtonOnClick: () => void;
 }
 
 export function ResponseCodeButtons(props: ResponseCodeButtonsProps) {
@@ -28,7 +28,7 @@ export function ResponseCodeAbortButton(props: {
   disabled: boolean;
   invalid: boolean;
   submit: () => void;
-  handleAbortButtonOnClick: any;
+  handleAbortButtonOnClick: () => void;
 }) {
   // abort button usable from both ResponseCodeButtons and when isExpired below
   return (

--- a/src/components/ResetPassword/EmailLinkSent.tsx
+++ b/src/components/ResetPassword/EmailLinkSent.tsx
@@ -53,21 +53,36 @@ export function EmailLinkSent(): JSX.Element | null {
     }
 
     // 'convert' from FormRenderProps to a simple "disabled" boolean
-    return <ResponseCodeAbortButton disabled={props.formProps.submitting} />;
+    return (
+      <ResponseCodeAbortButton
+        disabled={props.formProps.submitting}
+        invalid={props.formProps.invalid}
+        submit={props.formProps.form.submit}
+      />
+    );
   }
 
-  function ResponseCodeAbortButton(props: { disabled: boolean }) {
+  function ResponseCodeAbortButton(props: { disabled: boolean; invalid: boolean; submit: () => void }) {
     // abort button usable from both ResponseCodeButtons and when isExpired below
     return (
       <div className="buttons">
         <EduIDButton
-          type="submit"
+          type="button"
           buttonstyle="secondary"
           onClick={handleAbortButtonOnClick}
           id="response-code-abort-button"
           disabled={props.disabled}
         >
           <FormattedMessage defaultMessage="Cancel" description="Short code form" />
+        </EduIDButton>
+        <EduIDButton
+          type="submit"
+          buttonstyle="primary"
+          onClick={props.submit}
+          id="response-code-ok-button"
+          disabled={props.invalid}
+        >
+          <FormattedMessage defaultMessage="Ok" description="Short code form Ok button" />
         </EduIDButton>
       </div>
     );

--- a/src/components/ResetPassword/EmailLinkSent.tsx
+++ b/src/components/ResetPassword/EmailLinkSent.tsx
@@ -36,7 +36,6 @@ export function EmailLinkSent(): JSX.Element | null {
           dispatch(clearNotifications());
           resetPasswordContext.resetPasswordService.send({ type: "API_SUCCESS" });
         } else {
-          console.log("FAIL");
           resetPasswordContext.resetPasswordService.send({ type: "API_FAIL" });
         }
       }

--- a/src/components/ResetPassword/EmailLinkSent.tsx
+++ b/src/components/ResetPassword/EmailLinkSent.tsx
@@ -1,17 +1,12 @@
 import { verifyEmailLink } from "apis/eduidResetPassword";
-import EduIDButton from "components/Common/EduIDButton";
+import { ResponseCodeButtons } from "components/Common/ResponseCodeAbortButton";
 import { ResponseCodeForm, ResponseCodeValues } from "components/Login/ResponseCodeForm";
 import { useAppDispatch, useAppSelector } from "eduid-hooks";
 import React, { useContext } from "react";
-import { FormRenderProps } from "react-final-form";
 import { FormattedMessage } from "react-intl";
 import { clearNotifications } from "slices/Notifications";
 import resetPasswordSlice from "slices/ResetPassword";
 import { ResetPasswordGlobalStateContext } from "./ResetPasswordGlobalState";
-
-interface ResponseCodeButtonsProps {
-  formProps?: FormRenderProps<ResponseCodeValues>;
-}
 
 export function EmailLinkSent(): JSX.Element | null {
   const dispatch = useAppDispatch();
@@ -46,47 +41,6 @@ export function EmailLinkSent(): JSX.Element | null {
       dispatch(resetPasswordSlice.actions.resetEmailStatus());
       resetPasswordContext.resetPasswordService.send({ type: "GO_BACK" });
     }
-  }
-
-  function ResponseCodeButtons(props: ResponseCodeButtonsProps) {
-    if (!props.formProps) {
-      return null;
-    }
-
-    // 'convert' from FormRenderProps to a simple "disabled" boolean
-    return (
-      <ResponseCodeAbortButton
-        disabled={props.formProps.submitting}
-        invalid={props.formProps.invalid}
-        submit={props.formProps.form.submit}
-      />
-    );
-  }
-
-  function ResponseCodeAbortButton(props: { disabled: boolean; invalid: boolean; submit: () => void }) {
-    // abort button usable from both ResponseCodeButtons and when isExpired below
-    return (
-      <div className="buttons">
-        <EduIDButton
-          type="button"
-          buttonstyle="secondary"
-          onClick={handleAbortButtonOnClick}
-          id="response-code-abort-button"
-          disabled={props.disabled}
-        >
-          <FormattedMessage defaultMessage="Cancel" description="Short code form" />
-        </EduIDButton>
-        <EduIDButton
-          type="submit"
-          buttonstyle="primary"
-          onClick={props.submit}
-          id="response-code-ok-button"
-          disabled={props.invalid}
-        >
-          <FormattedMessage defaultMessage="Ok" description="Short code form Ok button" />
-        </EduIDButton>
-      </div>
-    );
   }
 
   if (!response) {
@@ -124,7 +78,7 @@ export function EmailLinkSent(): JSX.Element | null {
       </p>
       <div className="enter-code">
         <ResponseCodeForm inputsDisabled={false} handleSubmitCode={handleSubmitCode}>
-          <ResponseCodeButtons />
+          <ResponseCodeButtons handleAbortButtonOnClick={handleAbortButtonOnClick} />
         </ResponseCodeForm>
       </div>
     </React.Fragment>

--- a/src/components/ResetPassword/EmailLinkSent.tsx
+++ b/src/components/ResetPassword/EmailLinkSent.tsx
@@ -1,14 +1,12 @@
-import { requestEmailLink, verifyEmailLink } from "apis/eduidResetPassword";
+import { verifyEmailLink } from "apis/eduidResetPassword";
 import EduIDButton from "components/Common/EduIDButton";
-import { TimeRemainingWrapper } from "components/Common/TimeRemaining";
 import { ResponseCodeForm, ResponseCodeValues } from "components/Login/ResponseCodeForm";
 import { useAppDispatch, useAppSelector } from "eduid-hooks";
-import React, { useContext, useState } from "react";
+import React, { useContext } from "react";
 import { FormRenderProps } from "react-final-form";
 import { FormattedMessage } from "react-intl";
 import { clearNotifications } from "slices/Notifications";
-import { ExpiresMeter } from "../Login/ExpiresMeter";
-import { GoBackButton } from "./GoBackButton";
+import resetPasswordSlice from "slices/ResetPassword";
 import { ResetPasswordGlobalStateContext } from "./ResetPasswordGlobalState";
 
 interface ResponseCodeButtonsProps {
@@ -17,9 +15,9 @@ interface ResponseCodeButtonsProps {
 
 export function EmailLinkSent(): JSX.Element | null {
   const dispatch = useAppDispatch();
-  const [resendDisabled, setResendDisabled] = useState(true);
   const response = useAppSelector((state) => state.resetPassword.email_response);
   const resetPasswordContext = useContext(ResetPasswordGlobalStateContext);
+  const dashboard_link = useAppSelector((state) => state.config.dashboard_link);
 
   async function handleSubmitCode(values: ResponseCodeValues) {
     const code = values.v.join("");
@@ -42,9 +40,12 @@ export function EmailLinkSent(): JSX.Element | null {
     }
   }
 
-  function handleAbortButtonOnClick(event: React.MouseEvent<HTMLButtonElement>) {
-    event.preventDefault();
-    resetPasswordContext.resetPasswordService.send({ type: "GO_BACK" });
+  function handleAbortButtonOnClick() {
+    if (dashboard_link) {
+      document.location.href = dashboard_link;
+      dispatch(resetPasswordSlice.actions.resetEmailStatus());
+      resetPasswordContext.resetPasswordService.send({ type: "GO_BACK" });
+    }
   }
 
   function ResponseCodeButtons(props: ResponseCodeButtonsProps) {
@@ -88,28 +89,6 @@ export function EmailLinkSent(): JSX.Element | null {
     );
   }
 
-  /**
-   * The user has clicked the button to request that another e-mail should be sent.
-   */
-  function sendEmailOnClick(e: React.MouseEvent<HTMLElement>) {
-    (async () => {
-      e.preventDefault();
-      if (response?.email) {
-        try {
-          const resp = await dispatch(requestEmailLink({ email: response.email }));
-          if (requestEmailLink.rejected.match(resp)) {
-            resetPasswordContext.resetPasswordService.send({ type: "API_FAIL" });
-          }
-        } catch (error) {}
-      }
-      setResendDisabled(true); // disabled button again on use
-    })();
-  }
-
-  function handleTimerReachZero() {
-    setResendDisabled(false); // allow user to request a new e-mail when timer expires
-  }
-
   if (!response) {
     return null;
   }
@@ -139,31 +118,10 @@ export function EmailLinkSent(): JSX.Element | null {
       </p>
       <p>
         <FormattedMessage
-          defaultMessage="If you haven't receive the email code, you can resend it after five minutes, according to the timer next to the Resend button."
+          defaultMessage="If you haven't receive the email code, please cancel the process and restart from the beginning."
           description="Reset Password email link sent"
         />
       </p>
-
-      <div className="buttons">
-        <GoBackButton />
-        <EduIDButton
-          buttonstyle="primary"
-          type="submit"
-          id="send-email-button"
-          onClick={sendEmailOnClick}
-          disabled={resendDisabled}
-        >
-          <FormattedMessage defaultMessage="Resend email code" description="Resend email code button" />
-        </EduIDButton>
-        <TimeRemainingWrapper
-          name="reset-password-email-expires"
-          unique_id={response?.email}
-          value={response?.throttled_seconds}
-          onReachZero={handleTimerReachZero}
-        >
-          <ExpiresMeter showMeter={false} expires_max={response?.throttled_max} />
-        </TimeRemainingWrapper>
-      </div>
       <div className="enter-code">
         <ResponseCodeForm inputsDisabled={false} handleSubmitCode={handleSubmitCode}>
           <ResponseCodeButtons />

--- a/src/components/ResetPassword/HandleExtraSecurities.tsx
+++ b/src/components/ResetPassword/HandleExtraSecurities.tsx
@@ -165,6 +165,12 @@ export function HandleExtraSecurities(): JSX.Element | null {
     }
   }, [swedishEID_status]);
 
+  useEffect(() => {
+    if (extra_security && !Object.values(extra_security).length) {
+      resetPasswordContext.resetPasswordService.send({ type: "WITHOUT_EXTRA_SECURITY" });
+    }
+  }, [extra_security]);
+
   function handleOnClickFreja() {
     (async () => {
       const response = await dispatch(
@@ -214,7 +220,7 @@ export function HandleExtraSecurities(): JSX.Element | null {
   function continueSetPassword() {
     dispatch(resetPasswordSlice.actions.selectExtraSecurity("without"));
     dispatch(clearNotifications());
-    resetPasswordContext.resetPasswordService.send({ type: "CHOOSE_NO_EXTRA_SECURITY" });
+    resetPasswordContext.resetPasswordService.send({ type: "WITHOUT_EXTRA_SECURITY" });
   }
 
   if (!extra_security) {

--- a/src/components/ResetPassword/ResetPasswordApp.tsx
+++ b/src/components/ResetPassword/ResetPasswordApp.tsx
@@ -9,8 +9,10 @@ import loginSlice from "slices/Login";
 import { clearNotifications } from "slices/Notifications";
 import { EmailLinkSent } from "./EmailLinkSent";
 import { GoBackButton } from "./GoBackButton";
+import { HandleExtraSecurities } from "./HandleExtraSecurities";
 import { ResetPasswordEnterEmail } from "./ResetPasswordEnterEmail";
 import { ResetPasswordGlobalStateContext } from "./ResetPasswordGlobalState";
+import { ResetPasswordSuccess, SetNewPassword } from "./SetNewPassword";
 
 // URL parameters passed to ResetPasswordRequestEmail
 export interface UrlParams {
@@ -38,6 +40,9 @@ export function ResetPasswordApp(): JSX.Element {
       {state.matches("AskForEmailOrConfirmEmail.ResetPasswordConfirmEmail") && <ResetPasswordConfirmEmail />}
       {state.matches("AskForEmailOrConfirmEmail.ResetPasswordEnterEmail") && <ResetPasswordEnterEmail />}
       {state.matches("AskForEmailOrConfirmEmail.EmailLinkSent") && <EmailLinkSent />}
+      {state.matches("HandleExtraSecurities.HandleExtraSecurities") && <HandleExtraSecurities />}
+      {state.matches("FinaliseResetPassword.SetNewPassword") && <SetNewPassword />}
+      {state.matches("FinaliseResetPassword.ResetPasswordSuccess") && <ResetPasswordSuccess />}
     </React.Fragment>
   );
 }

--- a/src/components/ResetPassword/ResetPasswordMain.tsx
+++ b/src/components/ResetPassword/ResetPasswordMain.tsx
@@ -44,6 +44,7 @@ interface CodeParams {
   emailCode?: string;
 }
 
+//TODO:  remove it after the email code release
 export function HandleEmailCode(): JSX.Element {
   const isLoaded = useAppSelector((state) => state.config.is_configured);
   const email_code = useAppSelector((state) => state.resetPassword.email_code);

--- a/src/components/Signup/SignupEnterCode.tsx
+++ b/src/components/Signup/SignupEnterCode.tsx
@@ -1,19 +1,15 @@
 import { verifyEmailRequest } from "apis/eduidSignup";
 import EduIDButton from "components/Common/EduIDButton";
+import { ResponseCodeButtons } from "components/Common/ResponseCodeAbortButton";
 import { TimeRemainingWrapper } from "components/Common/TimeRemaining";
 import { ExpiresMeter } from "components/Login/ExpiresMeter";
 import { ResponseCodeForm, ResponseCodeValues } from "components/Login/ResponseCodeForm";
 import { useAppDispatch, useAppSelector } from "eduid-hooks";
 import { Fragment, useContext, useEffect, useState } from "react";
-import { FormRenderProps } from "react-final-form";
 import { FormattedMessage } from "react-intl";
 import { clearNotifications } from "slices/Notifications";
 import { signupSlice } from "slices/Signup";
 import { SignupGlobalStateContext } from "./SignupGlobalState";
-
-interface ResponseCodeButtonsProps {
-  formProps?: FormRenderProps<ResponseCodeValues>;
-}
 
 export function SignupEnterCode(): JSX.Element {
   const signupState = useAppSelector((state) => state.signup.state);
@@ -52,47 +48,6 @@ export function SignupEnterCode(): JSX.Element {
         signupContext.signupService.send({ type: "COMPLETE" });
       }
     }
-  }
-
-  function ResponseCodeButtons(props: ResponseCodeButtonsProps) {
-    if (!props.formProps) {
-      return null;
-    }
-
-    // 'convert' from FormRenderProps to a simple "disabled" boolean
-    return (
-      <ResponseCodeAbortButton
-        disabled={props.formProps.submitting}
-        invalid={props.formProps.invalid}
-        submit={props.formProps.form.submit}
-      />
-    );
-  }
-
-  function ResponseCodeAbortButton(props: { disabled: boolean; invalid: boolean; submit: () => void }) {
-    // abort button usable from both ResponseCodeButtons and when isExpired below
-    return (
-      <div className="buttons">
-        <EduIDButton
-          type="button"
-          buttonstyle="secondary"
-          onClick={handleAbortButtonOnClick}
-          id="response-code-abort-button"
-          disabled={props.disabled}
-        >
-          <FormattedMessage defaultMessage="Cancel" description="Short code form" />
-        </EduIDButton>
-        <EduIDButton
-          type="submit"
-          buttonstyle="primary"
-          onClick={props.submit}
-          id="response-code-ok-button"
-          disabled={props.invalid}
-        >
-          <FormattedMessage defaultMessage="Ok" description="Short code form Ok button" />
-        </EduIDButton>
-      </div>
-    );
   }
 
   if (isExpired) {
@@ -177,7 +132,7 @@ export function SignupEnterCode(): JSX.Element {
 
       <div className="enter-code">
         <ResponseCodeForm inputsDisabled={false} handleSubmitCode={handleSubmitCode}>
-          <ResponseCodeButtons />
+          <ResponseCodeButtons handleAbortButtonOnClick={handleAbortButtonOnClick} />
         </ResponseCodeForm>
       </div>
     </Fragment>

--- a/src/machines/ResetPasswordMachine.ts
+++ b/src/machines/ResetPasswordMachine.ts
@@ -15,7 +15,6 @@ const resetPasswordModel = createModel(
       CHOOSE_SECURITY_KEY: () => ({}), // no payload
       CHOOSE_PHONE_VERIFICATION: () => ({}), // no payload
       CHOOSE_FREJA_EID: () => ({}), // no payload
-      CHOOSE_NO_EXTRA_SECURITY: () => ({}), // no payload
       COMPLETE: () => ({}), // no payload
       CAN_DO_EXTRA_SECURITY: () => ({}), // no payload
       WITHOUT_EXTRA_SECURITY: () => ({}), // no payload
@@ -90,14 +89,24 @@ export function createResetPasswordMachine() {
             },
             EmailLinkSent: {
               on: {
+                API_SUCCESS: {
+                  target: "Finished",
+                },
                 API_FAIL: {
-                  target: "ResetPasswordEnterEmail",
+                  // target: "ResetPasswordEnterEmail",
+                  target: "EmailLinkSent",
                 },
                 GO_BACK: {
                   target: "#resetPassword.ReturnToPrevious",
                 },
               },
             },
+            Finished: {
+              type: "final",
+            },
+          },
+          onDone: {
+            target: "HandleExtraSecurities",
           },
         },
         HandleExtraSecurities: {
@@ -114,7 +123,7 @@ export function createResetPasswordMachine() {
                 CHOOSE_FREJA_EID: {
                   target: "ResetPasswordExternalMFA",
                 },
-                CHOOSE_NO_EXTRA_SECURITY: {
+                WITHOUT_EXTRA_SECURITY: {
                   target: "ExtraSecurityFinished",
                 },
                 API_SUCCESS: {

--- a/src/machines/ResetPasswordMachine.typegen.ts
+++ b/src/machines/ResetPasswordMachine.typegen.ts
@@ -20,6 +20,7 @@ export interface Typegen0 {
     | "AskForEmailOrConfirmEmail"
     | "AskForEmailOrConfirmEmail.AskForEmailOrConfirmEmail"
     | "AskForEmailOrConfirmEmail.EmailLinkSent"
+    | "AskForEmailOrConfirmEmail.Finished"
     | "AskForEmailOrConfirmEmail.ResetPasswordConfirmEmail"
     | "AskForEmailOrConfirmEmail.ResetPasswordEnterEmail"
     | "FinaliseResetPassword"
@@ -39,6 +40,7 @@ export interface Typegen0 {
         "AskForEmailOrConfirmEmail"?:
           | "AskForEmailOrConfirmEmail"
           | "EmailLinkSent"
+          | "Finished"
           | "ResetPasswordConfirmEmail"
           | "ResetPasswordEnterEmail";
         "FinaliseResetPassword"?: "ResetPasswordSuccess" | "SetNewPassword";

--- a/src/tests/login/LoginResetPassword-test.tsx
+++ b/src/tests/login/LoginResetPassword-test.tsx
@@ -146,7 +146,7 @@ test("can click 'forgot password' without an e-mail address", async () => {
     expect(screen.getByTestId("email-address")).toHaveTextContent(email);
   });
 
-  // verify resend button is initially disabled
-  const resendButton = screen.getByRole("button", { name: /^resend/i });
+  // the ok button is initially disabled without code
+  const resendButton = screen.getByRole("button", { name: /^ok/i });
   expect(resendButton).toBeDisabled();
 });

--- a/src/translation/extractedMessages.json
+++ b/src/translation/extractedMessages.json
@@ -683,6 +683,10 @@
     "developer_comment": "what is eduID - paragraph 2",
     "string": "Federated identities are one of the cornerstones of trust between organisations. Trust is based on all the organisations relying on all the others to carry out their authentication - identification and verification - properly and in a controlled and reliable IT environment."
   },
+  "GmoJ8i": {
+    "developer_comment": "Reset Password email link sent",
+    "string": "The email code is valid for two hours."
+  },
   "H08uQ1": {
     "developer_comment": "enhance eduid - list item 3",
     "string": "a security key of you are able to for added security,"
@@ -1237,10 +1241,6 @@
     "developer_comment": "not found heading",
     "string": "Page not found"
   },
-  "VymaGb": {
-    "developer_comment": "Resend e-mail button",
-    "string": "Resend e-mail"
-  },
   "WI2cKY": {
     "developer_comment": "verify identity",
     "string": "If you have an electronic ID from a country connected to eIDAS, you can connect it to your eduID."
@@ -1328,10 +1328,6 @@
   "YxJ0EU": {
     "developer_comment": "Login OtherDevice",
     "string": "Cancel"
-  },
-  "YyZ4yf": {
-    "developer_comment": "Reset Password email link sent",
-    "string": "If you didn’t receive the email, check your junk email before resending it after five minutes, according to the timer next to the Resend button."
   },
   "Z0Ireq": {
     "developer_comment": "Verified identity",
@@ -1777,10 +1773,6 @@
     "developer_comment": "eidas if personal number - paragraph",
     "string": "If you have a Swedish personal identity number, use that method instead e.g. to simplify communication with Swedish authorities. Note: If you initially verify your identity with eIDAS and later receive a Swedish personal identity number you can add it in eduID and verify yourself again using it in the Identity area."
   },
-  "fqZXes": {
-    "developer_comment": "Reset Password email link sent",
-    "string": "If you have an eduID account, an email with instructions has been sent to {email}."
-  },
   "fr8eQq": {
     "developer_comment": "Emails button cancel",
     "string": "Cancel"
@@ -1955,6 +1947,10 @@
   "jc2mpm": {
     "developer_comment": "how more secure description 1",
     "string": "Some services will require a higher security level and to improve the security of your eduID, in addition to knowledge of your username (confirmed email address) and password combination, you can use another layer of authentication to log in. This is called multi-Factor authentication (MFA); and in eduID's case two-factor authentication (2FA)."
+  },
+  "jeREhn": {
+    "developer_comment": "Reset Password email link sent",
+    "string": "If you haven't receive the email code, please cancel the process and restart from the beginning."
   },
   "jgCAmP": {
     "developer_comment": "about privacy accessibility - handle",
@@ -2508,6 +2504,10 @@
     "developer_comment": "Reset Password button",
     "string": "send email"
   },
+  "qiazcf": {
+    "developer_comment": "Reset Password email link sent",
+    "string": "If you have an eduID account, the code has been sent to {email}."
+  },
   "qkwsql": {
     "developer_comment": "Login MFA",
     "string": "If you have a Swedish national identity number and Freja eID+, confirm your identity and you'll be able to use Freja eID+ to log in."
@@ -2809,10 +2809,6 @@
   "u2p5j+": {
     "developer_comment": "use eidas - list item 2",
     "string": "to verify your identity in eduID, log in and choose the verification method for 'EU-citizens' in the Identity area and follow the instructions."
-  },
-  "uKzmRZ": {
-    "developer_comment": "Reset Password email link sent",
-    "string": "The link in the e-mail is valid for two hours."
   },
   "uWVxmX": {
     "developer_comment": "ErrorURL authorization failure",


### PR DESCRIPTION
#### Description:

Utilise the email code instead of the email link for reset password flow. remove the resend button and timer, and update the text so that users can cancel the reset password process and retry from the beginning to obtain the code.


---

![Screenshot 2024-04-02 at 11 57 06](https://github.com/SUNET/eduid-front/assets/44289056/a5cb1f11-3ef6-46cc-94da-7e8492ac96f1)

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
