### PR TITLE
minimal patch to make login work with security key first

### DIFF
--- a/src/apis/eduidLogin.ts
+++ b/src/apis/eduidLogin.ts
@@ -378,6 +378,7 @@ export const fetchNewDevice = createAsyncThunk<
 export interface LoginMfaAuthRequest {
   ref: string;
   webauthn_response?: webauthnAssertion;
+  this_device?: string;
 }
 
 export interface LoginMfaAuthResponse {

--- a/src/components/Common/SecurityKey.tsx
+++ b/src/components/Common/SecurityKey.tsx
@@ -86,6 +86,7 @@ function SecurityKeyActive(props: SecurityKeyProps): JSX.Element {
   //login
   const mfa = useAppSelector((state) => state.login.mfa);
   const ref = useAppSelector((state) => state.login.ref);
+  const this_device = useAppSelector((state) => state.login.this_device);
   //resetpw
   const resetPasswordContext = useContext(ResetPasswordGlobalStateContext);
   const webauthn_assertion = useAppSelector((state) => state.resetPassword.webauthn_assertion);
@@ -96,7 +97,7 @@ function SecurityKeyActive(props: SecurityKeyProps): JSX.Element {
         const res = await dispatch(performAuthentication(webauthn_challenge));
         if (performAuthentication.fulfilled.match(res)) {
           // Send response from security key to backend
-          dispatch(fetchMfaAuth({ ref: ref, webauthn_response: res.payload }));
+          dispatch(fetchMfaAuth({ ref: ref, this_device: this_device, webauthn_response: res.payload }));
         }
         if (props.setActive) props.setActive(false);
       }

--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -76,9 +76,8 @@ function Login(): JSX.Element {
       {next_page === "MFA" && <MultiFactorAuth />}
       {next_page === "FINISHED" && <RenderFinished />}
       {
-        /* show remember me toggle only for login password page */ next_page === "USERNAMEPASSWORD" && (
-          <RememberMeCheckbox />
-        )
+        /* show remember me toggle only for login password and MFA page */ (next_page === "USERNAMEPASSWORD" ||
+          next_page === "MFA") && <RememberMeCheckbox />
       }
     </React.Fragment>
   );

--- a/src/components/Login/MultiFactorAuth.tsx
+++ b/src/components/Login/MultiFactorAuth.tsx
@@ -14,6 +14,7 @@ export function MultiFactorAuth(): JSX.Element {
   const authn_options = useAppSelector((state) => state.login.authn_options);
   const mfa = useAppSelector((state) => state.login.mfa);
   const ref = useAppSelector((state) => state.login.ref);
+  const this_device = useAppSelector((state) => state.login.this_device);
 
   const isLoaded = mfa?.state === "loaded";
   //TODO: when backend is updated to swedish_eid, we should be able to rename this.
@@ -28,7 +29,7 @@ export function MultiFactorAuth(): JSX.Element {
       //
       // If returning from external authentication with Sweden Connect, we need
       // to call the MFA endpoint for it to complete.
-      dispatch(fetchMfaAuth({ ref: ref }));
+      dispatch(fetchMfaAuth({ ref: ref, this_device: this_device }));
     }
   }, [authn_options, mfa]);
 


### PR DESCRIPTION
#### Description:

Add this_device (known device info) to login mfa endpoint requests.

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
