### PR TITLE
Cleanup some errrors and warnings

### DIFF
--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -5,7 +5,7 @@ export default function ScrollToTop() {
   const { pathname } = useLocation();
 
   useEffect(() => {
-    window.scrollTo(0, 0);
+    window.scroll(0, 0);
   }, [pathname]);
 
   return null;

--- a/src/tests/AccountLinking-test.tsx
+++ b/src/tests/AccountLinking-test.tsx
@@ -5,6 +5,11 @@ import { act } from "react";
 import { mswServer, rest } from "setupTests";
 import { defaultDashboardTestState, fireEvent, render, screen } from "./helperFunctions/DashboardTestApp-rtl";
 
+beforeEach(() => {
+  // mock window.scroll for the notification middleware that scrolls to the top of the screen
+  window.scroll = jest.fn();
+});
+
 test("renders AccountLinking as expected", async () => {
   render(<IndexMain />, {
     routes: ["/profile"],

--- a/src/tests/AccountLinking-test.tsx
+++ b/src/tests/AccountLinking-test.tsx
@@ -1,7 +1,7 @@
 import { OrcidInfo } from "apis/eduidOrcid";
 import { activeClassName } from "components/Common/HeaderNav";
 import { IndexMain } from "components/IndexMain";
-import { act } from "react-dom/test-utils";
+import { act } from "react";
 import { mswServer, rest } from "setupTests";
 import { defaultDashboardTestState, fireEvent, render, screen } from "./helperFunctions/DashboardTestApp-rtl";
 

--- a/src/tests/AdvancedSettings-test.tsx
+++ b/src/tests/AdvancedSettings-test.tsx
@@ -3,6 +3,11 @@ import { initialState as configInitialState } from "slices/IndexConfig";
 import { initialState } from "slices/PersonalData";
 import { render } from "./helperFunctions/DashboardTestApp-rtl";
 
+beforeEach(() => {
+  // mock window.scroll for the notification middleware that scrolls to the top of the screen
+  window.scroll = jest.fn();
+});
+
 test("renders AccountId as expected", () => {
   const test_eppn = "test-123";
 

--- a/src/tests/BankID-test.tsx
+++ b/src/tests/BankID-test.tsx
@@ -1,5 +1,5 @@
 import { IndexMain } from "components/IndexMain";
-import { act } from "react-dom/test-utils";
+import { act } from "react";
 import { initialState as configInitialState } from "slices/IndexConfig";
 import { defaultDashboardTestState, render, screen, waitFor } from "./helperFunctions/DashboardTestApp-rtl";
 

--- a/src/tests/BankID-test.tsx
+++ b/src/tests/BankID-test.tsx
@@ -3,6 +3,11 @@ import { act } from "react";
 import { initialState as configInitialState } from "slices/IndexConfig";
 import { defaultDashboardTestState, render, screen, waitFor } from "./helperFunctions/DashboardTestApp-rtl";
 
+beforeEach(() => {
+  // mock window.scroll for the notification middleware that scrolls to the top of the screen
+  window.scroll = jest.fn();
+});
+
 test("renders bankID as expected", async () => {
   render(<IndexMain />, {
     state: {

--- a/src/tests/DashboardMain-test.tsx
+++ b/src/tests/DashboardMain-test.tsx
@@ -3,6 +3,11 @@ import { IndexMain } from "components/IndexMain";
 import { initialState as configInitialState } from "slices/IndexConfig";
 import { defaultDashboardTestState, render, screen } from "./helperFunctions/DashboardTestApp-rtl";
 
+beforeEach(() => {
+  // mock window.scroll for the notification middleware that scrolls to the top of the screen
+  window.scroll = jest.fn();
+});
+
 test("shows splash screen when not configured", () => {
   render(<IndexMain />, {
     state: { config: { ...configInitialState, is_app_loaded: false } },

--- a/src/tests/DashboardStart-test.tsx
+++ b/src/tests/DashboardStart-test.tsx
@@ -3,6 +3,11 @@ import { act } from "react";
 import { initialState as configInitialState } from "slices/IndexConfig";
 import { defaultDashboardTestState, render, screen, waitFor } from "./helperFunctions/DashboardTestApp-rtl";
 
+beforeEach(() => {
+  // mock window.scroll for the notification middleware that scrolls to the top of the screen
+  window.scroll = jest.fn();
+});
+
 test("start page heading text for new user", async () => {
   render(<IndexMain />, {
     state: {

--- a/src/tests/DeleteAccount-test.tsx
+++ b/src/tests/DeleteAccount-test.tsx
@@ -15,6 +15,11 @@ async function linkToAccountSettings() {
   expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
 }
 
+beforeEach(() => {
+  // mock window.scroll for the notification middleware that scrolls to the top of the screen
+  window.scroll = jest.fn();
+});
+
 test("renders DeleteAccount as expected", async () => {
   render(<IndexMain />);
 

--- a/src/tests/DeleteAccount-test.tsx
+++ b/src/tests/DeleteAccount-test.tsx
@@ -1,6 +1,6 @@
 import { activeClassName } from "components/Common/HeaderNav";
 import { IndexMain } from "components/IndexMain";
-import { act } from "react-dom/test-utils";
+import { act } from "react";
 import { mswServer, rest } from "setupTests";
 import { defaultDashboardTestState, fireEvent, render, screen, waitFor } from "./helperFunctions/DashboardTestApp-rtl";
 

--- a/src/tests/Eidas-test.tsx
+++ b/src/tests/Eidas-test.tsx
@@ -1,5 +1,5 @@
 import Eidas from "components/Dashboard/Eidas";
-import { act } from "react-dom/test-utils";
+import { act } from "react";
 import { render, screen, waitFor } from "./helperFunctions/DashboardTestApp-rtl";
 
 test("renders frejaeID", () => {

--- a/src/tests/Emails-test.tsx
+++ b/src/tests/Emails-test.tsx
@@ -1,5 +1,5 @@
 import Emails from "components/Dashboard/Emails";
-import { act } from "react-dom/test-utils";
+import { act } from "react";
 import { fireEvent, render, screen } from "./helperFunctions/DashboardTestApp-rtl";
 
 test("renders Emails component as expected", () => {

--- a/src/tests/FrejaeID-test.tsx
+++ b/src/tests/FrejaeID-test.tsx
@@ -4,6 +4,11 @@ import { act } from "react";
 import { mswServer, rest } from "setupTests";
 import { defaultDashboardTestState, render, screen } from "./helperFunctions/DashboardTestApp-rtl";
 
+beforeEach(() => {
+  // mock window.scroll for the notification middleware that scrolls to the top of the screen
+  window.scroll = jest.fn();
+});
+
 test("renders frejaeID as expected", () => {
   const method = "frejaeIDVerifyIdentity";
 

--- a/src/tests/FrejaeID-test.tsx
+++ b/src/tests/FrejaeID-test.tsx
@@ -1,6 +1,6 @@
 import { VerifyIdentityRequest, VerifyIdentityResponse } from "apis/eduidFrejaeID";
 import { IndexMain } from "components/IndexMain";
-import { act } from "react-dom/test-utils";
+import { act } from "react";
 import { mswServer, rest } from "setupTests";
 import { defaultDashboardTestState, render, screen } from "./helperFunctions/DashboardTestApp-rtl";
 

--- a/src/tests/LetterProofing-test.tsx
+++ b/src/tests/LetterProofing-test.tsx
@@ -1,5 +1,5 @@
 import LetterProofing from "components/Dashboard/LetterProofing";
-import { act } from "react-dom/test-utils";
+import { act } from "react";
 import { render, screen, waitFor } from "./helperFunctions/DashboardTestApp-rtl";
 
 test("renders LetterProofing without ID number", () => {

--- a/src/tests/Security-test.tsx
+++ b/src/tests/Security-test.tsx
@@ -7,7 +7,7 @@ import {
   RequestCredentialsResponse,
 } from "apis/eduidSecurity";
 import { IndexMain } from "components/IndexMain";
-import { act } from "react-dom/test-utils";
+import { act } from "react";
 import { mswServer, rest } from "setupTests";
 import securitySlice, { initialState } from "slices/Security";
 import { defaultDashboardTestState, render, screen, waitFor, within } from "./helperFunctions/DashboardTestApp-rtl";

--- a/src/tests/Security-test.tsx
+++ b/src/tests/Security-test.tsx
@@ -22,6 +22,11 @@ async function linkToAdvancedSettings() {
   expect(screen.getByRole("heading", { level: 2, name: "Two-factor Authentication (2FA)" })).toBeInTheDocument();
 }
 
+beforeEach(() => {
+  // mock window.scroll for the notification middleware that scrolls to the top of the screen
+  window.scroll = jest.fn();
+});
+
 test("renders security key as expected, not security key added", async () => {
   render(<IndexMain />);
   await linkToAdvancedSettings();
@@ -100,7 +105,7 @@ test("can remove a security key", async () => {
             created_ts: "2021-12-02",
             credential_type: "security.webauthn_credential_type",
             description: "extra touchID",
-            key: "dummy dummy",
+            key: "dummy dummy2",
             success_ts: "2022-10-17",
             used_for_login: false,
             verified: false,

--- a/src/tests/VerifyIdentity-test.tsx
+++ b/src/tests/VerifyIdentity-test.tsx
@@ -1,7 +1,7 @@
 import { activeClassName } from "components/Common/HeaderNav";
 import VerifyIdentity from "components/Dashboard/Identity";
 import { IndexMain } from "components/IndexMain";
-import { act } from "react-dom/test-utils";
+import { act } from "react";
 import { initialState as configInitialState } from "slices/IndexConfig";
 import { defaultDashboardTestState, fireEvent, render, screen, waitFor } from "./helperFunctions/DashboardTestApp-rtl";
 

--- a/src/tests/VerifyIdentity-test.tsx
+++ b/src/tests/VerifyIdentity-test.tsx
@@ -16,6 +16,11 @@ async function linkToIdentitySettings() {
   expect(screen.queryByRole("progressbar")).not.toBeInTheDocument();
 }
 
+beforeEach(() => {
+  // mock window.scroll for the notification middleware that scrolls to the top of the screen
+  window.scroll = jest.fn();
+});
+
 test("renders verifyIdentity, non verified user", async () => {
   render(<VerifyIdentity />);
   expect(screen.getByRole("heading", { name: /Identity/i })).toBeInTheDocument();

--- a/src/tests/login/LoginMain-test.tsx
+++ b/src/tests/login/LoginMain-test.tsx
@@ -3,6 +3,11 @@ import { IndexMain } from "components/IndexMain";
 import { mswServer, rest } from "setupTests";
 import { loginTestState, render, screen, waitFor } from "../helperFunctions/LoginTestApp-rtl";
 
+beforeEach(() => {
+  // mock window.scroll for the notification middleware that scrolls to the top of the screen
+  window.scroll = jest.fn();
+});
+
 test("show splash screen when not configured", () => {
   render(<IndexMain />, {
     state: {

--- a/src/tests/login/LoginResetPassword-test.tsx
+++ b/src/tests/login/LoginResetPassword-test.tsx
@@ -15,6 +15,11 @@ import { fireEvent, loginTestState, render, screen, waitFor } from "../helperFun
 
 const TEST_PASSWORD = "password";
 
+beforeEach(() => {
+  // mock window.scroll for the notification middleware that scrolls to the top of the screen
+  window.scroll = jest.fn();
+});
+
 test("can click 'forgot password' with an e-mail address", async () => {
   const email = "test@example.org";
   const ref = "abc567";


### PR DESCRIPTION
#### Description:

Cleanup some of the errors and warning that are output during tests
* replace only use of window.scrollTo with window.scroll to unify usage
* mock window.scroll in more tests
* as per warnings use act from react and not from react-dom/test-utils

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
