### PR TITLE
Remove `react-country-flag` — inline emoji flag

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,6 @@
         "postcss-import": "^16.1.1",
         "postcss-loader": "^8.2.0",
         "react-compiler-webpack": "^0.2.1",
-        "react-country-flag": "^3.1.0",
         "style-loader": "^4.0.0",
         "stylelint": "^17.6.0",
         "stylelint-config-standard": "^40.0.0",
@@ -14837,18 +14836,6 @@
       },
       "peerDependencies": {
         "babel-plugin-react-compiler": "*"
-      }
-    },
-    "node_modules/react-country-flag": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/react-country-flag/-/react-country-flag-3.1.0.tgz",
-      "integrity": "sha512-JWQFw1efdv9sTC+TGQvTKXQg1NKbDU2mBiAiRWcKM9F1sK+/zjhP2yGmm8YDddWyZdXVkR8Md47rPMJmo4YO5g==",
-      "dev": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "react": ">=16"
       }
     },
     "node_modules/react-dom": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,6 @@
     "postcss-import": "^16.1.1",
     "postcss-loader": "^8.2.0",
     "react-compiler-webpack": "^0.2.1",
-    "react-country-flag": "^3.1.0",
     "style-loader": "^4.0.0",
     "stylelint": "^17.6.0",
     "stylelint-config-standard": "^40.0.0",

--- a/src/components/Common/CountryFlag.tsx
+++ b/src/components/Common/CountryFlag.tsx
@@ -1,0 +1,30 @@
+import React from "react";
+
+interface CountryFlagProps {
+  /** ISO 3166-1 alpha-2 country code, e.g. "SE" */
+  countryCode: string;
+  className?: string;
+  "aria-label"?: string;
+}
+
+/**
+ * Renders a country's flag as a Unicode emoji, by mapping each ASCII letter of the
+ * (alpha-2) country code to its Regional Indicator Symbol. Replaces the react-country-flag
+ * dependency, whose default (emoji) mode did the exact same transform.
+ */
+export default function CountryFlag(props: Readonly<CountryFlagProps>): React.JSX.Element {
+  const emoji = props.countryCode
+    .toUpperCase()
+    .replace(/./g, (c) => String.fromCodePoint(c.charCodeAt(0) + 127397));
+
+  return (
+    <span
+      role="img"
+      className={props.className}
+      aria-label={props["aria-label"]}
+      style={{ display: "inline-block", fontSize: "1em", lineHeight: "1em", verticalAlign: "middle" }}
+    >
+      {emoji}
+    </span>
+  );
+}

--- a/src/components/Dashboard/Identity.tsx
+++ b/src/components/Dashboard/Identity.tsx
@@ -3,6 +3,7 @@ import { frejaeIDApi } from "apis/eduidFrejaeID";
 import personalDataApi from "apis/eduidPersonalData";
 import { ActionStatus, securityApi } from "apis/eduidSecurity";
 import { Accordion, AccordionItemTemplate } from "components/Common/AccordionItemTemplate";
+import CountryFlag from "components/Common/CountryFlag";
 import EduIDButton from "components/Common/EduIDButton";
 import NinDisplay from "components/Common/NinDisplay";
 import NotificationModal from "components/Common/NotificationModal";
@@ -13,7 +14,6 @@ import LetterProofing from "components/Dashboard/LetterProofing";
 import { SECURITY_PATH, START_PATH } from "components/IndexMain";
 import { useAppDispatch, useAppSelector } from "eduid-hooks";
 import React, { Fragment, useCallback, useEffect, useState } from "react";
-import ReactCountryFlag from "react-country-flag";
 import { FormattedMessage, useIntl } from "react-intl";
 import authnSlice from "slices/Authn";
 import BankIdFlag from "../../../img/flags/BankID_logo.svg";
