### PR TITLE
less drama around passkey bubble

### DIFF
--- a/src/styles/_Login.scss
+++ b/src/styles/_Login.scss
@@ -287,6 +287,10 @@ section.username-pw-option form .form-group:nth-of-type(2) {
 .passkey-option .status-box {
   display: block;
   margin-bottom: 1.5rem;
+  background-color: transparent;
+  border: $border-width var(--border-gray) solid !important;
+  box-shadow: none;
+
   .text-wrapper {
     img {
       width: 6rem;


### PR DESCRIPTION
#### Description:

grey border around grey (same as toggle-container) to avoid box-on-box look and less pertinent

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
