### PR TITLE
simplify dashboard(settings) URL paths by removing /profile prefix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13382,9 +13382,9 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
-      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
+      "integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
       "license": "MIT"
     },
     "node_modules/lodash.debounce": {

--- a/src/components/Common/ExternalReturnHandler.tsx
+++ b/src/components/Common/ExternalReturnHandler.tsx
@@ -2,7 +2,7 @@ import authnApi from "apis/eduidAuthn";
 import { bankIDApi } from "apis/eduidBankid";
 import { eidasApi, GetStatusResponse } from "apis/eduidEidas";
 import { frejaeIDApi } from "apis/eduidFrejaeID";
-import { CHPASS_BASE_PATH, IDENTITY_PATH, SECURITY_PATH } from "components/IndexMain";
+import { CHPASS_BASE_PATH, IDENTITY_PATH, SECURITY_PATH, START_PATH } from "components/IndexMain";
 import { useAppDispatch, useAppSelector } from "eduid-hooks";
 import { useCallback, useEffect } from "react";
 import { useNavigate, useParams } from "react-router";
@@ -52,7 +52,7 @@ export function ExternalReturnHandler() {
         }
       }
 
-      navigate("/start"); // GOTO start
+      navigate(START_PATH); // GOTO start
     },
     [dispatch, navigate],
   );

--- a/src/components/Common/ExternalReturnHandler.tsx
+++ b/src/components/Common/ExternalReturnHandler.tsx
@@ -2,7 +2,7 @@ import authnApi from "apis/eduidAuthn";
 import { bankIDApi } from "apis/eduidBankid";
 import { eidasApi, GetStatusResponse } from "apis/eduidEidas";
 import { frejaeIDApi } from "apis/eduidFrejaeID";
-import { IDENTITY_PATH, SECURITY_PATH } from "components/IndexMain";
+import { CHPASS_BASE_PATH, IDENTITY_PATH, SECURITY_PATH } from "components/IndexMain";
 import { useAppDispatch, useAppSelector } from "eduid-hooks";
 import { useCallback, useEffect } from "react";
 import { useNavigate, useParams } from "react-router";
@@ -37,7 +37,7 @@ export function ExternalReturnHandler() {
         const actionToRoute: { [key: string]: string } = {
           verifyIdentity: IDENTITY_PATH,
           verifyCredential: SECURITY_PATH,
-          changepwAuthn: "/chpass",
+          changepwAuthn: CHPASS_BASE_PATH,
           terminateAccountAuthn: "/",
           addSecurityKeyAuthn: SECURITY_PATH,
           removeSecurityKeyAuthn: SECURITY_PATH,
@@ -45,6 +45,7 @@ export function ExternalReturnHandler() {
           removeIdentity: IDENTITY_PATH,
         };
         const _path = actionToRoute[status.frontend_action];
+
         if (_path) {
           navigate(_path);
           return;

--- a/src/components/Common/ExternalReturnHandler.tsx
+++ b/src/components/Common/ExternalReturnHandler.tsx
@@ -37,7 +37,7 @@ export function ExternalReturnHandler() {
         const actionToRoute: { [key: string]: string } = {
           verifyIdentity: IDENTITY_PATH,
           verifyCredential: SECURITY_PATH,
-          changepwAuthn: "/profile/chpass",
+          changepwAuthn: "/chpass",
           terminateAccountAuthn: "/",
           addSecurityKeyAuthn: SECURITY_PATH,
           removeSecurityKeyAuthn: SECURITY_PATH,
@@ -51,9 +51,9 @@ export function ExternalReturnHandler() {
         }
       }
 
-      navigate("/profile/"); // GOTO start
+      navigate("/start"); // GOTO start
     },
-    [dispatch, navigate]
+    [dispatch, navigate],
   );
 
   const fetchEidasStatus = useCallback(
@@ -63,7 +63,7 @@ export function ExternalReturnHandler() {
         processStatus(response.data.payload);
       }
     },
-    [eidasGetStatus, processStatus]
+    [eidasGetStatus, processStatus],
   );
 
   const fetchFrejaeIDStatus = useCallback(
@@ -73,7 +73,7 @@ export function ExternalReturnHandler() {
         processStatus(response.data.payload);
       }
     },
-    [frejaeIDGetStatus, processStatus]
+    [frejaeIDGetStatus, processStatus],
   );
 
   const fetchBankIDStatus = useCallback(
@@ -83,7 +83,7 @@ export function ExternalReturnHandler() {
         processStatus(response.data.payload);
       }
     },
-    [bankIDGetStatus, processStatus]
+    [bankIDGetStatus, processStatus],
   );
 
   const fetchAuthStatus = useCallback(
@@ -93,7 +93,7 @@ export function ExternalReturnHandler() {
         processStatus(response.data.payload);
       }
     },
