### PR TITLE
Add api end point for checking authn status

### DIFF
--- a/src/apis/eduidSecurity.ts
+++ b/src/apis/eduidSecurity.ts
@@ -89,6 +89,18 @@ export interface AuthnActionStatusRequest {
   credential_id?: string;
 }
 
+export interface CheckAuthnStatusResponse {
+  asserted_authn_ctx: string;
+  authn_instant: string;
+  consumed: boolean;
+  created: string;
+  credential_id: string;
+  error: boolean;
+  frontend_action: string;
+  method: string;
+  req_authn_ctx: string[];
+}
+
 export const securityApi = eduIDApi.injectEndpoints({
   endpoints: (builder) => ({
     updateOfficialUserData: builder.query<ApiResponse<UpdateOfficialUserDataResponse>, void>({
@@ -179,6 +191,12 @@ export const securityApi = eduIDApi.injectEndpoints({
       query: (body) => ({
         url: "authn-status",
         body,
+      }),
+      extraOptions: { service: "security" },
+    }),
+    checkAuthnStatus: builder.query<ApiResponse<CheckAuthnStatusResponse>, void>({
+      query: () => ({
+        url: "authn-status",
       }),
       extraOptions: { service: "security" },
     }),


### PR DESCRIPTION
#### Description:

This PR wires up the GET end point of `authn-status` of the security service for further uses for showing the user why certain security actions are needed

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
