### PR TITLE
Remove redundant Redux MFA state — use RTK Query hook state

### DIFF
--- a/src/components/Login/MultiFactorAuth.tsx
+++ b/src/components/Login/MultiFactorAuth.tsx
@@ -16,7 +16,6 @@ import { securityZoneAction, SecurityZoneInfo } from "./SecurityZoneInfo";
 export function MultiFactorAuth(): React.JSX.Element {
   const service_info = useAppSelector((state) => state.login.service_info);
   const authn_options = useAppSelector((state) => state.login.authn_options);
-  const mfa = useAppSelector((state) => state.login.mfa);
   const ref = useAppSelector((state) => state.login.ref);
   const this_device = useAppSelector((state) => state.login.this_device);
   const has_session = authn_options?.has_session;
@@ -71,12 +70,12 @@ export function MultiFactorAuth(): React.JSX.Element {
     );
   }
 
-  const isLoaded = mfa?.state === "loaded";
+  const isLoaded = data.isSuccess;
   const hasMfaOptions =
     authn_options.swedish_eid || authn_options.webauthn || authn_options.eidas || authn_options.freja_eid;
 
   useEffect(() => {
-    if (ref && mfa?.state === undefined) {
+    if (ref && data.isUninitialized) {
       // Always call the MFA auth endpoint to get the current MFA state:
       //
       // If webauthn is an available choice for this user, fetch a challenge
@@ -86,7 +85,7 @@ export function MultiFactorAuth(): React.JSX.Element {
       // to call the MFA endpoint for it to complete.
       fetchMfaAuth({ ref: ref, this_device: this_device });
     }
-  }, [fetchMfaAuth, mfa, ref, this_device]);
+  }, [fetchMfaAuth, data.isUninitialized, ref, this_device]);
 
   async function getChallenge() {
     if (ref) {

--- a/src/slices/Login.ts
+++ b/src/slices/Login.ts
@@ -20,9 +20,6 @@ interface LoginState {
   next_page?: IdPAction; // should be called 'current page'
   fetching_next?: boolean;
   post_to?: string; // the target endpoint for the action at the current page
-  mfa: {
-    state?: "loading" | "loaded";
-  };
   saml_parameters?: SAMLParameters;
   tou: {
     available_versions: string[];
@@ -37,7 +34,6 @@ interface LoginState {
 
 // Define the initial state using that type. Export for use as a baseline in tests.
 export const initialState: LoginState = {
-  mfa: {},
   tou: { available_versions: Object.keys(ToUs) },
   authn_options: {},
 };
@@ -146,19 +142,11 @@ export const loginSlice = createSlice({
       .addMatcher(loginApi.endpoints.fetchNewDevice.matchFulfilled, (state, action) => {
         state.this_device = action.payload.payload.new_device;
       })
-      .addMatcher(loginApi.endpoints.fetchMfaAuth.matchPending, (state) => {
-        state.mfa = { state: "loading" };
-      })
       .addMatcher(loginApi.endpoints.fetchMfaAuth.matchFulfilled, (state, action) => {
         if (action.payload.payload.finished) {
           // Trigger fetching of /next on successful MFA authentication
           state.next_page = undefined;
         }
-        state.mfa.state = "loaded";
-      })
-      .addMatcher(loginApi.endpoints.fetchMfaAuth.matchRejected, (state) => {
-        // Handle error state, i.e. unknown credentials etc.
-        state.mfa.state = undefined;
       })
       .addMatcher(loginApi.endpoints.fetchToU.matchFulfilled, (state, action) => {
         if (action.payload.payload.version) {


### PR DESCRIPTION
# Remove redundant Redux MFA state — use RTK Query hook state

## Problem

Recent frontend changes around MFA broke the external MFA login flow (Sweden Connect, BankID via redirect). The backend requires a call to `mfa_auth` both before redirecting to external MFA (to update backend state) and after returning (to complete authentication). The pre-redirect call set the Redux `login.mfa.state` flag to `"loaded"`, and the `useEffect` guard (`mfa?.state === undefined`) then prevented the post-redirect call from firing.

This happened because `login.mfa.state` in Redux was a manually-managed parallel copy of RTK Query's own request lifecycle state. The flag was also polluted by `UsernamePw`, which calls `fetchMfaAuth` for passkey challenges on the password page — setting `mfa.state` to `"loaded"` before the MFA step even begins.

Additionally, the `matchRejected` handler reset `mfa.state` to `undefined`, which re-triggered the `useEffect` and created an unintentional retry loop on failure.

## Solution

Remove the `mfa` field from Redux state entirely and use RTK Query's hook-local state from `useLazyFetchMfaAuthQuery()` instead. Each hook instance tracks its own lifecycle independently, so `UsernamePw`'s calls don't interfere with `MultiFactorAuth`.

**Login.ts:**
- Remove `mfa` from `LoginState` and `initialState`
- Remove `fetchMfaAuth.matchPending` and `fetchMfaAuth.matchRejected` matchers
- Keep `fetchMfaAuth.matchFulfilled` only for the `next_page = undefined` side effect on successful auth

**MultiFactorAuth.tsx:**
- Replace `mfa?.state === undefined` guard with `data.isUninitialized` (RTK Query hook state)
- Replace `mfa?.state === "loaded"` loading indicator with `data.isSuccess`

The external auth return now works naturally: a fresh page load creates a fresh hook instance where `isUninitialized` is `true`, so `fetchMfaAuth` fires automatically.

## Test plan

- [x] Login with password + security key (webauthn) MFA completes successfully
- [x] Login with password + external MFA (Sweden Connect / BankID redirect) completes successfully
- [x] Passkey/conditional auth on the password page still works (UsernamePw flow unaffected)
- [x] Login via "use other device" flow still works

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
