### PR TITLE
fix help text to the security key button in the MFA page

### DIFF
--- a/src/components/Login/SecurityKey.tsx
+++ b/src/components/Login/SecurityKey.tsx
@@ -48,7 +48,7 @@ function SecurityKeyInactive({ setActive }: SecurityKeyProps): JSX.Element {
       <p className="help-text">
         <FormattedMessage
           description="platform authn help text"
-          defaultMessage="E.g. USB Security Key, Touch ID or Face ID"
+          defaultMessage="E.g. USB Security Key or the device you are currently using."
         />
       </p>
       <EduIDButton

--- a/src/translation/extractedMessages.json
+++ b/src/translation/extractedMessages.json
@@ -938,6 +938,10 @@
     "developer_comment": "help text for custom password tips",
     "string": "Use upper- and lowercase characters, but not at the beginning or end"
   },
+  "NT4bZ4": {
+    "developer_comment": "platform authn help text",
+    "string": "E.g. USB Security Key or the device you are currently using."
+  },
   "NcY26W": {
     "developer_comment": "why have eduID - paragraph 2",
     "string": "There are many services that require identification of users. This is often done by the user entering an email address to which the service provider sends a password. Such a user is normally called unconfirmed, because the service provider does not really know who the user with that email address is - and for many services this is at a sufficient level. Through the use of eduID, identification of users is elevated to that of confirmed users."
@@ -1978,10 +1982,6 @@
   "j0hRyW": {
     "developer_comment": "Phones main title",
     "string": "Mobile phone numbers"
-  },
-  "j8KKR3": {
-    "developer_comment": "platform authn help text",
-    "string": "E.g. USB Security Key, Touch ID or Face ID"
   },
   "j8RvSZ": {
     "developer_comment": "use freja - list definition",


### PR DESCRIPTION
#### Description:

[Replace this with a description of what you've done - if styling-related work please include a screenshot]

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
