### PR TITLE
add simple check for faulty username

### DIFF
--- a/src/helperFunctions/validation/regexPatterns.ts
+++ b/src/helperFunctions/validation/regexPatterns.ts
@@ -12,4 +12,5 @@ export const emptyStringPattern = /^\s+$/;
 export const emailPattern =
   /^(([^<>()\[\]\.,;:\s@\"]+(\.[^<>()\[\]\.,;:\s@\"]+)*)|(\".+\"))@(([^<>()[\]\.,;:\s@\"]+\.)+[^<>()[\]\.,;:\s@\"]{2,})$/i;
 export const eppnPattern = /^[a-zA-Z]{5}-[a-zA-Z]{5}$/;
+export const faultyEppnPattern = /^[a-zA-Z]{5}-[a-zA-Z]{5}@[eE][dD][uU][iI][dD]\.[sS][eE]$/;
 export const studentEppnPattern = /^[mM][aA]-[a-zA-Z0-9]{8}$/;

--- a/src/helperFunctions/validation/validateUserName.ts
+++ b/src/helperFunctions/validation/validateUserName.ts
@@ -1,4 +1,4 @@
-import { emailPattern, eppnPattern, studentEppnPattern } from "./regexPatterns";
+import { emailPattern, eppnPattern, faultyEppnPattern, studentEppnPattern } from "./regexPatterns";
 
 interface UserNameData {
   username?: string;
@@ -30,6 +30,8 @@ export function validateUserNameField(value?: string): string | undefined {
   const stringWithoutSpaces = value?.replace(/\s/g, "");
   if (!stringWithoutSpaces) {
     return "required";
+  } else if (faultyEppnPattern.test(stringWithoutSpaces)) {
+    return "invalid username";
   } else if (eppnPattern.test(stringWithoutSpaces)) {
     return undefined;
   } else if (studentEppnPattern.test(stringWithoutSpaces)) {


### PR DESCRIPTION
#### Description:

check if user is trying to login with `eppn@eduid.se` instead of email-address or eppn
Could use a more explicit error message for this case

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
