### PR TITLE
Fix: Button ref not working, even though using the same component

### DIFF
--- a/src/components/Common/SecurityKey.tsx
+++ b/src/components/Common/SecurityKey.tsx
@@ -43,6 +43,11 @@ export function SecurityKey(props: SecurityKeyProps): JSX.Element {
 
 function SecurityKeyInactive(props: SecurityKeyProps): JSX.Element {
   const ref = useRef<HTMLButtonElement>(null);
+  let buttonDisabled = false;
+
+  if (props.webauthn !== undefined && !props.webauthn) {
+    buttonDisabled = true;
+  }
 
   useEffect(() => {
     if (ref.current) ref?.current?.focus();
@@ -68,7 +73,7 @@ function SecurityKeyInactive(props: SecurityKeyProps): JSX.Element {
           if (props.setActive) props.setActive(true);
         }}
         id="mfa-security-key"
-        disabled={!props.webauthn}
+        disabled={buttonDisabled}
       >
         <FormattedMessage description="login mfa primary option button" defaultMessage="Use security key" />
       </button>


### PR DESCRIPTION
#### Description:

The disabled prop prevents the button focus ref
![Screenshot 2025-03-21 at 12 54 39](https://github.com/user-attachments/assets/fe1731ec-83e9-433a-94f1-283a6a8953b6)



#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
