### PR TITLE
Fix wrong message, no help text needed, toggling off at the login pag…

### DIFF
--- a/src/components/Login/NewDevice.tsx
+++ b/src/components/Login/NewDevice.tsx
@@ -50,6 +50,8 @@ export function RememberMeCheckbox(): JSX.Element | null {
   const next_page = useAppSelector((state) => state.login.next_page);
   const [switchChecked, setSwitchChecked] = useState(remember_me);
   const dispatch = useAppDispatch();
+  const warnRedirectToLogin: boolean | undefined = !has_session && switchChecked && next_page !== "USERNAMEPASSWORD";
+  const infoRememberME = !switchChecked;
 
   function handleSwitchChange(): void {
     const newValue = !switchChecked;
@@ -103,7 +105,7 @@ export function RememberMeCheckbox(): JSX.Element | null {
         />
         <div className="toggle-switch"></div>
       </label>
-      {!has_session && switchChecked && (
+      {warnRedirectToLogin && (
         <p className="help-text">
           <FormattedMessage
             defaultMessage="If you turn this off, you'll need to log in with your username and password."
@@ -111,7 +113,7 @@ export function RememberMeCheckbox(): JSX.Element | null {
           />
         </p>
       )}
-      {!switchChecked && (
+      {infoRememberME && (
         <p className="help-text">
           <FormattedMessage
             defaultMessage="Allowing eduID to remember you on this device makes logging in easier and more secure"


### PR DESCRIPTION
…e will redirect to the login page

#### Description:


- before ("turning this off..." message isn't needed at login page)

![Screenshot 2025-05-22 at 10 58 25](https://github.com/user-attachments/assets/0799a35a-8f50-47be-9cd9-2909d17a521f)


- efter
![Screenshot 2025-05-22 at 10 58 16](https://github.com/user-attachments/assets/1bf44207-a848-4ba9-a5ba-a184139acc2c)

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
