### PR TITLE
add ORCID connect status handler to ExternalReturnHandler

### DIFF
--- a/src/apis/eduidOrcid.ts
+++ b/src/apis/eduidOrcid.ts
@@ -1,5 +1,5 @@
 import { eduIDApi } from "./common";
-import type { ApiResponse } from "./helpers/types";
+import type { ApiResponse, AuthCommonResponse } from "./helpers/types";
 
 export interface OrcidInfo {
   id: string;
@@ -24,6 +24,16 @@ export const orcidApi = eduIDApi.injectEndpoints({
       query: () => ({
         url: "remove",
         body: {},
+      }),
+      extraOptions: { service: "orcid" },
+    }),
+    connectOrcid: builder.query<ApiResponse<AuthCommonResponse>, void>({
+      query: () => ({
+        url: "connect-orcid",
+        body: {
+          frontend_action: "connectOrcid",
+          frontend_state: "optional-opaque-string",
+        },
       }),
       extraOptions: { service: "orcid" },
     }),

--- a/src/apis/eduidOrcid.ts
+++ b/src/apis/eduidOrcid.ts
@@ -1,4 +1,5 @@
 import { eduIDApi } from "./common";
+import { GetStatusRequest, GetStatusResponse } from "./eduidEidas";
 import type { ApiResponse, AuthCommonResponse } from "./helpers/types";
 
 export interface OrcidInfo {
@@ -34,6 +35,13 @@ export const orcidApi = eduIDApi.injectEndpoints({
           frontend_action: "connectOrcid",
           frontend_state: "optional-opaque-string",
         },
+      }),
+      extraOptions: { service: "orcid" },
+    }),
+    orcidGetStatus: builder.query<ApiResponse<GetStatusResponse>, GetStatusRequest>({
+      query: (body) => ({
+        url: "get-status",
+        body,
       }),
       extraOptions: { service: "orcid" },
     }),

--- a/src/components/Common/ExternalReturnHandler.tsx
+++ b/src/components/Common/ExternalReturnHandler.tsx
@@ -43,6 +43,7 @@ export function ExternalReturnHandler() {
           removeSecurityKeyAuthn: SECURITY_PATH,
           changeSecurityPreferencesAuthn: SECURITY_PATH,
           removeIdentity: IDENTITY_PATH,
+          connectOrcid: IDENTITY_PATH,
         };
         const _path = actionToRoute[status.frontend_action];
 
