### PR TITLE
Cat post obs fixes

### DIFF
--- a/src/components/Common/ConfirmModal.tsx
+++ b/src/components/Common/ConfirmModal.tsx
@@ -9,6 +9,7 @@ import EduIDButton from "./EduIDButton";
 interface ConfirmModalProps {
   readonly id: string;
   readonly title: React.ReactNode;
+  readonly mainText?: React.ReactNode;
   readonly placeholder: string;
   readonly showModal: boolean;
   readonly closeModal: () => void;
@@ -71,6 +72,9 @@ function ConfirmModal(props: ConfirmModalProps): JSX.Element {
                     />
                   </React.Fragment>
                 )}
+
+                {props.mainText ? props.mainText : null}
+
                 <div id="confirmation-code-area">
                   <FinalField<string>
                     component={CustomInput}

--- a/src/components/Common/CopyToClipboardButton.tsx
+++ b/src/components/Common/CopyToClipboardButton.tsx
@@ -1,3 +1,4 @@
+import EduIDButton from "components/Common/EduIDButton";
 import { forwardRef, useState } from "react";
 import { FormattedMessage } from "react-intl";
 
@@ -17,16 +18,12 @@ export const CopyToClipboardButton = forwardRef((props, ref: any) => {
   }
 
   return (
-    <button
-      className="show-hide-button"
-      onClick={copyToClipboard}
-      aria-label={tooltipCopied ? "Copied!" : "Copy to clipboard"}
-    >
+    <EduIDButton className="txt-toggle-btn" buttonstyle="link" size="sm" onClick={copyToClipboard}>
       {tooltipCopied ? (
         <FormattedMessage defaultMessage="COPIED" description="copied button label" />
       ) : (
         <FormattedMessage defaultMessage="COPY" description="copy button label" />
       )}
-    </button>
+    </EduIDButton>
   );
 });

--- a/src/components/Common/CopyToClipboardButton.tsx
+++ b/src/components/Common/CopyToClipboardButton.tsx
@@ -23,9 +23,9 @@ export const CopyToClipboardButton = forwardRef((props, ref: any) => {
       aria-label={tooltipCopied ? "Copied!" : "Copy to clipboard"}
     >
       {tooltipCopied ? (
-        <FormattedMessage defaultMessage="COPIED" description="eppn copy button label" />
+        <FormattedMessage defaultMessage="COPIED" description="copied button label" />
       ) : (
-        <FormattedMessage defaultMessage="COPY" description="eppn copy button label" />
+        <FormattedMessage defaultMessage="COPY" description="copy button label" />
       )}
     </button>
   );

--- a/src/components/Common/CopyToClipboardButton.tsx
+++ b/src/components/Common/CopyToClipboardButton.tsx
@@ -1,0 +1,32 @@
+import { forwardRef, useState } from "react";
+import { FormattedMessage } from "react-intl";
+
+export const CopyToClipboardButton = forwardRef((props, ref: any) => {
+  const [tooltipCopied, setTooltipCopied] = useState(false); // say "Copy to clipboard" or "Copied!" in tooltip
+
+  function copyToClipboard() {
+    if (ref && ref.current) {
+      ref.current.select();
+      document.execCommand("copy");
+      setTooltipCopied(true);
+
+      setTimeout(() => {
+        setTooltipCopied(false);
+      }, 10000);
+    }
+  }
+
+  return (
+    <button
+      className="show-hide-button"
+      onClick={copyToClipboard}
+      aria-label={tooltipCopied ? "Copied!" : "Copy to clipboard"}
+    >
+      {tooltipCopied ? (
+        <FormattedMessage defaultMessage="COPIED" description="eppn copy button label" />
+      ) : (
+        <FormattedMessage defaultMessage="COPY" description="eppn copy button label" />
+      )}
+    </button>
+  );
+});

--- a/src/components/Common/PasswordInput.tsx
+++ b/src/components/Common/PasswordInput.tsx
@@ -1,3 +1,4 @@
+import EduIDButton from "components/Common/EduIDButton";
 import React, { useState } from "react";
 import { FieldRenderProps, Field as FinalField } from "react-final-form";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -68,10 +69,11 @@ export function PasswordInputElement(props: InputProps): JSX.Element {
         autoFocus={props.autoFocus}
       />
 
-      <button
-        type="button"
+      <EduIDButton
+        className="txt-toggle-btn"
+        buttonstyle="link"
+        size="sm"
         aria-label={showPassword ? "hide password" : "show password"}
-        className="show-hide-button"
         onClick={toggleShowPassword}
         tabIndex={-1}
       >
@@ -80,7 +82,7 @@ export function PasswordInputElement(props: InputProps): JSX.Element {
         ) : (
           <FormattedMessage defaultMessage="SHOW" description="nin/password button label" />
         )}
-      </button>
+      </EduIDButton>
     </div>
   );
 }