@@ -249,7 +249,7 @@ function VerifiedIdentitiesTable(): React.JSX.Element {
       {identities?.freja?.verified && (
         <figure className="grid-container identity-summary">
           <div>
-            <ReactCountryFlag
+            <CountryFlag
               className="flag-icon"
               aria-label={regionNames.of(identities.freja.country_code)}
               countryCode={identities.freja.country_code}

--- a/src/components/Signup/SignupEntry.tsx
+++ b/src/components/Signup/SignupEntry.tsx
@@ -4,12 +4,12 @@ import { bankIDApi } from "apis/eduidBankid";
 import { eidasApi } from "apis/eduidEidas";
 import { frejaeIDApi } from "apis/eduidFrejaeID";
 import signupApi from "apis/eduidSignup";
+import CountryFlag from "components/Common/CountryFlag";
 import EduIDButton from "components/Common/EduIDButton";
 import NotificationModal from "components/Common/NotificationModal";
 import Splash from "components/Common/Splash";
 import { useAppDispatch, useAppSelector } from "eduid-hooks";
 import { useState } from "react";
-import ReactCountryFlag from "react-country-flag";
 import { FormattedMessage } from "react-intl";
 import { Fragment } from "react/jsx-runtime";
 import { signupSlice } from "slices/Signup";
@@ -63,14 +63,14 @@ export function SignupEntry(): React.JSX.Element {
     }
     if (external_mfa?.country_code) {
       return (
-        <ReactCountryFlag
+        <CountryFlag
           className="flag-icon"
           aria-label={regionNames.of(external_mfa.country_code)}
           countryCode={external_mfa.country_code}
         />
       );
     }
-    return <ReactCountryFlag className="flag-icon" aria-label="SE" countryCode="SE" />;
+    return <CountryFlag className="flag-icon" aria-label="SE" countryCode="SE" />;
   };
 
   const appNameDisplay: Record<string, string> = {

--- a/src/tests/Dashboard/VerifyIdentity-test.tsx
+++ b/src/tests/Dashboard/VerifyIdentity-test.tsx
@@ -90,6 +90,38 @@ test("renders verifyIdentity as expected, verified with eidas", async () => {
   expect(screen.getByText("Swedish personal ID or coordination number")).toBeInTheDocument();
 });
 
+test("renders verifyIdentity as expected, verified with freja passport, showing country flag", async () => {
+  render(<VerifyIdentity />, {
+    state: {
+      config: { ...configInitialState, is_app_loaded: true },
+      personal_data: {
+        response: {
+          eppn: "test",
+          identities: {
+            is_verified: true,
+            freja: {
+              country_code: "NO",
+              verified: true,
+              date_of_birth: "19850101",
+              prid: "prid",
+              prid_persistence: "A",
+            },
+          },
+        },
+      },
+    },
+  });
+  expect(
+    screen.getByRole("heading", { name: /The identities below are now connected to your eduID/i }),
+  ).toBeInTheDocument();
+  expect(screen.getByText(/Freja eID identity/i)).toBeInTheDocument();
+  expect(screen.getByText(/19850101/i)).toBeInTheDocument();
+  // flag rendered as an emoji span with the country name as accessible label
+  const flag = screen.getByRole("img", { name: "Norway" });
+  expect(flag).toHaveClass("flag-icon");
+  expect(flag).toHaveTextContent("🇳🇴");
+});
+
 test("renders the identity page title", async () => {
   render(<IndexMain />);
   await linkToIdentitySettings();


### PR DESCRIPTION
# Remove `react-country-flag` — inline emoji flag

## Summary

- Remove the `react-country-flag` dependency. It was used to render a country flag for verified identities in three places: [Identity.tsx](src/components/Dashboard/Identity.tsx) (Freja identity) and two sites in [SignupEntry.tsx](src/components/Signup/SignupEntry.tsx) (external MFA country + Swedish fallback).
- Add a shared [CountryFlag.tsx](src/components/Common/CountryFlag.tsx) component — a drop-in for the old `<ReactCountryFlag>` API (same `countryCode` / `className` / `aria-label` props). It applies the exact regional-indicator transform the library did internally in its default (emoji) mode:
  ```js
  countryCode.toUpperCase().replace(/./g, (c) => String.fromCodePoint(c.charCodeAt(0) + 127397))
  ```
  rendered as `<span role="img">` with the same inline style the library emitted (`display`/`fontSize`/`lineHeight`/`verticalAlign`).
- Point all three call sites at the shared component — one implementation instead of a per-site inline copy.
- Add a test covering the Freja identity flag render (non-EU country) in [VerifyIdentity-test.tsx](src/tests/Dashboard/VerifyIdentity-test.tsx).

## Why

The library was pulled in for a handful of render sites. In its default (emoji) mode it only applies the regional-indicator codepoint shift — verified against the built bundle — so `CountryFlag` is a like-for-like replacement with no behavior or coverage change (including the same fallback on fonts without flag glyphs).

- Drops a dependency (~60K + subtree) for a small local component
- One less package to maintain / audit
- No visual or accessibility change

## Notes

- `country_code` is always ISO-3166 alpha-2, so subdivision / tag-sequence flags are never needed — same as before.
- Freja passport verification targets foreign nationals; EU citizens route through eidas. The test uses a non-EU code to reflect the real path.
- The eidas branch in SignupEntry keeps its existing `<img>` EU flag; only the `<ReactCountryFlag>` calls changed.
