### PR TITLE
wrapping toggle in footer mobile

### DIFF
--- a/src/styles/_inputs.scss
+++ b/src/styles/_inputs.scss
@@ -316,6 +316,15 @@ input:-webkit-autofill {
   input::placeholder {
     font-size: $txt-md;
   }
+
+  footer .toggle {
+    flex-direction: column;
+    align-self: end;
+
+    > span {
+      margin: 0 0 5px;
+    }
+  }
 }
 
 @media (max-width: $bp-md) {


### PR DESCRIPTION
#### Description:

Label for toggle in footer wraps over control for small screens.

<img width="448" height="115" alt="Skärmavbild 2025-08-15 kl  16 16 44" src="https://github.com/user-attachments/assets/901d277d-2910-4a80-93d4-951a3425af04" />


#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