@@ -98,17 +99,19 @@ export function ExternalReturnHandler() {
   );
 
   useEffect(() => {
-    if (params.authn_id && params.app_name === "eidas" && app_loaded) {
-      fetchEidasStatus(params.authn_id).catch(console.error);
-    }
-    if (params.authn_id && params.app_name === "freja_eid") {
-      fetchFrejaeIDStatus(params.authn_id).catch(console.error);
-    }
-    if (params.authn_id && params.app_name === "bankid" && app_loaded) {
-      fetchBankIDStatus(params.authn_id).catch(console.error);
-    }
-    if (params.authn_id && params.app_name === "authn" && app_loaded) {
-      fetchAuthStatus(params.authn_id);
+    if (app_loaded && params.authn_id) {
+      if (params.app_name === "eidas") {
+        fetchEidasStatus(params.authn_id).catch(console.error);
+      }
+      if (params.app_name === "freja_eid") {
+        fetchFrejaeIDStatus(params.authn_id).catch(console.error);
+      }
+      if (params.app_name === "bankid") {
+        fetchBankIDStatus(params.authn_id).catch(console.error);
+      }
+      if (params.app_name === "authn" || params.app_name === "connectOrcid") {
+        fetchAuthStatus(params.authn_id);
+      }
     }
   }, [params, app_loaded, fetchEidasStatus, fetchFrejaeIDStatus, fetchBankIDStatus, fetchAuthStatus]);
 

--- a/src/components/Common/ExternalReturnHandler.tsx
+++ b/src/components/Common/ExternalReturnHandler.tsx
@@ -2,7 +2,8 @@ import authnApi from "apis/eduidAuthn";
 import { bankIDApi } from "apis/eduidBankid";
 import { eidasApi, GetStatusResponse } from "apis/eduidEidas";
 import { frejaeIDApi } from "apis/eduidFrejaeID";
-import { CHPASS_BASE_PATH, IDENTITY_PATH, SECURITY_PATH, START_PATH } from "components/IndexMain";
+import { orcidApi } from "apis/eduidOrcid";
+import { ACCOUNT_PATH, CHPASS_BASE_PATH, IDENTITY_PATH, SECURITY_PATH, START_PATH } from "components/IndexMain";
 import { useAppDispatch, useAppSelector } from "eduid-hooks";
 import { useCallback, useEffect } from "react";
 import { useNavigate, useParams } from "react-router";
@@ -23,6 +24,7 @@ export function ExternalReturnHandler() {
   const [bankIDGetStatus] = bankIDApi.useLazyBankIDGetStatusQuery();
   const [eidasGetStatus] = eidasApi.useLazyEidasGetStatusQuery();
   const [frejaeIDGetStatus] = frejaeIDApi.useLazyFrejaeIDGetStatusQuery();
+  const [orcidGetStatus] = orcidApi.useLazyOrcidGetStatusQuery();
 
   const processStatus = useCallback(
     (response: GetStatusResponse) => {
@@ -43,7 +45,7 @@ export function ExternalReturnHandler() {
           removeSecurityKeyAuthn: SECURITY_PATH,
           changeSecurityPreferencesAuthn: SECURITY_PATH,
           removeIdentity: IDENTITY_PATH,
-          connectOrcid: IDENTITY_PATH,
+          connectOrcid: ACCOUNT_PATH,
         };
         const _path = actionToRoute[status.frontend_action];
 
@@ -98,6 +100,16 @@ export function ExternalReturnHandler() {
     [authnGetStatus, processStatus],
   );
 
+  const fetchOrcidStatus = useCallback(
+    async (authn_id: string) => {
+      const response = await orcidGetStatus({ authn_id: authn_id });
+      if (response.isSuccess) {
+        processStatus(response.data.payload);
+      }
+    },
+    [orcidGetStatus, processStatus],
+  );
+
   useEffect(() => {
     if (app_loaded && params.authn_id) {
       if (params.app_name === "eidas") {
@@ -109,8 +121,11 @@ export function ExternalReturnHandler() {
       if (params.app_name === "bankid") {
         fetchBankIDStatus(params.authn_id).catch(console.error);
       }
-      if (params.app_name === "authn" || params.app_name === "connectOrcid") {
+      if (params.app_name === "authn") {
         fetchAuthStatus(params.authn_id);
+      }
+      if (params.app_name === "orcid") {
+        fetchOrcidStatus(params.authn_id);
       }
     }
   }, [params, app_loaded, fetchEidasStatus, fetchFrejaeIDStatus, fetchBankIDStatus, fetchAuthStatus]);

--- a/src/components/Dashboard/Orcid.tsx
+++ b/src/components/Dashboard/Orcid.tsx
@@ -22,9 +22,9 @@ export function urlJoin(base_url: string, endpoint?: string) {
 
 export function Orcid(): React.JSX.Element {
   const orcid = useAppSelector((state) => state.account_linking.orcid);
-  const orcid_service_url = useAppSelector((state) => state.config.orcid_service_url);
   const intl = useIntl();
   const [removeOrcid] = orcidApi.useLazyRemoveOrcidQuery();
+  const [connectOrcid] = orcidApi.useLazyConnectOrcidQuery();
 
   async function handleOrcidDelete() {
     const result = await removeOrcid();
@@ -33,14 +33,12 @@ export function Orcid(): React.JSX.Element {
     }
   }
 
-  function handleOrcidConnect() {
-    try {
-      if (orcid_service_url) {
-        const auth_url = urlJoin(orcid_service_url, "authorize");
-        globalThis.location.assign(auth_url);
+  async function handleOrcidConnect() {
+    const response = await connectOrcid();
+    if (response.isSuccess) {
+      if (response.data.payload.location) {
+        globalThis.location.assign(response.data.payload.location);
       }
-    } catch (error) {
-      console.error("Error connecting to orcid", error);
     }
   }
 


### PR DESCRIPTION
#### Description:

Changes:
- Add orcidGetStatus lazy query to fetch ORCID authentication status
- Add fetchOrcidStatus callback to process ORCID return flow
- Handle "orcid" app_name in useEffect to route ORCID callbacks
- Map connectOrcid frontend_action to ACCOUNT_PATH

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
