### PR TITLE
prevent desktop menu wrapping

### DIFF
--- a/src/styles/_Header.scss
+++ b/src/styles/_Header.scss
@@ -156,7 +156,7 @@ header {
       text-overflow: ellipsis;
       white-space: nowrap;
       display: inline-block;
-      padding: 0.5rem 1rem;
+      padding: 0.5rem 1rem 0.5rem 0;
       font-family: $inter-bold;
       font-size: $txt-sm;
       text-align: right;


### PR DESCRIPTION
#### Description:

Lets not have this
<img width="992" height="168" alt="Skärmavbild 2025-12-09 kl  15 42 10" src="https://github.com/user-attachments/assets/8e41be7c-9926-4b4e-83fc-612d5f7db4c3" />


#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
