### PR TITLE
Sticky error-bar if scroll past top.

### DIFF
--- a/src/styles/_Notifications.scss
+++ b/src/styles/_Notifications.scss
@@ -3,6 +3,10 @@
 // Top notification bar
 .notifications-area {
   width: 100%;
+  position: sticky;
+  top: 0;
+  z-index: 150;
+  opacity: 0.95;
 }
 
 .alert.alert-dismissible {


### PR DESCRIPTION
slightly opaque,
z-sandwiched between spinner and menu.



<img width="313" alt="Skärmavbild 2025-06-11 kl  15 09 11" src="https://github.com/user-attachments/assets/87d304bf-e3cf-4d5f-8ae9-3e657ba50630" />

#### Description:

[Replace this with a description of what you've done - if styling-related work please include a screenshot]

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
