### PR TITLE
Cat togglebox on start

### DIFF
--- a/src/components/Dashboard/UseSecurityKeyToggle.tsx
+++ b/src/components/Dashboard/UseSecurityKeyToggle.tsx
@@ -41,9 +41,9 @@ export default function UseSecurityKeyToggle(): React.JSX.Element | null {
   return (
     <form>
       {/* always_use_security_key toggle button */}
-      <fieldset>
-        <label className="toggle flex-between border-toggle-area" htmlFor="security-key-mfa">
-          <legend className="legend-2fa">
+      <fieldset className="border-toggle-area">
+        <label className="toggle" htmlFor="security-key-mfa">
+          <legend>
             <FormattedMessage
               defaultMessage={`Always use a security key to log in`}
               description="Security key toggle"

--- a/src/components/Dashboard/UseSecurityKeyToggle.tsx
+++ b/src/components/Dashboard/UseSecurityKeyToggle.tsx
@@ -51,7 +51,7 @@ export default function UseSecurityKeyToggle(): React.JSX.Element | null {
             <p className="help-text">
               <FormattedMessage
                 description="help text toggle 2FA"
-                defaultMessage="If toggled off you only need to use your security key for services that require extra login verification."
+                defaultMessage="If turned off you only need to use your security key for services that require extra login verification."
               />
             </p>
           </legend>

--- a/src/components/Login/NewDevice.tsx
+++ b/src/components/Login/NewDevice.tsx
@@ -100,7 +100,7 @@ export function RememberMeCheckbox(): React.JSX.Element | null {
             {!infoRememberME && (
               <p className="help-text">
                 <FormattedMessage
-                  defaultMessage="If you turn this off, you'll need to log in with your username and password."
+                  defaultMessage="Turning this off will enable login with username and password instead."
                   description="MFA as the first step of login, toggle off"
                 />
               </p>
@@ -108,7 +108,7 @@ export function RememberMeCheckbox(): React.JSX.Element | null {
             {infoRememberME && (
               <p className="help-text">
                 <FormattedMessage
-                  defaultMessage="Allowing eduID to remember you on this device makes logging in easier and more secure"
+                  defaultMessage="Allowing eduID to remember you on this device makes logging in easier and more secure."
                   description="Login remember user device"
                 />
               </p>

--- a/src/components/Login/NewDevice.tsx
+++ b/src/components/Login/NewDevice.tsx
@@ -93,35 +93,38 @@ export function RememberMeCheckbox(): React.JSX.Element | null {
 
   return (
     <React.Fragment>
-      <label className="toggle flex-between" htmlFor="remember-me">
-        <legend>
-          <FormattedMessage defaultMessage="Remember me on this device" description="Login remember user device" />
-        </legend>
-        <input
-          onChange={handleSwitchChange}
-          className="toggle-checkbox"
-          type="checkbox"
-          checked={switchChecked}
-          id="remember-me"
-        />
-        <div className="toggle-switch"></div>
-      </label>
-      {warnRedirectToLogin && (
-        <p className="help-text">
-          <FormattedMessage
-            defaultMessage="If you turn this off, you'll need to log in with your username and password."
-            description="MFA as the first step of login, toggle off"
+      <fieldset className="border-toggle-area">
+        <label className="toggle" htmlFor="remember-me">
+          <legend>
+            <FormattedMessage defaultMessage="Remember me on this device" description="Login remember user device" />
+            {warnRedirectToLogin && (
+              <p className="help-text">
+                <FormattedMessage
+                  defaultMessage="If you turn this off, you'll need to log in with your username and password."
+                  description="MFA as the first step of login, toggle off"
+                />
+              </p>
+            )}
+            {infoRememberME && (
+              <p className="help-text">
+                <FormattedMessage
+                  defaultMessage="Allowing eduID to remember you on this device makes logging in easier and more secure"
+                  description="Login remember user device"
+                />
+              </p>
+            )}
+          </legend>
+          <input
+            onChange={handleSwitchChange}
+            className="toggle-checkbox"
+            type="checkbox"
+            checked={switchChecked}
+            id="remember-me"
           />
-        </p>
-      )}
-      {infoRememberME && (
-        <p className="help-text">
-          <FormattedMessage
-            defaultMessage="Allowing eduID to remember you on this device makes logging in easier and more secure"
-            description="Login remember user device"
-          />
-        </p>
-      )}
+
+          <div className="toggle-switch"></div>
+        </label>
+      </fieldset>
     </React.Fragment>
   );
 }

--- a/src/components/Login/NewDevice.tsx
+++ b/src/components/Login/NewDevice.tsx
@@ -97,7 +97,7 @@ export function RememberMeCheckbox(): React.JSX.Element | null {
         <label className="toggle" htmlFor="remember-me">
           <legend>
             <FormattedMessage defaultMessage="Remember me on this device" description="Login remember user device" />
-            {warnRedirectToLogin && (
+            {!infoRememberME && (
               <p className="help-text">
                 <FormattedMessage
                   defaultMessage="If you turn this off, you'll need to log in with your username and password."

--- a/src/styles/_forms.scss
+++ b/src/styles/_forms.scss
@@ -182,9 +182,9 @@ fieldset.change-password-custom-inputs {
   }
 }
 
-.legend-2fa {
-  flex-direction: column;
-  p {
-    font-family: $inter-regular;
-  }
-}
+// .legend-2fa {
+//   flex-direction: column;
+//   p {
+//     font-family: $inter-regular;
+//   }
+// }

--- a/src/styles/_label.scss
+++ b/src/styles/_label.scss
@@ -12,12 +12,17 @@ label,
 }
 
 .border-toggle-area {
-  flex-basis: 100%;
   border-color: var(--border-gray);
-  border-width: 1px;
+  border-width: $border-width;
   border-style: solid;
   border-radius: 10px;
-  padding: 16px;
+  padding: $margin;
+  label {
+    margin: 0;
+  }
+  legend {
+    margin-right: 5px;
+  }
 }
 
 #uniqueId-container label {


### PR DESCRIPTION
#### Description:

Refactored border-toggle area markub and css
Reuse border-toggle-area on start for remember me
Fixed logic for remember me text
Streamlined copy for both instructions


#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
