### PR TITLE
Limit logging to development environment

### DIFF
--- a/src/eduid-init-app.ts
+++ b/src/eduid-init-app.ts
@@ -4,7 +4,10 @@ import eduIDApp from "./eduid-store";
 import notifyAndDispatch from "./notify-middleware";
 
 /* setup to run the combined sagas */
-const middlewares = [notifyAndDispatch, logger];
+const middlewares = [notifyAndDispatch];
+if (process.env.NODE_ENV === "development") {
+  middlewares.push(logger);
+}
 
 export const eduidStore = configureStore({
   reducer: eduIDApp,

--- a/src/eduid-init-app.ts
+++ b/src/eduid-init-app.ts
@@ -5,7 +5,7 @@ import notifyAndDispatch from "./notify-middleware";
 
 /* setup to run the combined sagas */
 const middlewares = [notifyAndDispatch];
-if (process.env.NODE_ENV === "development") {
+if (process.env.NODE_ENV !== "production") {
   middlewares.push(logger);
 }
 

--- a/src/notify-middleware.ts
+++ b/src/notify-middleware.ts
@@ -1,7 +1,8 @@
+import { Middleware } from "redux";
 import { clearNotifications, showNotification } from "slices/Notifications";
 
 showNotification;
-const notifyAndDispatch = () => (next: any) => (action: any) => {
+const notifyAndDispatch: Middleware = () => (next: any) => (action: any) => {
   if (action.type.endsWith("FAIL")) {
     if (
       action.payload.message === "authn_status.must-authenticate" ||


### PR DESCRIPTION
#### Description:

Limit the use of redux-logger middleware to development

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
