### PR TITLE
Refactor SecurityKey

### DIFF
--- a/src/components/Login/MultiFactorAuth.tsx
+++ b/src/components/Login/MultiFactorAuth.tsx
@@ -55,7 +55,22 @@ export function MultiFactorAuth(): React.JSX.Element {
       // to call the MFA endpoint for it to complete.
       fetchMfaAuth({ ref: ref, this_device: this_device });
     }
-  }, [authn_options, mfa]);
+  }, [mfa]);
+
+  async function getChallenge() {
+    if (ref) {
+      const response = await fetchMfaAuth({ ref: ref, this_device: this_device });
+      if (response.isSuccess) {
+        return response.data.payload.webauthn_options;
+      }
+    }
+  }
+
+  function useCredential(credential: PublicKeyCredentialJSON) {
+    if (ref) {
+      fetchMfaAuth({ ref: ref, this_device: this_device, webauthn_response: credential });
+    }
+  }
 
   return (
     <Fragment>
@@ -82,7 +97,7 @@ export function MultiFactorAuth(): React.JSX.Element {
           <React.Fragment>
             <p>{leadText}</p>
             <div className="options">
-              <SecurityKey webauthn={authn_options?.webauthn} />
+              <SecurityKey disabled={!authn_options?.webauthn} setup={getChallenge} onSuccess={useCredential} />
               <SwedishEID recoveryAvailable={authn_options.swedish_eid} />
             </div>
           </React.Fragment>

--- a/src/components/ResetPassword/HandleExtraSecurities.tsx
+++ b/src/components/ResetPassword/HandleExtraSecurities.tsx
@@ -43,6 +43,17 @@ export function HandleExtraSecurities(): React.JSX.Element | null {
     return null;
   }
 
+  async function setupSecurityKey() {
+    if (extra_security?.tokens?.webauthn_options) {
+      dispatch(resetPasswordSlice.actions.selectExtraSecurity("securityKey"));
+      return extra_security.tokens.webauthn_options;
+    }
+  }
+
+  function continueWithSecurityKey() {
+    resetPasswordContext.resetPasswordService.send({ type: "CHOOSE_SECURITY_KEY" });
+  }
+
   return (
     <React.Fragment>
       <section className="intro">
@@ -69,7 +80,7 @@ export function HandleExtraSecurities(): React.JSX.Element | null {
       </section>
       <div className="options">
         {extra_security.tokens !== undefined && (
-          <SecurityKeyLogin webauthn={true} webauthn_options={extra_security.tokens.webauthn_options} />
+          <SecurityKeyLogin setup={setupSecurityKey} onSuccess={continueWithSecurityKey} />
         )}
         <SwedishEID recoveryAvailable={extra_security.external_mfa} />
       </div>


### PR DESCRIPTION
#### Description:

Refactor SecurityKey
* Moves logic from sub-component SecurityKeyActive to whatever uses SecurityKey.
* SecurityKey component handles authentication by `navigator.credentials`
* setup and further logic are used via callbacks

This fixes the edge case of not having an active SSO session and having "remember me" set and cancelling first authentication, further retries are not possible until reload as the logic missed sending device information on subsequent authentication requests.

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