--- a/src/components/Common/Security.tsx
+++ b/src/components/Common/Security.tsx
@@ -251,6 +251,14 @@ export function Security(): React.ReactElement | null {
             defaultMessage="Add a name for your security key"
           />
         }
+        mainText={
+          <p>
+            <FormattedMessage
+              description="security webauthn describe paragraph"
+              defaultMessage={`Note: this is only for your own use to be able to distinguish between your added keys.`}
+            />
+          </p>
+        }
         placeholder={placeholder}
         showModal={showSecurityKeyNameModal}
         closeModal={handleStopAskingWebauthnDescription}

--- a/src/components/Dashboard/AccountId.tsx
+++ b/src/components/Dashboard/AccountId.tsx
@@ -22,7 +22,6 @@ export function AccountId(): JSX.Element {
         />
       </p>
       <div className="profile-grid-cell figure tight">
-        <CopyToClipboard ref={ref} />
         <span aria-label={idUserEppn}>
           <strong>
             <FormattedMessage defaultMessage="Unique ID:" description="Dashboard AccountId" />
@@ -31,6 +30,7 @@ export function AccountId(): JSX.Element {
         </span>
         <div className="display-data">
           <input readOnly={true} name={eppn} id={idUserEppn} ref={ref} defaultValue={eppn} />
+          <CopyToClipboard ref={ref} />
         </div>
       </div>
     </article>

--- a/src/components/Dashboard/AccountId.tsx
+++ b/src/components/Dashboard/AccountId.tsx
@@ -1,4 +1,4 @@
-import { CopyToClipboard } from "components/Common/CopyToClipboard";
+import { CopyToClipboardButton } from "components/Common/CopyToClipboardButton";
 import { useAppSelector } from "eduid-hooks";
 import { useRef } from "react";
 import { FormattedMessage } from "react-intl";
@@ -30,7 +30,7 @@ export function AccountId(): JSX.Element {
         </span>
         <div className="display-data">
           <input readOnly={true} name={eppn} id={idUserEppn} ref={ref} defaultValue={eppn} />
-          <CopyToClipboard ref={ref} />
+          <CopyToClipboardButton ref={ref} />
         </div>
       </div>
     </article>

--- a/src/components/Dashboard/AccountId.tsx
+++ b/src/components/Dashboard/AccountId.tsx
@@ -22,6 +22,7 @@ export function AccountId(): JSX.Element {
         />
       </p>
       <div className="profile-grid-cell figure tight">
+        <CopyToClipboard ref={ref} />
         <span aria-label={idUserEppn}>
           <strong>
             <FormattedMessage defaultMessage="Unique ID:" description="Dashboard AccountId" />
@@ -30,7 +31,6 @@ export function AccountId(): JSX.Element {
         </span>
         <div className="display-data">
           <input readOnly={true} name={eppn} id={idUserEppn} ref={ref} defaultValue={eppn} />
-          <CopyToClipboard ref={ref} />
         </div>
       </div>
     </article>

--- a/src/components/Dashboard/ChangePasswordSuggested.tsx
+++ b/src/components/Dashboard/ChangePasswordSuggested.tsx
@@ -1,4 +1,4 @@
-import { CopyToClipboard } from "components/Common/CopyToClipboard";
+import { CopyToClipboardButton } from "components/Common/CopyToClipboardButton";
 import { NewPasswordForm } from "components/Common/NewPasswordForm";
 import React, { useRef } from "react";
 import { FormattedMessage } from "react-intl";
@@ -21,7 +21,7 @@ export default function ChangePasswordSuggestedForm(props: ChangePasswordChildFo
           defaultValue={props.suggestedPassword}
           readOnly={true}
         />
-        <CopyToClipboard ref={ref} />
+        <CopyToClipboardButton ref={ref} />
       </div>
       <NewPasswordForm
         suggested_password={props.suggestedPassword}

--- a/src/components/Dashboard/ChangePasswordSuggested.tsx
+++ b/src/components/Dashboard/ChangePasswordSuggested.tsx
@@ -13,7 +13,7 @@ export default function ChangePasswordSuggestedForm(props: ChangePasswordChildFo
         <label htmlFor="copy-new-password">
           <FormattedMessage defaultMessage="New password" description="new password" />
         </label>
-        <CopyToClipboard ref={ref} />
+
         <input
           name="copy-new-password"
           id="copy-new-password"
@@ -21,6 +21,7 @@ export default function ChangePasswordSuggestedForm(props: ChangePasswordChildFo
           defaultValue={props.suggestedPassword}
           readOnly={true}
         />
+        <CopyToClipboard ref={ref} />
       </div>
       <NewPasswordForm
         suggested_password={props.suggestedPassword}

--- a/src/components/Dashboard/ChangePasswordSuggested.tsx
+++ b/src/components/Dashboard/ChangePasswordSuggested.tsx
@@ -13,6 +13,7 @@ export default function ChangePasswordSuggestedForm(props: ChangePasswordChildFo
         <label htmlFor="copy-new-password">
           <FormattedMessage defaultMessage="New password" description="new password" />
         </label>
+        <CopyToClipboard ref={ref} />
         <input
           name="copy-new-password"
           id="copy-new-password"
@@ -20,7 +21,6 @@ export default function ChangePasswordSuggestedForm(props: ChangePasswordChildFo
           defaultValue={props.suggestedPassword}
           readOnly={true}
         />
-        <CopyToClipboard ref={ref} />
       </div>
       <NewPasswordForm
         suggested_password={props.suggestedPassword}

--- a/src/components/Dashboard/VerifyIdentity.tsx
+++ b/src/components/Dashboard/VerifyIdentity.tsx
@@ -157,6 +157,8 @@ function VerifiedIdentitiesTable(): JSX.Element {
   const frontend_action = useAppSelector((state) => state.authn.response?.frontend_action);
   const [showConfirmRemoveIdentityVerificationModal, setShowConfirmRemoveIdentityVerificationModal] = useState(false);
 
+  const intl = useIntl();
+
   useEffect(() => {
     if (frontend_action) {
       if (frontend_action === "removeIdentity") {
@@ -209,6 +211,10 @@ function VerifiedIdentitiesTable(): JSX.Element {
             buttonstyle="close"
             size="sm"
             onClick={() => handleConfirmDeleteModal()}
+            title={intl.formatMessage({
+              id: "verified identity delete button",
+              defaultMessage: "Delete this verified identity",
+            })}
           ></EduIDButton>
         </figure>
       )}

--- a/src/components/IndexMain.tsx
+++ b/src/components/IndexMain.tsx
@@ -23,6 +23,7 @@ import Login from "./Login/Login";
 import { LoginExternalReturnHandler } from "./Login/LoginExternalReturnHandler";
 import UseOtherDevice2 from "./Login/UseOtherDevice2";
 import { ResetPasswordApp } from "./ResetPassword/ResetPasswordApp";
+import ScrollToTop from "./ScrollToTop";
 import { SignupApp } from "./Signup/SignupApp";
 import { Errors } from "./SwamidErrors/Errors";
 
@@ -50,6 +51,7 @@ export function IndexMain(): JSX.Element {
         <ErrorBoundary FallbackComponent={GenericError}>
           <Splash showChildren={isLoaded}>
             <section id="content" className="horizontal-content-margin content">
+              <ScrollToTop />
               <Routes>
                 <Route path="/" element={<Index />} />
                 {/* Signup */}

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,12 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+export default function ScrollToTop() {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+}

--- a/src/styles/_ResetPassword.scss
+++ b/src/styles/_ResetPassword.scss
@@ -102,7 +102,7 @@ a#resend-phone:not(.button-active) {
 .copybutton {
   position: absolute;
   width: auto !important;
-  left: 1rem;
+  right: 1rem;
 
   svg {
     color: $txt-black;
@@ -125,7 +125,8 @@ a#resend-phone:not(.button-active) {
     position: absolute;
     z-index: 5;
     bottom: 85%;
-    left: -1rem;
+    left: 1rem;
+    margin-left: -75px;
     opacity: 0;
     transition: opacity 0.3s;
     text-transform: none;
@@ -136,7 +137,7 @@ a#resend-phone:not(.button-active) {
     content: "";
     position: absolute;
     top: 100%;
-    left: 0;
+    left: 2.6rem;
     margin-left: 20px;
     border-width: 5px;
     border-style: solid;
@@ -149,11 +150,6 @@ a#resend-phone:not(.button-active) {
   }
   &:focus-visible {
     outline: auto;
-  }
-
-  //allowing space between absolute button and next element
-  + * {
-    padding-left: 1.75em;
   }
 }
 

--- a/src/styles/_ResetPassword.scss
+++ b/src/styles/_ResetPassword.scss
@@ -101,8 +101,8 @@ a#resend-phone:not(.button-active) {
 
 .copybutton {
   position: absolute;
-  right: 1rem;
   width: auto !important;
+  left: 1rem;
 
   svg {
     color: $txt-black;
@@ -125,18 +125,18 @@ a#resend-phone:not(.button-active) {
     position: absolute;
     z-index: 5;
     bottom: 85%;
-    left: 1rem;
-    margin-left: -75px;
+    left: -1rem;
     opacity: 0;
     transition: opacity 0.3s;
-    text-transform: capitalize;
+    text-transform: none;
+    line-height: 1.2;
   }
 
   .tool-tip-text::after {
     content: "";
     position: absolute;
     top: 100%;
-    left: 2.6rem;
+    left: 0;
     margin-left: 20px;
     border-width: 5px;
     border-style: solid;
@@ -149,6 +149,11 @@ a#resend-phone:not(.button-active) {
   }
   &:focus-visible {
     outline: auto;
+  }
+
+  //allowing space between absolute button and next element
+  + * {
+    padding-left: 1.75em;
   }
 }
 

--- a/src/styles/_buttons.scss
+++ b/src/styles/_buttons.scss
@@ -252,10 +252,8 @@ button.btn-icon {
   }
 }
 
-// login username-pw / reset-password set-new-password
-.show-hide-button {
-  @extend #{".btn", ".btn-link", ".btn-sm"};
-
+//textual toggle control, eg. copy/show
+.txt-toggle-btn {
   position: absolute;
   right: 1rem;
 }

--- a/src/styles/_label.scss
+++ b/src/styles/_label.scss
@@ -10,10 +10,10 @@ label,
 }
 
 .border-toggle-area {
-	flex-basis: 100%;
-	border-color: var(--borderColor-default,var(--color-border-default,#d0d7de));
-	border-width: 1px;
-	border-style: solid;
-	border-radius: 10px;
-	padding: 16px;
+  flex-basis: 100%;
+  border-color: $border-gray;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 10px;
+  padding: 16px;
 }

--- a/src/translation/extractedMessages.json
+++ b/src/translation/extractedMessages.json
@@ -1340,6 +1340,10 @@
     "developer_comment": "eidas proofing help text",
     "string": "To use this option you will need to first create a digital ID-card in the {freja_eid_link} app."
   },
+  "YhOtY3": {
+    "developer_comment": "copied button label",
+    "string": "COPIED"
+  },
   "Z4yZ3N": {
     "developer_comment": "Use another device, finished",
     "string": "After using the code on the other device, please close this browser window."
@@ -1989,6 +1993,10 @@
   "kK4Hum": {
     "developer_comment": "Account recovery cancel information",
     "string": "If you decide to cancel, simply click the Go Back button to return to the login page."
+  },
+  "kKMiD/": {
+    "developer_comment": "copy button label",
+    "string": "COPY"
   },
   "kN1GC+": {
     "developer_comment": "Make primary button",

--- a/src/translation/extractedMessages.json
+++ b/src/translation/extractedMessages.json
@@ -752,6 +752,10 @@
     "developer_comment": "security key status",
     "string": "Verify"
   },
+  "HgfPrt": {
+    "developer_comment": "security webauthn describe paragraph",
+    "string": "Note: this is only for your own use to be able to distinguish between your added keys."
+  },
   "HgjRtU": {
     "developer_comment": "button add more",
     "string": "+ add more"
@@ -2912,6 +2916,9 @@
   "vQpAQz": {
     "developer_comment": "verification status sub text",
     "string": "Your eduID is ready to use."
+  },
+  "verified identity delete button": {
+    "string": "Delete this verified identity"
   },
   "vmreyb": {
     "developer_comment": "accordion item Adding name",


### PR DESCRIPTION
#### Description:

- copy icon before field to be copied inst of after
- translatable hover title on X- icon where identity is removed
- added reusable scrolltotop component, included in indexmain at navigation.
- added optional maintext paragraf in confirm modal with text to explain key naming
- reused border site-variabel for mfa-toggle

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
