### PR TITLE
patch CBOR for misbehaving extensions

### DIFF
--- a/src/helperFunctions/cbor.ts
+++ b/src/helperFunctions/cbor.ts
@@ -164,7 +164,9 @@ export function decode(data: ArrayBufferLike, tagger: any = undefined, simpleVal
     return value;
   }
   function readArrayBuffer(length: number): Uint8Array {
-    return commitRead(length, new Uint8Array(data, offset, length));
+    const arrayBufferView = new Uint8Array(data, offset, length);
+    const arrayBufferCopy = new Uint8Array(arrayBufferView)
+    return commitRead(length, arrayBufferCopy);
   }
   function readFloat16() {
     const tempArrayBuffer = new ArrayBuffer(4);


### PR DESCRIPTION
#### Description:

Some browser extensions, e.g. Bitwarden, can't read some data like user.id due to reading the full buffer from a Uint8Array even if it is a typed array view.
See https://github.com/bitwarden/clients/pull/10657 for a patch for the bitwarden browser extension client. 
This patch makes sure to make a copy so that our customers do not get hindered by the misbehaving browser extensions.

See
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/Uint8Array
and
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/TypedArray#parameters
for the technical details

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
