### PR TITLE
Add "confirm remove modal" when deleting Identity Verfication or Security Key

### DIFF
--- a/src/apis/eduidSecurity.ts
+++ b/src/apis/eduidSecurity.ts
@@ -286,14 +286,33 @@ export const removeIdentity = createAsyncThunk<
 
 /*********************************************************************************************************************/
 
+export enum ActionStatus {
+  OK = "ok",
+  NOT_FOUND = "not-found",
+  CONSUMED = "consumed",
+  STALE = "stale",
+  WRONG_ACCR = "wrong-accr",
+  NO_MFA = "no-mfa",
+  CREDENTIAL_NOT_RECENTLY_USED = "credential-not-recently-used",
+}
+
+export interface AuthnActionStatusResponse {
+  authn_status: ActionStatus;
+}
+
+export interface AuthnActionStatusRequest {
+  frontend_action: string;
+  credential_id?: string;
+}
+
 /**
  * @public
  * @function getAuthnStatus
  * @desc Redux async thunk to post get authn status.
  */
 export const getAuthnStatus = createAsyncThunk<
-  any, // return type
-  any, // args type
+  AuthnActionStatusResponse, // return type
+  AuthnActionStatusRequest, // args type
   { dispatch: EduIDAppDispatch; state: EduIDAppRootState }
 >("security/authn-status", async (args, thunkAPI) => {
   const body: KeyValues = args;

--- a/src/apis/eduidSecurity.ts
+++ b/src/apis/eduidSecurity.ts
@@ -286,6 +286,24 @@ export const removeIdentity = createAsyncThunk<
 
 /*********************************************************************************************************************/
 
+/**
+ * @public
+ * @function getAuthnStatus
+ * @desc Redux async thunk to post get authn status.
+ */
+export const getAuthnStatus = createAsyncThunk<
+  any, // return type
+  any, // args type
+  { dispatch: EduIDAppDispatch; state: EduIDAppRootState }
+>("security/authn-status", async (args, thunkAPI) => {
+  const body: KeyValues = args;
+  return makeSecurityRequest<any>(thunkAPI, "authn-status", body)
+    .then((response) => response.payload)
+    .catch((err) => thunkAPI.rejectWithValue(err));
+});
+
+/*********************************************************************************************************************/
+
 function makeSecurityRequest<T>(
   thunkAPI: RequestThunkAPI,
   endpoint: string,

--- a/src/components/Common/Security.tsx
+++ b/src/components/Common/Security.tsx
@@ -3,6 +3,7 @@ import { eidasVerifyCredential } from "apis/eduidEidas";
 import {
   beginRegisterWebauthn,
   CredentialType,
+  getAuthnStatus,
   registerWebauthn,
   removeWebauthnToken,
   requestCredentials,
@@ -321,8 +322,9 @@ function SecurityKeyTable(props: RequestCredentialsResponse) {
     }
   }
 
-  function handleConfirmDeleteModal(credential_key: string) {
-    credentialKey.current = credential_key;
+  async function handleConfirmDeleteModal(credential_key: string) {
+    // Test if the user can direct execute the action or a re-auth security zone will be required
+    dispatch(getAuthnStatus({ frontend_action: "removeSecurityKeyAuthn" }));
     setShowConfirmRemoveSecurityKeyModal(true);
   }
 

--- a/src/components/Dashboard/VerifyIdentity.tsx
+++ b/src/components/Dashboard/VerifyIdentity.tsx
@@ -181,6 +181,7 @@ function VerifiedIdentitiesTable(): JSX.Element {
   }
 
   async function handleRemoveIdentity() {
+    setShowConfirmRemoveIdentityVerificationModal(false);
     dispatch(authnSlice.actions.setFrontendActionState());
     // find dynamically which identity_type
     const idType =

--- a/src/components/Dashboard/VerifyIdentity.tsx
+++ b/src/components/Dashboard/VerifyIdentity.tsx
@@ -18,9 +18,10 @@ import SeFlag from "../../../img/flags/se.svg";
 import WorldFlag from "../../../img/flags/world.svg";
 import AccordionItemTemplate from "../Common/AccordionItemTemplate";
 
-import { removeIdentity } from "apis/eduidSecurity";
+import { ActionStatus, getAuthnStatus, removeIdentity } from "apis/eduidSecurity";
 import EduIDButton from "components/Common/EduIDButton";
 import NinDisplay from "components/Common/NinDisplay";
+import NotificationModal from "components/Common/NotificationModal";
 import authnSlice from "slices/Authn";
 import { AuthenticateModal } from "./Authenticate";
 import BankID from "./BankID";
@@ -157,6 +158,7 @@ function VerifiedIdentitiesTable(): JSX.Element {
   const dispatch = useAppDispatch();
   const [showAuthnModal, setShowAuthnModal] = useState(false);
   const frontend_action = useAppSelector((state) => state.authn.frontend_action);
+  const [showConfirmRemoveIdentityVerificationModal, setShowConfirmRemoveIdentityVerificationModal] = useState(false);
 
   useEffect(() => {
     if (frontend_action) {
@@ -165,6 +167,18 @@ function VerifiedIdentitiesTable(): JSX.Element {
       }
     }
   }, [frontend_action]);
+
+  async function handleConfirmDeleteModal() {
+    // Test if the user can directly execute the action or a re-auth security zone will be required
+    // If no re-auth is required, then show the modal to confirm the removal
+    // else show the re-auth modal and do now show the confirmation modal (show only 1 modal)
+    const response = await dispatch(getAuthnStatus({ frontend_action: "removeIdentity" }));
+    if (getAuthnStatus.fulfilled.match(response) && response.payload.authn_status === ActionStatus.OK) {
+      setShowConfirmRemoveIdentityVerificationModal(true);
+    } else {
+      setShowAuthnModal(true);
+    }
+  }
 
   async function handleRemoveIdentity() {
     dispatch(authnSlice.actions.setFrontendActionState());
@@ -201,7 +215,7 @@ function VerifiedIdentitiesTable(): JSX.Element {
             id="remove-webauthn"
             buttonstyle="close"
             size="sm"
-            onClick={() => handleRemoveIdentity()}
+            onClick={() => handleConfirmDeleteModal()}
           ></EduIDButton>
         </figure>
       )}
@@ -221,7 +235,7 @@ function VerifiedIdentitiesTable(): JSX.Element {
             id="remove-webauthn"
             buttonstyle="close"
             size="sm"
-            onClick={() => handleRemoveIdentity()}
+            onClick={() => handleConfirmDeleteModal()}
           ></EduIDButton>
         </figure>
       )}
@@ -245,10 +259,29 @@ function VerifiedIdentitiesTable(): JSX.Element {
             id="remove-webauthn"
             buttonstyle="close"
             size="sm"
-            onClick={() => handleRemoveIdentity()}
+            onClick={() => handleConfirmDeleteModal()}
           ></EduIDButton>
         </figure>
       )}
+      <NotificationModal
+        id="remove-identity-verification"
+        title={
+          <FormattedMessage
+            defaultMessage="Remove Identity Verification"
+            description="settings.remove_identity_verification_modal_title"
+          />
+        }
+        mainText={
+          <FormattedMessage
+            defaultMessage={`Are you sure you want to remove your identity verfication?`}
+            description="delete.remove_identity_verification_modal_text"
+          />
+        }
+        showModal={showConfirmRemoveIdentityVerificationModal}
+        closeModal={() => setShowConfirmRemoveIdentityVerificationModal(false)}
+        acceptModal={handleRemoveIdentity}
+        acceptButtonText={<FormattedMessage defaultMessage="Confirm" description="delete.confirm_button" />}
+      />
       <AuthenticateModal
         action="removeIdentity"
         dispatch={dispatch}


### PR DESCRIPTION
#### Description:

There are 3 important elements in the Idp:
- eduID account itself
- MFA / Security Keys that protects the account
- user Identity Verification

The removal of the account is protected by a confirmation modal, but the other 2 can be removed directly by the user without any confirmation. To help avoid the user to remove so critical items by mistake we introduce a "confirm modal" also for Identity Verification and Security Keys.

However we consider that those 2 functions has been protected by the "security zone"/re-auth which has its own modal. To reduce the amount of clicks the user has to do to achieve the removal, we consider to show only 1 modal:
- either the confirmation modal, if the user does not need to re-auth
- or the re-auth modal, when we know the user has to re-auth. This will act as a form of "remove item" click protection because the user has the chance to "cancel" the operation.

There is a edge-case when the frontend asks the backend if the user has to re-auth few seconds before the condition expires. This scenario is managed by reading the answer of the execution of frontend_action. If backend requires re-auth, we run the re-auth modal right after the confirmation modal.


#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
