### PR TITLE
remove instanceof type tests

### DIFF
--- a/src/apis/navigatorCredentials.ts
+++ b/src/apis/navigatorCredentials.ts
@@ -16,8 +16,8 @@ async function handlePerformAuthentication(args: AuthenticationRequest) {
     signal: navigatorAbortController?.signal,
     mediation: args.mediation,
   });
-  if (credential instanceof PublicKeyCredential && credential.response instanceof AuthenticatorAssertionResponse) {
-    return { data: credentialToJSON(credential) };
+  if (credential) {
+    return { data: credentialToJSON(credential as PublicKeyCredential) };
   }
   throw new Error("Unable to obtain credential.");
 }
@@ -25,8 +25,8 @@ async function handlePerformAuthentication(args: AuthenticationRequest) {
 async function handleCreateCredential(args: PublicKeyCredentialCreationOptionsJSON) {
   const publicKey = PublicKeyCredential.parseCreationOptionsFromJSON(args);
   const credential = await navigator.credentials.create({ publicKey });
-  if (credential instanceof PublicKeyCredential && credential.response instanceof AuthenticatorAttestationResponse) {
-    return { data: credentialToJSON(credential) };
+  if (credential) {
+    return { data: credentialToJSON(credential as PublicKeyCredential) };
   }
   throw new Error("Unable to create credential.");
 }


### PR DESCRIPTION
#### Description:

Remove instanceof tests as some password manager extensions create objects in the shape of PublicKeyCredential but not instanceof the same.
Our own JSON-ification method will handle those anyway when returning to backend

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
