### PR TITLE
Remove duplicated text

### DIFF
--- a/src/components/Common/NinDisplay.tsx
+++ b/src/components/Common/NinDisplay.tsx
@@ -58,11 +58,6 @@ function RenderShowHideNin(props: NinDisplayProps): JSX.Element | null {
 export function NinDisplay(props: NinDisplayProps) {
   return (
     <div className="profile-grid-cell">
-      <span aria-label="id number">
-        <strong>
-          <FormattedMessage description="nin label" defaultMessage="National ID number" />
-        </strong>
-      </span>
       {!props.nin ? (
         // if there is no NIN, render a link to verify-identity
         <Link to={`/profile/verify-identity/`} className="display-data unverified">

--- a/src/components/Dashboard/VerifyIdentity.tsx
+++ b/src/components/Dashboard/VerifyIdentity.tsx
@@ -193,7 +193,7 @@ function VerifiedIdentitiesTable(): JSX.Element {
           </div>
           <div className="profile-grid-cell">
             <strong>
-              <FormattedMessage defaultMessage="Swedish national identity number" description="Verified identity" />
+              <FormattedMessage defaultMessage="Swedish national ID number" description="Verified identity" />
             </strong>
           </div>
           <NinDisplay nin={identities?.nin} allowDelete={true} />

--- a/src/styles/_DashboardMain.scss
+++ b/src/styles/_DashboardMain.scss
@@ -8,13 +8,9 @@
   .display-nin-show-hide {
     display: flex;
 
-    .display-data {
-      width: 200px;
-    }
-
     // show and hide button
     button {
-      margin-left: 1rem;
+      margin: 0 0.5rem;
       height: auto;
     }
   }

--- a/src/styles/_figure.scss
+++ b/src/styles/_figure.scss
@@ -40,7 +40,7 @@ figure,
       height: 1.5rem;
     }
     > div {
-      padding: 0.5rem 0.5rem;
+      padding: 0.3rem 0.3rem;
       align-self: center;
 
       .display-data.verified {


### PR DESCRIPTION
#### Description:

In mobile mode, when verifying with the Swedish number in the identity tab. the long text "Swedish national Identity number" causes horizontal scrolling and text is duplicated . therefore, I removed the label text and changed "Identity Namer to ID number to prevent the scroll bar from appearing on mobile.


![Screenshot 2024-09-11 at 12 05 24](https://github.com/user-attachments/assets/c9f6f276-6c58-45ce-98d3-2eb6233850a8)


#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
