### PR TITLE
show-hide and copy-copied repositioned

### DIFF
--- a/src/components/Common/PasswordInput.tsx
+++ b/src/components/Common/PasswordInput.tsx
@@ -75,17 +75,6 @@ export function PasswordInputElement(props: any): JSX.Element {
 
   return (
     <div className="password-input">
-      <input
-        {...props.input}
-        id={props.input.name}
-        type={showPassword ? "text" : "password"}
-        placeholder={props.placeholder}
-        autoComplete={props.autoComplete}
-        autoFocus={props.autoFocus}
-        className={className}
-        ref={inputRef}
-      />
-
       <EduIDButton
         type="button"
         buttonstyle="txt-toggle-btn link sm"
@@ -98,6 +87,16 @@ export function PasswordInputElement(props: any): JSX.Element {
           <FormattedMessage defaultMessage="SHOW" description="nin/password button label" />
         )}
       </EduIDButton>
+      <input
+        {...props.input}
+        id={props.input.name}
+        type={showPassword ? "text" : "password"}
+        placeholder={props.placeholder}
+        autoComplete={props.autoComplete}
+        autoFocus={props.autoFocus}
+        className={className}
+        ref={inputRef}
+      />
     </div>
   );
 }

--- a/src/components/Dashboard/ChangePasswordSuggested.tsx
+++ b/src/components/Dashboard/ChangePasswordSuggested.tsx
@@ -9,11 +9,11 @@ export default function ChangePasswordSuggestedForm(props: ChangePasswordChildFo
 
   return (
     <React.Fragment>
-      <div className="copy-password-input">
-        <label htmlFor="copy-new-password">
-          <FormattedMessage defaultMessage="New password" description="new password" />
-        </label>
-
+      <label htmlFor="copy-new-password">
+        <FormattedMessage defaultMessage="New password" description="new password" />
+      </label>
+      <div className="password-input">
+        <CopyToClipboardButton ref={ref} />
         <input
           name="copy-new-password"
           id="copy-new-password"
@@ -21,7 +21,6 @@ export default function ChangePasswordSuggestedForm(props: ChangePasswordChildFo
           defaultValue={props.suggestedPassword}
           readOnly={true}
         />
-        <CopyToClipboardButton ref={ref} />
       </div>
       <NewPasswordForm
         suggested_password={props.suggestedPassword}

--- a/src/styles/_ResetPassword.scss
+++ b/src/styles/_ResetPassword.scss
@@ -150,10 +150,6 @@ a#resend-phone:not(.button-active) {
   }
 }
 
-.copy-password-input {
-  position: relative; // not needed since Splash is relative but best leave for safety.
-}
-
 @media (max-width: $bp-sm) {
   #reset-password-form,
   #phone-code-form {

--- a/src/styles/_buttons.scss
+++ b/src/styles/_buttons.scss
@@ -291,10 +291,16 @@ button.icon {
   }
 }
 
-//textual toggle control, eg. copy/show
+//textual toggle control, eg. copy/copied right after input
 .txt-toggle-btn {
-  position: absolute;
-  right: 1rem;
+  height: auto;
+
+  //and show/hide just before input
+  &:has(+ input) {
+    position: absolute;
+    right: 0;
+    top: -1.1rem;
+  }
 }
 
 /* Instance/icon unique styles to be set in targeted css */

--- a/src/styles/_inputs.scss
+++ b/src/styles/_inputs.scss
@@ -158,7 +158,6 @@ input[type="radio"] {
 
 /* Login username-pw / reset-password set-new-password */
 .password-input {
-  display: flex;
   position: relative;
 
   input[name="currentPassword"].is-valid {


### PR DESCRIPTION
#### Description:

Reused css,
repositioned copy/copied after input 
and show/hide before input, in relative container.
Test for login pw, change/forgotten pw and eppn at start.

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
