### PR TITLE
Cat submenu fokus fix

### DIFF
--- a/src/styles/_Header.scss
+++ b/src/styles/_Header.scss
@@ -29,7 +29,7 @@ header {
 
       ul {
         li {
-          padding: 0.5rem 0;
+          padding: 0.5rem 0 0.5rem 3px;
           line-height: 1.2;
           a {
             font-size: $txt-sm;

--- a/src/styles/_buttons.scss
+++ b/src/styles/_buttons.scss
@@ -211,6 +211,10 @@ button.icon {
   &.refresh[disabled]:hover svg {
     transform: none;
   }
+  span {
+    text-align: left;
+    line-height: $line-height;
+  }
 }
 
 /* TODO possibly replace with .buttons */


### PR DESCRIPTION
#### Description:

Visual fixes:
- left focus border on submeny was cut off
- refresh button (icon + text) was silly responsive, now keeping together to the left, with line-height for responsive legibility.

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
