### PR TITLE
adding viewport-fit and safe-areas to mobile landscape bg coverage

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <title>eduID</title>
   </head>
   <body>

--- a/src/styles/_base.scss
+++ b/src/styles/_base.scss
@@ -13,6 +13,8 @@ body {
   color: var(--body-txt);
   scroll-behavior: smooth;
   display: flex;
+  padding: env(safe-area-inset-top, 1.25rem) env(safe-area-inset-right, 1.25rem) env(safe-area-inset-bottom, 1.25rem)
+    env(safe-area-inset-left, 1.25rem);
 }
 
 #root,


### PR DESCRIPTION
#### Description:

Avoiding the white side areas. Safe areas considering iphone screen "notch" etc.

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
