### PR TITLE
fix, when clicking the menu on mobile, the menu text and arrow up/down slightly shift

### DIFF
--- a/src/styles/_Header.scss
+++ b/src/styles/_Header.scss
@@ -106,12 +106,12 @@ header {
           opacity: 0;
           visibility: hidden;
           filter: drop-shadow(0 6px 17px rgba(89, 89, 89, 0.07));
-          padding-top: 1rem;
 
           @media (min-width: $bp-xl) {
             position: absolute;
             min-width: 180px;
             z-index: 100;
+            padding-top: 1rem;
 
             li {
               border-bottom: 1px solid var(--body-gray);

--- a/src/styles/_Header.scss
+++ b/src/styles/_Header.scss
@@ -92,6 +92,7 @@ header {
 
         a {
           color: var(--body-txt);
+          transition: none;
 
           &.active,
           &:hover {


### PR DESCRIPTION
#### Description:

[Replace this with a description of what you've done - if styling-related work please include a screenshot]

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
