### PR TITLE
smaller validation text (12px) to avoid jumping form)

### DIFF
--- a/src/styles/_forms.scss
+++ b/src/styles/_forms.scss
@@ -33,8 +33,8 @@ form {
   margin-top: 1.25rem;
 
   .form-wrapper {
-    min-height: 5.5rem;
-    margin-bottom: 1rem;
+    min-height: 6rem;
+    margin-bottom: 0.5rem;
   }
 }
 
@@ -131,7 +131,7 @@ fieldset.change-password-custom-inputs {
 }
 
 .input-validate-error {
-  font-size: $txt-sm;
+  font-size: $txt-xs;
   color: var(--error-red);
 
   fieldset & {


### PR DESCRIPTION
#### Description:

Higher form-wrapper with less bottom-margin and smaller validation text - to avoid jumping form with errors.

<img width="322" height="335" alt="Skärmavbild 2025-11-21 kl  15 46 18" src="https://github.com/user-attachments/assets/9dd0ca21-6ef2-4d29-9a89-0f1fc6ae38e5" />


#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
