### PR TITLE
Add credential serialization helper function

### DIFF
--- a/src/apis/navigatorCredentials.ts
+++ b/src/apis/navigatorCredentials.ts
@@ -1,4 +1,5 @@
 import { BaseQueryFn, createApi } from "@reduxjs/toolkit/query/react";
+import { credentialToJSON } from "../helperFunctions/publicKeyCredentialToJSON";
 import { genericApiFail } from "./common";
 
 const navigatorCredentialsBaseQuery: BaseQueryFn = async (args, api) => {
@@ -8,7 +9,7 @@ const navigatorCredentialsBaseQuery: BaseQueryFn = async (args, api) => {
       const publicKey = PublicKeyCredential.parseRequestOptionsFromJSON(args.payload);
       const credential = await navigator.credentials.get({ publicKey });
       if (credential instanceof PublicKeyCredential && credential.response instanceof AuthenticatorAssertionResponse) {
-        return { data: credential.toJSON() };
+        return { data: credentialToJSON(credential) };
       } else {
         errorMessage = "Unable to obtain credential.";
       }
@@ -20,7 +21,7 @@ const navigatorCredentialsBaseQuery: BaseQueryFn = async (args, api) => {
         credential instanceof PublicKeyCredential &&
         credential.response instanceof AuthenticatorAttestationResponse
       ) {
-        return { data: credential.toJSON() };
+        return { data: credentialToJSON(credential) };
       } else {
         errorMessage = "Unable to create credential.";
       }

--- a/src/helperFunctions/publicKeyCredentialToJSON.ts
+++ b/src/helperFunctions/publicKeyCredentialToJSON.ts
@@ -1,0 +1,73 @@
+/**
+ * This file contains helper functions for converting PublicKeyCredential objects to JSON.
+ * It only exists because some password extensions create PublicKeyCredential objects without
+ * a toJSON method and (incomplete internal?) data for serialization.
+ * This can be removed when extensions start to behave.*9*
+ */
+
+type Base64urlString = string;
+
+function bufferToBase64url(buffer: ArrayBuffer | null): Base64urlString | undefined {
+  if (!buffer) {
+    return undefined;
+  }
+  // Buffer to binary string
+  const byteView = new Uint8Array(buffer);
+  let str = "";
+  for (const charCode of byteView) {
+    str += String.fromCharCode(charCode);
+  }
+
+  // Binary string to base64
+  const base64String = btoa(str);
+
+  // Base64 to base64url
+  // We assume that the base64url string is well-formed.
+  const base64urlString = base64String.replace(/\+/g, "-").replace(/\//g, "_").replace(/=/g, "");
+  return base64urlString;
+}
+
+export function credentialToJSON(credential: PublicKeyCredential): PublicKeyCredentialJSON {
+  try {
+    return credential.toJSON();
+  } catch (error) {
+    if (error instanceof TypeError) {
+      // An extension has created an incomplete PublicKeyCredential missing a toJSON method
+      // We need to serialize it manually
+      if (credential.response instanceof AuthenticatorAssertionResponse) {
+        // for using credential
+        return {
+          id: credential.id,
+          rawId: bufferToBase64url(credential.rawId),
+          type: credential.type,
+          clientExtensionResults: credential.getClientExtensionResults(),
+          response: {
+            clientDataJSON: bufferToBase64url(credential.response.clientDataJSON),
+            authenticatorData: bufferToBase64url(credential.response.authenticatorData),
+            signature: bufferToBase64url(credential.response.signature),
+            userHandle: bufferToBase64url(credential.response.userHandle),
+          },
+        };
+      } else if (credential.response instanceof AuthenticatorAttestationResponse) {
+        // for registering credential
+        return {
+          id: credential.id,
+          rawId: bufferToBase64url(credential.rawId),
+          type: credential.type,
+          clientExtensionResults: credential.getClientExtensionResults(),
+          response: {
+            clientDataJSON: bufferToBase64url(credential.response.clientDataJSON),
+            authenticatorData: bufferToBase64url(credential.response.getAuthenticatorData()),
+            transports: credential.response.getTransports(),
+            publicKey: bufferToBase64url(credential.response.getPublicKey()),
+            publicKeyAlgorithm: credential.response.getPublicKeyAlgorithm(),
+            attestationObject: bufferToBase64url(credential.response.attestationObject),
+          },
+        };
+      }
+    } else {
+      // re-throw the error
+      throw error;
+    }
+  }
+}


### PR DESCRIPTION
#### Description:

Introduce a helper function to serialize PublicKeyCredential objects to JSON, addressing cases where extensions create incomplete credentials lacking a toJSON method and/or sufficient data for PublicKeyCredential objects builtin toJSON to be able to convert to JSON.

This function enhances compatibility and ensures proper serialization of credential data.

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
