### PR TITLE
Cat making figure fit

### DIFF
--- a/src/styles/_PersonalData.scss
+++ b/src/styles/_PersonalData.scss
@@ -9,25 +9,10 @@
     }
   }
 
-  //TODO: remove this when we move icon-text to a more generic place
   .name-inputs {
     .icon-text {
       display: flex;
       align-items: baseline;
-
-      button.icon-only {
-        &:hover,
-        &:active,
-        &:focus,
-        &:active:focus {
-          transform: rotate(180deg);
-          padding: initial;
-        }
-
-        svg {
-          color: $bright-orange;
-        }
-      }
 
       label.hint {
         font-family: inherit;

--- a/src/styles/_buttons.scss
+++ b/src/styles/_buttons.scss
@@ -24,11 +24,12 @@ button.btn {
 
   &:disabled,
   .disabled {
-    cursor: not-allowed;
+    cursor: not-allowed !important;
     pointer-events: all !important;
     border-color: inherit;
     color: $white;
-    &:not(.btn-link) {
+
+    &.btn-primary {
       background-color: $btn-orange;
     }
   }
@@ -253,6 +254,14 @@ button.btn-icon {
 
     svg {
       color: $bright-orange;
+    }
+    &:disabled {
+      &:hover {
+        transform: none;
+      }
+      path {
+        fill: $txt-gray;
+      }
     }
   }
 

--- a/src/styles/_figure.scss
+++ b/src/styles/_figure.scss
@@ -26,7 +26,7 @@ figure,
     }
   }
   &.tight {
-    padding: 0.5em 1em;
+    padding: 0.5rem 1rem;
   }
   &.grid-container {
     display: grid;

--- a/src/styles/_inputs.scss
+++ b/src/styles/_inputs.scss
@@ -53,9 +53,6 @@ input::placeholder {
   transition: none !important;
 
   //has parents with overflow hidden
-  &[type="text"],
-  &[type="password"],
-  &[type="email"],
   &.accordion__button,
   table & {
     outline-offset: -2px;


### PR DESCRIPTION
#### Description:

- figure.tight rem unit inst em to play nice with child elements spacing (eg remove eppn button)
- removed outline-offset on text input focus to keep size, not needed now as they already have outline (eg text, email, password)
- gathered icon-only button styles to button css, disabled style (eg captcha, displayname update).

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
