### PR TITLE
allow signup replace identity

### DIFF
--- a/src/apis/eduidSignup.ts
+++ b/src/apis/eduidSignup.ts
@@ -103,6 +103,7 @@ export interface SignupReturnToAuthnRequest {
 export interface ExternalMfaRegisterRequest {
   app_name: string;
   authn_id: string;
+  confirm_replace?: boolean;
 }
 
 export const signupApi = eduIDApi.injectEndpoints({
@@ -201,6 +202,13 @@ export const signupApi = eduIDApi.injectEndpoints({
       query: (body) => ({
         url: "external-mfa-register",
         body,
+      }),
+      extraOptions: { service: "signup" },
+    }),
+    externalMfaClear: builder.query<ApiResponse<SignupStatusResponse>, void>({
+      query: () => ({
+        url: "external-mfa-clear",
+        body: {},
       }),
       extraOptions: { service: "signup" },
     }),

--- a/src/components/Signup/SignupEmailForm.tsx
+++ b/src/components/Signup/SignupEmailForm.tsx
@@ -49,6 +49,9 @@ export function EmailForm() {
 
   if (!state) return null;
 
+  const givenName = state?.external_mfa?.given_name ?? state?.name?.given_name ?? "";
+  const surname = state?.external_mfa?.surname ?? state?.name?.surname ?? "";
+
   const firstNamePlaceholder = intl.formatMessage({
     id: "placeholder.firstName",
     defaultMessage: "first name",
@@ -100,8 +103,8 @@ export function EmailForm() {
       validate={validateSignupUserInForm}
       initialValues={{
         email: "",
-        given_name: state?.name?.given_name?.replace(/^\w/, (c) => c.toUpperCase()) ?? "",
-        surname: state?.name?.surname?.replace(/^\w/, (c) => c.toUpperCase()) ?? "",
+        given_name: givenName.replace(/^\w/, (c) => c.toUpperCase()) ?? "",
+        surname: surname?.replace(/^\w/, (c) => c.toUpperCase()) ?? "",
       }}
       render={(formProps: FormRenderProps<SignupEmailFormData>) => {
         const _submitError = Boolean(formProps.submitError && !formProps.dirtySinceLastSubmit);

--- a/src/components/Signup/SignupEntry.tsx
+++ b/src/components/Signup/SignupEntry.tsx
@@ -5,9 +5,10 @@ import { eidasApi } from "apis/eduidEidas";
 import { frejaeIDApi } from "apis/eduidFrejaeID";
 import signupApi from "apis/eduidSignup";
 import EduIDButton from "components/Common/EduIDButton";
+import NotificationModal from "components/Common/NotificationModal";
 import Splash from "components/Common/Splash";
-import { useAppSelector } from "eduid-hooks";
-import { useState } from "react";
+import { useAppDispatch, useAppSelector } from "eduid-hooks";
+import { useEffect, useState } from "react";
 import ReactCountryFlag from "react-country-flag";
 import { FormattedMessage } from "react-intl";
 import { Fragment } from "react/jsx-runtime";
@@ -49,6 +50,11 @@ export function SignupEntry(): React.JSX.Element {
   const regionNames = new Intl.DisplayNames([currentLocale], { type: "region" });
   const { isFetching } = signupApi.useFetchStateQuery();
   const [isLoading, setIsLoading] = useState(false);
+  const [externalMfaRegister] = signupApi.useLazyExternalMfaRegisterQuery();
+  const [showModal, setShowModal] = useState<boolean>(false);
+  const errorMsg = useAppSelector((state) => state.notifications.error?.message);
+  const dispatch = useAppDispatch();
+  const identity_collision = useAppSelector((state) => state.signup.identity_collision);
 
   const appNameDisplay: Record<string, string> = {
     freja_eid: "Freja eID",
@@ -73,6 +79,12 @@ export function SignupEntry(): React.JSX.Element {
       setIsLoading(false);
     }
   };
+
+  useEffect(() => {
+    if (identity_collision) {
+      setShowModal(true);
+    }
+  }, [identity_collision]);
 
   return (
     <div className="step-container">
@@ -307,6 +319,27 @@ export function SignupEntry(): React.JSX.Element {
           </Fragment>
         )}
       </Splash>
+      <NotificationModal
+        id="account-collision-modal"
+        title={
+          <FormattedMessage
+            defaultMessage="An account with this identity already exists"
+            description="Collision dialog heading"
+          />
+        }
+        mainText={
+          <FormattedMessage
+            defaultMessage="This identity already belongs to an eduID account. Do you want to create a new account with it anyway? Your verified identity will be moved to the new account."
+            description="Collision dialog description"
+          />
+        }
+        showModal={showModal}
+        closeModal={() => setShowModal(false)}
+        acceptModal={() => console.log("accept")}
+        acceptButtonText={
+          <FormattedMessage defaultMessage="Yes, create a new account" description="Collision dialog confirm button" />
+        }
+      />
       <SignupStepIndicator currentStep={1} />
     </div>
   );

--- a/src/components/Signup/SignupEntry.tsx
+++ b/src/components/Signup/SignupEntry.tsx
@@ -343,7 +343,7 @@ export function SignupEntry(): React.JSX.Element {
         closeModal={() => handleCancelCollision()}
         acceptModal={() => confirmCollision()}
         acceptButtonText={
-          <FormattedMessage defaultMessage="Yes, create a new account" description="Collision dialog confirm button" />
+          <FormattedMessage defaultMessage="Continue with new account" description="Collision dialog confirm button" />
         }
       />
       <SignupStepIndicator currentStep={1} />

--- a/src/components/Signup/SignupEntry.tsx
+++ b/src/components/Signup/SignupEntry.tsx
@@ -8,10 +8,11 @@ import EduIDButton from "components/Common/EduIDButton";
 import NotificationModal from "components/Common/NotificationModal";
 import Splash from "components/Common/Splash";
 import { useAppDispatch, useAppSelector } from "eduid-hooks";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import ReactCountryFlag from "react-country-flag";
 import { FormattedMessage } from "react-intl";
 import { Fragment } from "react/jsx-runtime";
+import { signupSlice } from "slices/Signup";
 import BankIdFlag from "../../../img/flags/BankID_logo.svg";
 import Eidas from "../../../img/flags/EU_trust_mark_logo_eIDAS.png";
 import EuFlag from "../../../img/flags/EuFlag.svg";
@@ -51,10 +52,10 @@ export function SignupEntry(): React.JSX.Element {
   const { isFetching } = signupApi.useFetchStateQuery();
   const [isLoading, setIsLoading] = useState(false);
   const [externalMfaRegister] = signupApi.useLazyExternalMfaRegisterQuery();
-  const [showModal, setShowModal] = useState<boolean>(false);
-  const errorMsg = useAppSelector((state) => state.notifications.error?.message);
+  const [externalMfaClear] = signupApi.useLazyExternalMfaClearQuery();
   const dispatch = useAppDispatch();
   const identity_collision = useAppSelector((state) => state.signup.identity_collision);
+  const showModal = Boolean(identity_collision);
 
   const appNameDisplay: Record<string, string> = {
     freja_eid: "Freja eID",
@@ -80,11 +81,21 @@ export function SignupEntry(): React.JSX.Element {
     }
   };
 
-  useEffect(() => {
+  const confirmCollision = async () => {
     if (identity_collision) {
-      setShowModal(true);
+      await externalMfaRegister({
+        app_name: identity_collision.app_name,
+        authn_id: identity_collision.authn_id,
+        confirm_replace: true,
+      });
+      dispatch(signupSlice.actions.setIdentityCollision(undefined));
     }
-  }, [identity_collision]);
+  };
+
+  const handleCancelCollision = async () => {
+    await externalMfaClear();
+    dispatch(signupSlice.actions.setIdentityCollision(undefined));
+  };
 
   return (
     <div className="step-container">
@@ -321,12 +332,7 @@ export function SignupEntry(): React.JSX.Element {
       </Splash>
       <NotificationModal
         id="account-collision-modal"
-        title={
-          <FormattedMessage
-            defaultMessage="An account with this identity already exists"
-            description="Collision dialog heading"
-          />
-        }
+        title={<FormattedMessage defaultMessage="Identity already registered" description="Collision dialog heading" />}
         mainText={
           <FormattedMessage
             defaultMessage="This identity already belongs to an eduID account. Do you want to create a new account with it anyway? Your verified identity will be moved to the new account."
@@ -334,8 +340,8 @@ export function SignupEntry(): React.JSX.Element {
           />
         }
         showModal={showModal}
-        closeModal={() => setShowModal(false)}
-        acceptModal={() => console.log("accept")}
+        closeModal={() => handleCancelCollision()}
+        acceptModal={() => confirmCollision()}
         acceptButtonText={
           <FormattedMessage defaultMessage="Yes, create a new account" description="Collision dialog confirm button" />
         }

--- a/src/components/Signup/SignupExternalReturnHandler.tsx
+++ b/src/components/Signup/SignupExternalReturnHandler.tsx
@@ -5,7 +5,8 @@ import signupApi from "apis/eduidSignup";
 import { useAppDispatch, useAppSelector } from "eduid-hooks";
 import { useCallback, useEffect } from "react";
 import { useNavigate, useParams } from "react-router";
-import { showNotification } from "slices/Notifications";
+import { clearNotifications, showNotification } from "slices/Notifications";
+import { signupSlice } from "slices/Signup";
 
 // URL parameters passed to this component
 interface SignupCallbackParams {
@@ -29,10 +30,17 @@ export function SignupExternalReturnHandler() {
         dispatch(showNotification({ message: response.status, level: response.error ? "error" : "info" }));
       }
       if (response.frontend_action) {
-        await externalMfaRegister({
+        const result = await externalMfaRegister({
           app_name,
           authn_id,
         });
+        if (result.error) {
+          const error = result.error as { payload?: { message?: string } };
+          if (error.payload?.message === "signup.identity-already-registered") {
+            dispatch(clearNotifications());
+            dispatch(signupSlice.actions.setIdentityCollision({ app_name, authn_id }));
+          }
+        }
         navigate("/register");
       }
     },

--- a/src/components/Signup/SignupUserCreated.tsx
+++ b/src/components/Signup/SignupUserCreated.tsx
@@ -135,7 +135,7 @@ export function SignupUserCreated(): React.JSX.Element {
   const idp_service_info = signupState?.idp_service_info;
   const locale = useAppSelector((state) => state.intl.locale);
   const service_name = idp_service_info?.display_name?.[locale] || idp_service_info?.display_name?.["en"] || undefined;
-
+  console.log("jhjjj");
   async function handleFinish() {
     if (idpRequestRef) {
       const signupResponse = await signupAuthn({ ref: idpRequestRef });
@@ -143,9 +143,8 @@ export function SignupUserCreated(): React.JSX.Element {
         globalThis.location.href = `/login/${idpRequestRef}`;
         return;
       }
-    } else {
-      globalThis.location.href = dashboard_link ?? "/";
     }
+    globalThis.location.href = dashboard_link ?? "/";
   }
 
   return (

--- a/src/slices/Signup.ts
+++ b/src/slices/Signup.ts
@@ -1,5 +1,5 @@
 import { Action, createSlice, PayloadAction } from "@reduxjs/toolkit";
-import signupApi, { CaptchaRequest, SignupState as SignupBackendState, SignupStatusResponse } from "apis/eduidSignup";
+import { CaptchaRequest, SignupState as SignupBackendState, SignupStatusResponse } from "apis/eduidSignup";
 import { isFSA } from "apis/helpers/typeGuards";
 
 export type NextPageTypes =
@@ -78,13 +78,6 @@ export const signupSlice = createSlice({
   extraReducers: (builder) => {
     builder.addMatcher(hasSignupStateResponse, (state, action) => {
       state.state = action.payload.payload.state;
-    });
-    builder.addMatcher(signupApi.endpoints.fetchState.matchFulfilled, (state, action) => {
-      const externalMfa = action.payload.payload.state.external_mfa;
-      if (state.state?.name && externalMfa) {
-        state.state.name.given_name = externalMfa.given_name;
-        state.state.name.surname = externalMfa.surname;
-      }
     });
   },
 });

--- a/src/slices/Signup.ts
+++ b/src/slices/Signup.ts
@@ -25,6 +25,7 @@ interface SignupState {
   email_code?: string; // pass email code from one state to another
   captcha?: CaptchaRequest; // pass captcha response from one state to another
   next_page?: string;
+  identity_collision?: { app_name: string; authn_id: string };
 }
 
 // type predicate to help identify payloads with the signup state.
@@ -69,6 +70,9 @@ export const signupSlice = createSlice({
     },
     setNextPage: (state, action: PayloadAction<NextPageTypes>) => {
       state.next_page = action.payload;
+    },
+    setIdentityCollision(state, action: PayloadAction<{ app_name: string; authn_id: string } | undefined>) {
+      state.identity_collision = action.payload;
     },
   },
   extraReducers: (builder) => {


### PR DESCRIPTION
#### Description:

Add a confirmation modal when a user attempts to register with a digital ID 
that is already associated with an existing account.


## Flow

1. User selects a digital ID (BankID, Freja+, eIDAS, Freja eID)
2. Backend returns `signup.identity-already-registered` error
3. Modal is displayed: "This identity already belongs to an eduID account. 
   Do you want to create a new account with it anyway?"
4. User confirms → same request is sent with `confirm_replace: true` → registration continues
5. User cancels → external MFA is cleared → user returns to entry page


<img width="801" height="1124" alt="Screenshot 2026-06-12 at 10 31 26" src="https://github.com/user-attachments/assets/4a38bd8b-57d9-4b09-a536-1f9a8e1d9e3e" />
----

#### For reviewer:

- [ ] Read the above description
- [ ] Reviewed the code changes
- [ ] Navigate to the branch (pulled the latest version)
- [ ] Run the code and been able to execute the expected function
- [ ] Check any styling on both desktop and mobile sizes