-    [authnGetStatus, processStatus]
+    [authnGetStatus, processStatus],
   );
 
   useEffect(() => {

--- a/src/components/Common/Header.tsx
+++ b/src/components/Common/Header.tsx
@@ -3,6 +3,7 @@ import { faArrowRightFromBracket } from "@fortawesome/free-solid-svg-icons/faArr
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { loginApi } from "apis/eduidLogin";
 import EduIDButton from "components/Common/EduIDButton";
+import { SIGNUP_BASE_PATH } from "components/IndexMain";
 import { useAppSelector } from "eduid-hooks";
 import { eduidStore } from "eduid-init-app";
 import { useCallback, useMemo } from "react";
@@ -37,7 +38,7 @@ export function Header(props: Readonly<HeaderProps>): React.JSX.Element {
   }, [fetchLogout, props.loginRef, eduid_site_link]);
 
   const handleRegister = useCallback(() => {
-    navigate("/register");
+    navigate(SIGNUP_BASE_PATH);
   }, [navigate]);
 
   const handleLogin = useCallback(() => {

--- a/src/components/Dashboard/AuthenticateModal.tsx
+++ b/src/components/Dashboard/AuthenticateModal.tsx
@@ -55,7 +55,7 @@ export function AuthenticateModal() {
   function handleCloseModal() {
     // navigate to account when user cancel re-authentication
     if (frontend_action === "changepwAuthn" && re_authenticate) {
-      navigate("profile/account/");
+      navigate("account");
     }
     dispatch(authnSlice.actions.setAuthnFrontendReset());
     dispatch(authnSlice.actions.setReAuthenticate(false));

--- a/src/components/Dashboard/AuthenticateModal.tsx
+++ b/src/components/Dashboard/AuthenticateModal.tsx
@@ -1,6 +1,7 @@
 import authnApi from "apis/eduidAuthn";
 import { AuthMethod } from "apis/helpers/types";
 import NotificationModal from "components/Common/NotificationModal";
+import { ACCOUNT_PATH } from "components/IndexMain";
 import { useAppDispatch, useAppSelector } from "eduid-hooks";
 import { Fragment, useEffect, useMemo } from "react";
 import { FormattedMessage } from "react-intl";
@@ -55,7 +56,7 @@ export function AuthenticateModal() {
   function handleCloseModal() {
     // navigate to account when user cancel re-authentication
     if (frontend_action === "changepwAuthn" && re_authenticate) {
-      navigate("account");
+      navigate(ACCOUNT_PATH);
     }
     dispatch(authnSlice.actions.setAuthnFrontendReset());
     dispatch(authnSlice.actions.setReAuthenticate(false));

--- a/src/components/Dashboard/ChangePassword.tsx
+++ b/src/components/Dashboard/ChangePassword.tsx
@@ -10,7 +10,7 @@ import { ChangePasswordRadioOption } from "./ChangePasswordRadioOption";
 import ChangePasswordSuggestedForm from "./ChangePasswordSuggested";
 
 // exported for use in tests
-export const finish_url = "/profile/account";
+export const finish_url = "account";
 
 export interface ChangePasswordFormProps {
   finish_url: string; // URL to direct browser to when user cancels password change, or completes it
@@ -48,7 +48,7 @@ export function ChangePassword() {
       const response = await fetchSuggestedPassword();
       if (isMounted.current) {
         if (response.isSuccess) {
-          navigate("/profile/chpass");
+          navigate("chpass");
         }
       }
     } catch (error) {
@@ -62,7 +62,7 @@ export function ChangePassword() {
       if (newPassword) {
         const response = await changePassword({ new_password: newPassword });
         if (response.isSuccess) {
-          navigate("/profile/chpass/success", {
+          navigate("chpass/success", {
             state: { password: newPassword, isSuggested: renderSuggested } as ChangePasswordSuccessState,
           });
         }

--- a/src/components/Dashboard/ChangePassword.tsx
+++ b/src/components/Dashboard/ChangePassword.tsx
@@ -1,6 +1,6 @@
 import securityApi from "apis/eduidSecurity";
 import Splash from "components/Common/Splash";
-import { CHPASS_BASE_PATH } from "components/IndexMain";
+import { ACCOUNT_PATH, CHPASS_BASE_PATH } from "components/IndexMain";
 import { useAppSelector } from "eduid-hooks";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Form as FinalForm, FormRenderProps } from "react-final-form";
@@ -10,8 +10,7 @@ import ChangePasswordCustomForm from "./ChangePasswordCustom";
 import { ChangePasswordRadioOption } from "./ChangePasswordRadioOption";
 import ChangePasswordSuggestedForm from "./ChangePasswordSuggested";
 
-// exported for use in tests
-export const finish_url = "account";
+const finish_url = ACCOUNT_PATH;
 
 export interface ChangePasswordFormProps {
   finish_url: string; // URL to direct browser to when user cancels password change, or completes it

--- a/src/components/Dashboard/ChangePassword.tsx
+++ b/src/components/Dashboard/ChangePassword.tsx
@@ -10,12 +10,6 @@ import ChangePasswordCustomForm from "./ChangePasswordCustom";
 import { ChangePasswordRadioOption } from "./ChangePasswordRadioOption";
 import ChangePasswordSuggestedForm from "./ChangePasswordSuggested";
 
-const finish_url = ACCOUNT_PATH;
-
-export interface ChangePasswordFormProps {
-  finish_url: string; // URL to direct browser to when user cancels password change, or completes it
-}
-
 export interface ChangePasswordChildFormProps {
   formProps: FormRenderProps<ChangePasswordFormData>;
   handleCancel?: (event: React.MouseEvent<HTMLElement>) => void;
@@ -76,7 +70,7 @@ export function ChangePassword() {
       // Callback from sub-component when the user clicks on the button to abort changing password
       event.preventDefault();
 
-      navigate(finish_url);
+      navigate(ACCOUNT_PATH);
     },
     [navigate],
   );

--- a/src/components/Dashboard/ChangePassword.tsx
+++ b/src/components/Dashboard/ChangePassword.tsx
@@ -1,5 +1,6 @@
 import securityApi from "apis/eduidSecurity";
 import Splash from "components/Common/Splash";
+import { CHPASS_BASE_PATH } from "components/IndexMain";
 import { useAppSelector } from "eduid-hooks";
 import React, { useCallback, useEffect, useRef, useState } from "react";
 import { Form as FinalForm, FormRenderProps } from "react-final-form";
@@ -48,7 +49,7 @@ export function ChangePassword() {
       const response = await fetchSuggestedPassword();
       if (isMounted.current) {
         if (response.isSuccess) {
-          navigate("chpass");
+          navigate(CHPASS_BASE_PATH);
         }
       }
     } catch (error) {
@@ -62,7 +63,7 @@ export function ChangePassword() {
       if (newPassword) {
         const response = await changePassword({ new_password: newPassword });
         if (response.isSuccess) {
-          navigate("chpass/success", {
+          navigate(`${CHPASS_BASE_PATH}/success`, {
             state: { password: newPassword, isSuggested: renderSuggested } as ChangePasswordSuccessState,
           });
         }

--- a/src/components/Dashboard/ChangePasswordDisplay.tsx
+++ b/src/components/Dashboard/ChangePasswordDisplay.tsx
@@ -1,6 +1,7 @@
 import securityApi from "apis/eduidSecurity";
 import EduIDButton from "components/Common/EduIDButton";
 import { ToolTip } from "components/Common/ToolTip";
+import { CHPASS_BASE_PATH } from "components/IndexMain";
 import { useCallback } from "react";
 import { FormattedMessage } from "react-intl";
 import { useNavigate } from "react-router";
@@ -12,7 +13,7 @@ function ChangePasswordDisplay() {
   const handleSuggestedPassword = useCallback(async () => {
     const response = await fetchSuggestedPassword();
     if (response.isSuccess) {
-      navigate("/chpass");
+      navigate(CHPASS_BASE_PATH);
     }
   }, [fetchSuggestedPassword, navigate]);
 

--- a/src/components/Dashboard/ChangePasswordDisplay.tsx
+++ b/src/components/Dashboard/ChangePasswordDisplay.tsx
@@ -12,7 +12,7 @@ function ChangePasswordDisplay() {
   const handleSuggestedPassword = useCallback(async () => {
     const response = await fetchSuggestedPassword();
     if (response.isSuccess) {
-      navigate("/profile/chpass");
+      navigate("/chpass");
     }
   }, [fetchSuggestedPassword, navigate]);
 

--- a/src/components/Dashboard/ChangePasswordSuccess.tsx
+++ b/src/components/Dashboard/ChangePasswordSuccess.tsx
@@ -1,11 +1,11 @@
 import { ConfirmUserInfo, EmailFieldset } from "components/Common/ConfirmUserInfo";
 import EduIDButton from "components/Common/EduIDButton";
 import Splash from "components/Common/Splash";
+import { ACCOUNT_PATH } from "components/IndexMain";
 import { useAppSelector } from "eduid-hooks";
 import { useMemo } from "react";
 import { FormattedMessage } from "react-intl";
 import { useLocation } from "react-router";
-import { finish_url } from "./ChangePassword";
 
 export function ChangePasswordSuccess(): React.JSX.Element {
   const emails = useAppSelector((state) => state.emails.emails);
@@ -19,7 +19,7 @@ export function ChangePasswordSuccess(): React.JSX.Element {
 
   return (
     <Splash showChildren={is_loaded}>
-      <form method="GET" action={finish_url}>
+      <form method="GET" action={ACCOUNT_PATH}>
         <section className="intro">
           <h1>
             <FormattedMessage

--- a/src/components/Index.tsx
+++ b/src/components/Index.tsx
@@ -15,17 +15,16 @@ import Splash from "./Common/Splash";
 export function Index() {
   const navigate = useNavigate();
   const dispatch = useAppDispatch();
-  const dashboard_link = useAppSelector((state) => state.config.dashboard_link);
   const frontend_action = useAppSelector((state) => state.authn?.response?.frontend_action);
   const eduid_site_link = useAppSelector((state) => state.config.eduid_site_link);
   const [postDeleteAccount] = securityApi.useLazyPostDeleteAccountQuery();
 
   const redirectToLogin = useCallback(async () => {
     dispatch(indexSlice.actions.appLoaded());
-    if (dashboard_link) {
-      document.location.href = dashboard_link;
+    if (eduid_site_link) {
+      document.location.href = eduid_site_link + "start";
     }
-  }, [dispatch, dashboard_link]);
+  }, [dispatch, eduid_site_link]);
 
   const deleteAccount = useCallback(async () => {
     const response = await postDeleteAccount();

--- a/src/components/Index.tsx
+++ b/src/components/Index.tsx
@@ -11,6 +11,7 @@ import registerIcon from "../../img/register-icon.png";
 import securityIcon from "../../img/security-icon.svg";
 import EduIDButton from "./Common/EduIDButton";
 import Splash from "./Common/Splash";
+import { SIGNUP_BASE_PATH } from "./IndexMain";
 
 export function Index() {
   const navigate = useNavigate();
@@ -83,7 +84,7 @@ export function Index() {
           />
         </p>
         <div className="buttons">
-          <EduIDButton onClick={() => navigate("/register")} buttonstyle="primary" id="sign-up-button">
+          <EduIDButton onClick={() => navigate(SIGNUP_BASE_PATH)} buttonstyle="primary" id="sign-up-button">
             <FormattedMessage defaultMessage="Create your eduID" description="Signup button" />
           </EduIDButton>
           <EduIDButton onClick={redirectToLogin} buttonstyle="secondary" id="login-button">

--- a/src/components/IndexMain.tsx
+++ b/src/components/IndexMain.tsx
@@ -34,16 +34,20 @@ export const ACCOUNT_PATH = "/account";
 export const SECURITY_PATH = "/security";
 export const IDENTITY_PATH = "/identity";
 export const SIGNUP_BASE_PATH = "/register";
+export const CHPASS_BASE_PATH = "/chpass";
+
+export const DASHBOARD_PATHS = [START_PATH, ACCOUNT_PATH, SECURITY_PATH, IDENTITY_PATH, CHPASS_BASE_PATH, "/profile"];
 
 export function IndexMain(): React.JSX.Element {
   const isLoaded = useAppSelector((state) => state.config.is_configured);
   const loginRef = useAppSelector((state) => state.login.ref);
   const location = useLocation();
-  const showAuthenticateModal = location.pathname.startsWith("/profile");
+  const showAuthenticateModal = DASHBOARD_PATHS.some((path) => location.pathname.startsWith(path));
   const isIndex = location.pathname === "/";
 
-  if (location.pathname === "/profile") {
-    return <Navigate to={`${location.pathname}/`} />;
+  // Legacy /profile redirects
+  if (location.pathname === "/profile" || location.pathname === "/profile/") {
+    return <Navigate to={START_PATH} replace />;
   }
 
   return (
@@ -74,9 +78,9 @@ export function IndexMain(): React.JSX.Element {
                     <Route path={SECURITY_PATH} element={<Security />} />
                     <Route path={ACCOUNT_PATH} element={<Account />} />
                     <Route path={IDENTITY_PATH} element={<Identity />} />
-                    <Route path="/chpass/" element={<ChangePassword />} />
-                    <Route path="/chpass/success" element={<ChangePasswordSuccess />} />
-                    <Route path="ext-return/:app_name/:authn_id" element={<ExternalReturnHandler />} />
+                    <Route path={CHPASS_BASE_PATH} element={<ChangePassword />} />
+                    <Route path={`${CHPASS_BASE_PATH}/success`} element={<ChangePasswordSuccess />} />
+                    <Route path="/profile/ext-return/:app_name/:authn_id" element={<ExternalReturnHandler />} />
                     <Route path={START_PATH} element={<Start />} />
                     {/* Errors*/}
                     <Route path="/errors" element={<Errors />} />

--- a/src/components/IndexMain.tsx
+++ b/src/components/IndexMain.tsx
@@ -36,13 +36,13 @@ export const IDENTITY_PATH = "/identity";
 export const SIGNUP_BASE_PATH = "/register";
 export const CHPASS_BASE_PATH = "/chpass";
 
-export const DASHBOARD_PATHS = [START_PATH, ACCOUNT_PATH, SECURITY_PATH, IDENTITY_PATH, CHPASS_BASE_PATH, "/profile"];
+export const SETTINGS_PATHS = [START_PATH, ACCOUNT_PATH, SECURITY_PATH, IDENTITY_PATH, CHPASS_BASE_PATH, "/profile"];
 
 export function IndexMain(): React.JSX.Element {
   const isLoaded = useAppSelector((state) => state.config.is_configured);
   const loginRef = useAppSelector((state) => state.login.ref);
   const location = useLocation();
-  const showAuthenticateModal = DASHBOARD_PATHS.some((path) => location.pathname.startsWith(path));
+  const showAuthenticateModal = SETTINGS_PATHS.some((path) => location.pathname.startsWith(path));
   const isIndex = location.pathname === "/";
 
   // Legacy /profile redirects

--- a/src/components/IndexMain.tsx
+++ b/src/components/IndexMain.tsx
@@ -29,10 +29,10 @@ import ScrollToTop from "./ScrollToTop";
 import { SignupApp } from "./Signup/SignupApp";
 import { Errors } from "./SwamidErrors/Errors";
 
-export const START_PATH = "/profile/";
-export const ACCOUNT_PATH = "/profile/account/";
-export const SECURITY_PATH = "/profile/security/";
-export const IDENTITY_PATH = "/profile/identity/";
+export const START_PATH = "/start";
+export const ACCOUNT_PATH = "/account";
+export const SECURITY_PATH = "/security";
+export const IDENTITY_PATH = "/identity";
 export const SIGNUP_BASE_PATH = "/register";
 
 export function IndexMain(): React.JSX.Element {
@@ -74,17 +74,9 @@ export function IndexMain(): React.JSX.Element {
                     <Route path={SECURITY_PATH} element={<Security />} />
                     <Route path={ACCOUNT_PATH} element={<Account />} />
                     <Route path={IDENTITY_PATH} element={<Identity />} />
-                    <Route path="/profile/chpass/" element={<ChangePassword />} />
-                    <Route path="/profile/chpass/success" element={<ChangePasswordSuccess />} />
-                    <Route path="/profile/ext-return/:app_name/:authn_id" element={<ExternalReturnHandler />} />
-                    {/* Navigates for old paths. TODO: redirect in backend server instead */}
-                    <Route path="/profile/accountlinking/" element={<Navigate to={ACCOUNT_PATH} />} />
-                    <Route path="/profile/nins/" element={<Navigate to={IDENTITY_PATH} />} />
-                    <Route path="/profile/emails/" element={<Navigate to={ACCOUNT_PATH} />} />
-                    <Route path="/profile/settings/" element={<Navigate to={ACCOUNT_PATH} />} />
-                    <Route path="/profile/settings/personaldata/" element={<Navigate to={ACCOUNT_PATH} />} />
-                    <Route path="/profile/settings/advanced-settings/" element={<Navigate to={SECURITY_PATH} />} />
-                    <Route path="/profile/verify-identity/" element={<Navigate to={IDENTITY_PATH} />} />
+                    <Route path="/chpass/" element={<ChangePassword />} />
+                    <Route path="/chpass/success" element={<ChangePasswordSuccess />} />
+                    <Route path="ext-return/:app_name/:authn_id" element={<ExternalReturnHandler />} />
                     <Route path={START_PATH} element={<Start />} />
                     {/* Errors*/}
                     <Route path="/errors" element={<Errors />} />

--- a/src/components/IndexMain.tsx
+++ b/src/components/IndexMain.tsx
@@ -29,6 +29,8 @@ import ScrollToTop from "./ScrollToTop";
 import { SignupApp } from "./Signup/SignupApp";
 import { Errors } from "./SwamidErrors/Errors";
 
+export const LOGIN_BASE_PATH = "/login";
+export const RESET_PASSWORD_PATH = "/reset-password";
 export const START_PATH = "/start";
 export const ACCOUNT_PATH = "/account";
 export const SECURITY_PATH = "/security";
@@ -68,12 +70,15 @@ export function IndexMain(): React.JSX.Element {
                     {/* Signup */}
                     <Route path={SIGNUP_BASE_PATH} element={<SignupApp />} />
                     {/* Login */}
-                    <Route path="/login/ext-return/:app_name/:authn_id" element={<LoginExternalReturnHandler />} />
-                    <Route path="/login/other/:state_id" element={<UseOtherDevice2 />} />
-                    <Route path="/login/password/:ref" element={<Login />} />
-                    <Route path="/login/:ref" element={<Login />} />
-                    <Route path="/login/mfa/password/:ref" element={<Login />} />
-                    <Route path="/reset-password/*" element={<ResetPasswordApp />} />
+                    <Route
+                      path={`${LOGIN_BASE_PATH}/ext-return/:app_name/:authn_id`}
+                      element={<LoginExternalReturnHandler />}
+                    />
+                    <Route path={`${LOGIN_BASE_PATH}/other/:state_id`} element={<UseOtherDevice2 />} />
+                    <Route path={`${LOGIN_BASE_PATH}/password/:ref`} element={<Login />} />
+                    <Route path={`${LOGIN_BASE_PATH}/:ref`} element={<Login />} />
+                    <Route path={`${LOGIN_BASE_PATH}/mfa/password/:ref`} element={<Login />} />
+                    <Route path={RESET_PASSWORD_PATH} element={<ResetPasswordApp />} />
                     {/* Dashboard */}
                     <Route path={SECURITY_PATH} element={<Security />} />
                     <Route path={ACCOUNT_PATH} element={<Account />} />

--- a/src/components/Login/Login.tsx
+++ b/src/components/Login/Login.tsx
@@ -1,5 +1,6 @@
 import { loginApi } from "apis/eduidLogin";
 import EduIDButton from "components/Common/EduIDButton";
+import { LOGIN_BASE_PATH } from "components/IndexMain";
 import { useAppDispatch, useAppSelector } from "eduid-hooks";
 import React, { useEffect } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -82,11 +83,11 @@ function Login(): React.JSX.Element {
        * change to/from 'login/password' when that module is used.
        */
       if (next_page === "USERNAMEPASSWORD") {
-        navigate(`/login/password/${ref}`);
+        navigate(`${LOGIN_BASE_PATH}/password/${ref}`);
       } else if (next_page === "PASSWORD") {
-        navigate(`/login/mfa/password/${ref}`);
+        navigate(`${LOGIN_BASE_PATH}/mfa/password/${ref}`);
       } else {
-        navigate(`/login/${ref}`);
+        navigate(`${LOGIN_BASE_PATH}/${ref}`);
       }
     }
   }, [navigate, next_page, ref]);

--- a/src/components/Login/LoginExternalReturnHandler.tsx
+++ b/src/components/Login/LoginExternalReturnHandler.tsx
@@ -61,7 +61,7 @@ export function LoginExternalReturnHandler() {
           const actionToRoute: { [key: string]: string } = {
             loginMfaAuthn: `/login/${status.frontend_state}`,
             resetpwMfaAuthn: `/reset-password/`,
-            login: "/profile/",
+            login: "/start",
           };
           if (!status.error && status.frontend_action === "resetpwMfaAuthn" && status.frontend_state) {
             verifyEmailLink({ email_code: status.frontend_state });

--- a/src/components/Login/LoginExternalReturnHandler.tsx
+++ b/src/components/Login/LoginExternalReturnHandler.tsx
@@ -4,6 +4,7 @@ import { eidasApi } from "apis/eduidEidas";
 import { frejaeIDApi } from "apis/eduidFrejaeID";
 import personalDataApi from "apis/eduidPersonalData";
 import { resetPasswordApi } from "apis/eduidResetPassword";
+import { LOGIN_BASE_PATH } from "components/IndexMain";
 import { useAppDispatch, useAppSelector } from "eduid-hooks";
 import { LOCALIZED_MESSAGES } from "globals";
 import { useCallback, useEffect } from "react";
@@ -88,7 +89,7 @@ export function LoginExternalReturnHandler() {
         }
 
         // TODO: Navigate to errors page here
-        navigate("/login/"); // GOTO start
+        navigate(LOGIN_BASE_PATH); // GOTO start
       }
     },
     [

--- a/src/components/Login/UseOtherDevice2.tsx
+++ b/src/components/Login/UseOtherDevice2.tsx
@@ -4,6 +4,7 @@ import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
 import { loginApi, LoginUseOtherDevice2Response, UseOtherDevice2ResponseLoggedIn } from "apis/eduidLogin";
 import EduIDButton from "components/Common/EduIDButton";
 import { TimeRemainingWrapper } from "components/Common/TimeRemaining";
+import { LOGIN_BASE_PATH } from "components/IndexMain";
 import { useAppDispatch, useAppSelector } from "eduid-hooks";
 import React, { useEffect, useRef, useState } from "react";
 import { FormattedMessage, useIntl } from "react-intl";
@@ -250,7 +251,7 @@ function Device2Buttons(props: Readonly<Device2ButtonsProps>): React.JSX.Element
     if (data?.login_ref) {
       dispatch(loginSlice.actions.callLoginNext());
       // Send the user off to the regular login flow when they click the button
-      navigate(`/login/${data.login_ref}`);
+      navigate(`${LOGIN_BASE_PATH}/${data.login_ref}`);
     }
   }
 

--- a/src/components/Login/UsernamePw.tsx
+++ b/src/components/Login/UsernamePw.tsx
@@ -5,6 +5,7 @@ import TextInput from "components/Common/EduIDTextInput";
 import { PassKey } from "components/Common/Passkey";
 import PasswordInput from "components/Common/PasswordInput";
 import UserNameInput from "components/Common/UserNameInput";
+import { RESET_PASSWORD_PATH } from "components/IndexMain";
 import { useAppDispatch, useAppSelector } from "eduid-hooks";
 import { emailPattern } from "helperFunctions/validation/regexPatterns";
 import React, { Fragment, useCallback, useEffect, useRef, useState } from "react";
@@ -310,7 +311,7 @@ function RenderResetPasswordLink(): React.JSX.Element {
       dispatch(resetPasswordSlice.actions.setEmailAddress(usernameField.input.value));
     }
     dispatch(clearNotifications());
-    navigate("/reset-password/");
+    navigate(RESET_PASSWORD_PATH);
   };
 
   return (

--- a/src/components/Signup/SignupUserCreated.tsx
+++ b/src/components/Signup/SignupUserCreated.tsx
@@ -7,6 +7,7 @@ import { ChangePasswordChildFormProps } from "components/Dashboard/ChangePasswor
 import ChangePasswordCustomForm from "components/Dashboard/ChangePasswordCustom";
 import { ChangePasswordRadioOption } from "components/Dashboard/ChangePasswordRadioOption";
 import ChangePasswordSuggestedForm from "components/Dashboard/ChangePasswordSuggested";
+import { SIGNUP_BASE_PATH } from "components/IndexMain";
 import { useAppDispatch, useAppSelector } from "eduid-hooks";
 import { useState } from "react";
 import { Form as FinalForm } from "react-final-form";
@@ -51,7 +52,7 @@ export function SignupConfirmPassword() {
   function handleCancel(event: React.MouseEvent<HTMLElement>) {
     event.preventDefault();
     dispatch(signupSlice.actions.setNextPage("SIGNUP_EMAIL_FORM"));
-    navigate("/register");
+    navigate(SIGNUP_BASE_PATH);
   }
 
   const suggested = signupState?.credentials.generated_password;

--- a/src/entry-points/index.tsx
+++ b/src/entry-points/index.tsx
@@ -1,7 +1,7 @@
 import { jsConfigApi } from "apis/eduidJsConfig";
 import personalDataApi from "apis/eduidPersonalData";
 import { ReduxIntlProvider } from "components/Common/ReduxIntl";
-import { DASHBOARD_PATHS, IndexMain } from "components/IndexMain";
+import { IndexMain, SETTINGS_PATHS } from "components/IndexMain";
 import { eduidStore } from "eduid-init-app";
 import { LOCALIZED_MESSAGES } from "globals";
 import Raven from "raven-js";
@@ -35,9 +35,9 @@ const getConfig = async function () {
     if (jsConfig.data.payload.sentry_dsn) {
       Raven.config(jsConfig.data.payload.sentry_dsn as string).install();
     }
-    const isDashboard = DASHBOARD_PATHS.some((path) => globalThis.location.href.includes(path));
+    const isSettings = SETTINGS_PATHS.some((path) => globalThis.location.href.includes(path));
 
-    if (isDashboard) {
+    if (isSettings) {
       const personalData_promise = eduidStore.dispatch(personalDataApi.endpoints.requestAllPersonalData.initiate());
       const personalData = await personalData_promise;
       if (personalData.isSuccess) {

--- a/src/entry-points/index.tsx
+++ b/src/entry-points/index.tsx
@@ -35,7 +35,7 @@ const getConfig = async function () {
     if (jsConfig.data.payload.sentry_dsn) {
       Raven.config(jsConfig.data.payload.sentry_dsn as string).install();
     }
-    if (globalThis.location.href.includes("/profile/")) {
+    if (globalThis.location.href.includes("/start")) {
       const personalData_promise = eduidStore.dispatch(personalDataApi.endpoints.requestAllPersonalData.initiate());
       const personalData = await personalData_promise;
       if (personalData.isSuccess) {

--- a/src/entry-points/index.tsx
+++ b/src/entry-points/index.tsx
@@ -1,7 +1,7 @@
 import { jsConfigApi } from "apis/eduidJsConfig";
 import personalDataApi from "apis/eduidPersonalData";
 import { ReduxIntlProvider } from "components/Common/ReduxIntl";
-import { IndexMain } from "components/IndexMain";
+import { DASHBOARD_PATHS, IndexMain } from "components/IndexMain";
 import { eduidStore } from "eduid-init-app";
 import { LOCALIZED_MESSAGES } from "globals";
 import Raven from "raven-js";
@@ -35,7 +35,9 @@ const getConfig = async function () {
     if (jsConfig.data.payload.sentry_dsn) {
       Raven.config(jsConfig.data.payload.sentry_dsn as string).install();
     }
-    if (globalThis.location.href.includes("/start")) {
+    const isDashboard = DASHBOARD_PATHS.some((path) => globalThis.location.href.includes(path));
+
+    if (isDashboard) {
       const personalData_promise = eduidStore.dispatch(personalDataApi.endpoints.requestAllPersonalData.initiate());
       const personalData = await personalData_promise;
       if (personalData.isSuccess) {

--- a/src/tests/Dashboard/DashboardMain-test.tsx
+++ b/src/tests/Dashboard/DashboardMain-test.tsx
@@ -6,7 +6,7 @@ import { defaultDashboardTestState, render, screen } from "../helperFunctions/Da
 test("shows splash screen when not configured", () => {
   render(<IndexMain />, {
     state: { config: { ...configInitialState, is_app_loaded: false } },
-    routes: ["/profile/"],
+    routes: ["/start/"],
   });
 
   expect(screen.getAllByRole("heading")[0]).toHaveTextContent(/Welcome, !/);
@@ -16,7 +16,7 @@ test("shows splash screen when not configured", () => {
 
 test("renders Profile page as expected", () => {
   render(<IndexMain />, {
-    routes: ["/profile/"],
+    routes: ["/start"],
     state: {
       ...defaultDashboardTestState,
       config: { ...defaultDashboardTestState.config, login_service_url: "https://example.com/login" },
@@ -45,7 +45,7 @@ test("renders Profile page as expected", () => {
 
 test("renders eduID status overview, confirmed account", () => {
   render(<IndexMain />, {
-    routes: ["/profile/"],
+    routes: ["/start"],
     state: {
       ...defaultDashboardTestState,
       emails: {
@@ -72,7 +72,7 @@ test("renders eduID status overview, confirmed account", () => {
 
 test("renders verified identity user", () => {
   render(<IndexMain />, {
-    routes: ["/profile/"],
+    routes: ["/start"],
     state: {
       ...defaultDashboardTestState,
       emails: {
@@ -96,7 +96,7 @@ test("renders verified identity user", () => {
 
 test("renders identity verification progress, verified user", () => {
   render(<IndexMain />, {
-    routes: ["/profile/"],
+    routes: ["/start"],
     state: {
       ...defaultDashboardTestState,
       emails: {

--- a/src/tests/Dashboard/DashboardMain-test.tsx
+++ b/src/tests/Dashboard/DashboardMain-test.tsx
@@ -1,12 +1,12 @@
 import { activeClassName } from "components/Common/HeaderNav";
-import { IndexMain } from "components/IndexMain";
+import { IndexMain, START_PATH } from "components/IndexMain";
 import { initialState as configInitialState } from "slices/IndexConfig";
 import { defaultDashboardTestState, render, screen } from "../helperFunctions/DashboardTestApp-rtl";
 
 test("shows splash screen when not configured", () => {
   render(<IndexMain />, {
     state: { config: { ...configInitialState, is_app_loaded: false } },
-    routes: ["/start/"],
+    routes: [START_PATH],
   });
 
   expect(screen.getAllByRole("heading")[0]).toHaveTextContent(/Welcome, !/);
@@ -16,7 +16,7 @@ test("shows splash screen when not configured", () => {
 
 test("renders Profile page as expected", () => {
   render(<IndexMain />, {
-    routes: ["/start"],
+    routes: [START_PATH],
     state: {
       ...defaultDashboardTestState,
       config: { ...defaultDashboardTestState.config, login_service_url: "https://example.com/login" },
@@ -45,7 +45,7 @@ test("renders Profile page as expected", () => {
 
 test("renders eduID status overview, confirmed account", () => {
   render(<IndexMain />, {
-    routes: ["/start"],
+    routes: [START_PATH],
     state: {
       ...defaultDashboardTestState,
       emails: {
@@ -72,7 +72,7 @@ test("renders eduID status overview, confirmed account", () => {
 
 test("renders verified identity user", () => {
   render(<IndexMain />, {
-    routes: ["/start"],
+    routes: [START_PATH],
     state: {
       ...defaultDashboardTestState,
       emails: {
@@ -96,7 +96,7 @@ test("renders verified identity user", () => {
 
 test("renders identity verification progress, verified user", () => {
   render(<IndexMain />, {
-    routes: ["/start"],
+    routes: [START_PATH],
     state: {
       ...defaultDashboardTestState,
       emails: {

--- a/src/tests/Dashboard/DashboardStart-test.tsx
+++ b/src/tests/Dashboard/DashboardStart-test.tsx
@@ -1,4 +1,4 @@
-import { IDENTITY_PATH, IndexMain, SECURITY_PATH } from "components/IndexMain";
+import { IDENTITY_PATH, IndexMain, SECURITY_PATH, START_PATH } from "components/IndexMain";
 import { act } from "react";
 import { initialState as configInitialState } from "slices/IndexConfig";
 import { defaultDashboardTestState, render, screen, waitFor } from "../helperFunctions/DashboardTestApp-rtl";
@@ -19,7 +19,7 @@ test("start page heading text for new user", async () => {
         },
       },
     },
-    routes: ["/start/"],
+    routes: [START_PATH],
   });
   expect(screen.getAllByRole("progressbar")[0]).toBeInTheDocument();
   expect(screen.getAllByRole("progressbar")[0]).toHaveClass("spinner");
@@ -43,7 +43,7 @@ test("recommendations for new users, connect your identity", async () => {
         },
       },
     },
-    routes: ["/start/"],
+    routes: [START_PATH],
   });
 
   expect(screen.getByText(/Connect your identity to eduID at/i)).toBeInTheDocument();
@@ -90,7 +90,7 @@ test("recommendations for new users, add your security key", async () => {
         ],
       },
     },
-    routes: ["/start/"],
+    routes: [START_PATH],
   });
 
   expect(screen.getByText(/Add multi-factor authentication at/i)).toBeInTheDocument();
@@ -139,7 +139,7 @@ test("recommendations for new user, verify security key", async () => {
         ],
       },
     },
-    routes: ["/start/"],
+    routes: [START_PATH],
   });
   expect(screen.getByText(/Verify your Security key at/i)).toBeInTheDocument();
   const securityPath = screen.getAllByRole("link", { name: /Security/i })[0];

--- a/src/tests/Dashboard/DashboardStart-test.tsx
+++ b/src/tests/Dashboard/DashboardStart-test.tsx
@@ -19,7 +19,7 @@ test("start page heading text for new user", async () => {
         },
       },
     },
-    routes: ["/profile/"],
+    routes: ["/start/"],
   });
   expect(screen.getAllByRole("progressbar")[0]).toBeInTheDocument();
   expect(screen.getAllByRole("progressbar")[0]).toHaveClass("spinner");
@@ -43,7 +43,7 @@ test("recommendations for new users, connect your identity", async () => {
         },
       },
     },
-    routes: ["/profile/"],
+    routes: ["/start/"],
   });
 
   expect(screen.getByText(/Connect your identity to eduID at/i)).toBeInTheDocument();
@@ -90,7 +90,7 @@ test("recommendations for new users, add your security key", async () => {
         ],
       },
     },
-    routes: ["/profile/"],
+    routes: ["/start/"],
   });
 
   expect(screen.getByText(/Add multi-factor authentication at/i)).toBeInTheDocument();
@@ -139,7 +139,7 @@ test("recommendations for new user, verify security key", async () => {
         ],
       },
     },
-    routes: ["/profile/"],
+    routes: ["/start/"],
   });
   expect(screen.getByText(/Verify your Security key at/i)).toBeInTheDocument();
   const securityPath = screen.getAllByRole("link", { name: /Security/i })[0];

--- a/src/tests/common/Header-test.tsx
+++ b/src/tests/common/Header-test.tsx
@@ -1,5 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import { Header } from "components/Common/Header";
+import { LOGIN_BASE_PATH } from "components/IndexMain";
 import { initialState as configInitialState } from "slices/IndexConfig";
 import { signupTestState } from "tests/helperFunctions/SignupTestApp-rtl";
 import { loginTestState, render, screen, waitFor } from "../helperFunctions/LoginTestApp-rtl";
@@ -68,7 +69,7 @@ test.each(["/register", "/error", "/reset-password"])("shows Login button on %s 
 test("shows Register button on login page with auth options", () => {
   render(<Header />, {
     state: loginPageState,
-    routes: ["/login/abc123"],
+    routes: [`${LOGIN_BASE_PATH}/abc123`],
   });
 
   const registerButton = screen.getByRole("button", { name: /create eduid/i });
@@ -81,7 +82,7 @@ test("when Register button is clicked, changes header button text to Login", asy
       ...loginPageState,
       signup: { ...signupTestState.signup },
     },
-    routes: ["/login/abc123"],
+    routes: [`${LOGIN_BASE_PATH}/abc123`],
   });
 
   const registerButton = screen.getByRole("button", { name: /create eduid/i });

--- a/src/tests/helperFunctions/DashboardTestApp-rtl.tsx
+++ b/src/tests/helperFunctions/DashboardTestApp-rtl.tsx
@@ -1,5 +1,6 @@
 import { RenderOptions, RenderResult, render as rtlRender } from "@testing-library/react";
 import { ReduxIntlProvider } from "components/Common/ReduxIntl";
+import { START_PATH } from "components/IndexMain";
 import { EduIDAppRootState, getTestEduIDStore } from "eduid-init-app";
 import React from "react";
 import { InitialEntry, MemoryRouter } from "react-router";
@@ -26,7 +27,7 @@ interface RenderArgs {
 }
 
 function render(ui: React.ReactElement, args: RenderArgs = {}): RenderResult {
-  const routes = args.routes || ["/start/"];
+  const routes = args.routes || [START_PATH];
   const store = getTestEduIDStore(args.state || defaultDashboardTestState);
 
   function Wrapper({ children }: Readonly<{ children: React.ReactNode }>) {

--- a/src/tests/helperFunctions/DashboardTestApp-rtl.tsx
+++ b/src/tests/helperFunctions/DashboardTestApp-rtl.tsx
@@ -26,7 +26,7 @@ interface RenderArgs {
 }
 
 function render(ui: React.ReactElement, args: RenderArgs = {}): RenderResult {
-  const routes = args.routes || ["/profile/"];
+  const routes = args.routes || ["/start/"];
   const store = getTestEduIDStore(args.state || defaultDashboardTestState);
 
   function Wrapper({ children }: Readonly<{ children: React.ReactNode }>) {

--- a/src/tests/login/LoginMain-test.tsx
+++ b/src/tests/login/LoginMain-test.tsx
@@ -1,6 +1,6 @@
 import userEvent from "@testing-library/user-event";
 import { LoginNextRequest, LoginNextResponse } from "apis/eduidLogin";
-import { IndexMain } from "components/IndexMain";
+import { IndexMain, LOGIN_BASE_PATH } from "components/IndexMain";
 import { http, HttpResponse } from "msw";
 import { mswServer } from "setupTests";
 import { initialState as configInitialState } from "slices/IndexConfig";
@@ -51,7 +51,7 @@ function renderLoginPage(route: string, options: StateOptions = {}) {
 test("show splash screen when not configured", () => {
   render(<IndexMain />, {
     state: { config: configInitialState },
-    routes: ["/login/abc123"],
+    routes: [`${LOGIN_BASE_PATH}/abc123`],
   });
 
   expect(screen.getByRole("progressbar")).toBeInTheDocument();
@@ -66,8 +66,7 @@ test("renders FINISHED as expected", async () => {
       parameters: { SAMLResponse: "saml-response" },
     }),
   );
-
-  renderLoginPage(`/login/${TEST_REF}`);
+  renderLoginPage(`${LOGIN_BASE_PATH}/${TEST_REF}`);
 
   await waitFor(() => screen.getByRole("heading"));
 
@@ -84,7 +83,7 @@ test("renders UsernamePw as expected", async () => {
     }),
   );
 
-  renderLoginPage(`/login/password/${TEST_REF}`);
+  renderLoginPage(`${LOGIN_BASE_PATH}/password/${TEST_REF}`);
 
   await waitFor(() => screen.getByRole("heading"));
 
@@ -108,7 +107,7 @@ test("renders passkey button as expected", async () => {
     }),
   );
 
-  renderLoginPage(`/login/password/${TEST_REF}`, { webauthn: true });
+  renderLoginPage(`${LOGIN_BASE_PATH}/password/${TEST_REF}`, { webauthn: true });
 
   await waitFor(() => screen.getByRole("heading", { level: 1 }));
 

--- a/src/tests/login/LoginResetPassword-test.tsx
+++ b/src/tests/login/LoginResetPassword-test.tsx
@@ -11,7 +11,7 @@ import {
 } from "apis/eduidResetPassword";
 import { emailPlaceHolder } from "components/Common/EmailInput";
 import { userNameInputPlaceHolder } from "components/Common/UserNameInput";
-import { IndexMain } from "components/IndexMain";
+import { IndexMain, LOGIN_BASE_PATH } from "components/IndexMain";
 import { http, HttpResponse } from "msw";
 import { mswServer } from "setupTests";
 import { loginTestState, render, screen, waitFor } from "../helperFunctions/LoginTestApp-rtl";
@@ -65,11 +65,11 @@ test("can click 'forgot password' with an e-mail address", async () => {
         throttled_seconds: 60,
       };
       return HttpResponse.json({ type: "test response", payload: payload });
-    })
+    }),
   );
 
   render(<IndexMain />, {
-    routes: [`/login/${ref}`],
+    routes: [`${LOGIN_BASE_PATH}/${ref}`],
     state: {
       ...loginTestState,
       resetPassword: {
@@ -178,7 +178,7 @@ test("can click 'forgot password' without an e-mail address", async () => {
         }
         const payload: NewPasswordResponse = {};
         return new HttpResponse(JSON.stringify({ type: "test response", payload: payload }));
-      }
+      },
     ),
     http.post("https://idp.eduid.docker/services/reset-password/new-password", async ({ request }) => {
       const body = (await request.json()) as NewPasswordRequest;
@@ -187,11 +187,11 @@ test("can click 'forgot password' without an e-mail address", async () => {
       }
       const payload: NewPasswordResponse = {};
       return new HttpResponse(JSON.stringify({ type: "test response", payload: payload }));
-    })
+    }),
   );
 
   render(<IndexMain />, {
-    routes: [`/login/${ref}`],
+    routes: [`${LOGIN_BASE_PATH}/${ref}`],
     state: {
       ...loginTestState,
       resetPassword: {


### PR DESCRIPTION
#### Description:

Remove the `/profile` prefix from dashboard URLs for cleaner paths.

### Changes
- `/profile/` → `/start`
- `/profile/account` → `/account`
- `/profile/security` → `/security`
- `/profile/identity` → `/identity`
- `/profile/chpass` → `/chpass`

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
