### PR TITLE
add  autofocus for custom password

### DIFF
--- a/src/components/Common/InputWrapper.tsx
+++ b/src/components/Common/InputWrapper.tsx
@@ -54,7 +54,7 @@ function RenderErrorMessage(props: InputWrapperProps): JSX.Element | null {
 
   return (
     <FormText>
-      <span role="alert" aria-invalid="true" tabIndex={0} className="input-validate-error">
+      <span role="alert" aria-invalid="true" tabIndex={-1} className="input-validate-error">
         {errorMsg || submitErrorMsg}
       </span>
       {props.passwordStrengthMeter ? props.passwordStrengthMeter : null}

--- a/src/components/Common/PasswordInput.tsx
+++ b/src/components/Common/PasswordInput.tsx
@@ -35,8 +35,6 @@ export default function PasswordInput(props: PasswordInputProps): JSX.Element {
 }
 
 export function WrappedPasswordInput(props: FieldRenderProps<string>): JSX.Element {
-  const { input, meta } = props;
-
   // the InputWrapper renders it's children plus a label, helpBlock and any error message from the field validation
   return (
     <InputWrapper {...props}>
@@ -67,6 +65,7 @@ export function PasswordInputElement(props: InputProps): JSX.Element {
         invalid={props.meta.invalid}
         placeholder={props.placeholder}
         autoComplete={props.autoComplete}
+        autoFocus={props.autoFocus}
       />
 
       <button

--- a/src/components/Dashboard/ChangePasswordCustom.tsx
+++ b/src/components/Dashboard/ChangePasswordCustom.tsx
@@ -111,6 +111,8 @@ export default function ChangePasswordCustomForm(props: ChangePasswordCustomForm
                 autoComplete="new-password"
                 required={true}
                 placeHolder={new_password_placeholder}
+                tabIndex={1}
+                autoFocus={true}
               />
               <FinalField
                 name="repeat"
@@ -126,6 +128,7 @@ export default function ChangePasswordCustomForm(props: ChangePasswordCustomForm
                 }
                 required={true}
                 placeHolder={repeat_new_password_placeholder}
+                tabIndex={2}
               />
             </fieldset>
             <div id="chpass-form" className="tab-pane buttons">

--- a/src/components/Dashboard/ChangePasswordCustom.tsx
+++ b/src/components/Dashboard/ChangePasswordCustom.tsx
@@ -111,7 +111,6 @@ export default function ChangePasswordCustomForm(props: ChangePasswordCustomForm
                 autoComplete="new-password"
                 required={true}
                 placeHolder={new_password_placeholder}
-                tabIndex={1}
                 autoFocus={true}
               />
               <FinalField
@@ -128,7 +127,6 @@ export default function ChangePasswordCustomForm(props: ChangePasswordCustomForm
                 }
                 required={true}
                 placeHolder={repeat_new_password_placeholder}
-                tabIndex={2}
               />
             </fieldset>
             <div id="chpass-form" className="tab-pane buttons">


### PR DESCRIPTION
#### Description:

added autofocus to the custom password inout and ensured that pressing tab moves to repeat password field. 

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
